### PR TITLE
Remove unwraps from parser and typechecker and add repr error type

### DIFF
--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -1,7 +1,10 @@
+use lalrpop_util::ParseError;
+
 use syntax::{Definition, Field};
 use syntax::binary::Type;
 use syntax::host::{Binop, Expr, Unop};
-use parser::lexer::{Token, Error as LexerError};
+use parser::GrammarError;
+use parser::lexer::Token;
 use source::BytePos;
 
 
@@ -12,7 +15,7 @@ grammar<'input>();
 
 extern {
     type Location = BytePos;
-    type Error = LexerError;
+    type Error = GrammarError<String>;
 
     enum Token<'input> {
         // Data
@@ -82,10 +85,11 @@ pub Type: Type<String> = {
 
 PrimaryType: Type<String> = {
     AtomicType,
-    <ty: PrimaryType> "where" <param: "Ident"> "=>" <pred: PrimaryExpr> => {
-        // FIXME: unwrap
-        let repr_ty = Box::new(ty.repr().unwrap());
-        Type::cond(ty, Expr::abs((param, repr_ty), pred))
+    <ty: PrimaryType> "where" <param: "Ident"> "=>" <pred: PrimaryExpr> =>? {
+        let repr_ty = Box::new(ty.repr().map_err(|err| {
+            ParseError::User { error: GrammarError::from(err) }
+        })?);
+        Ok(Type::cond(ty, Expr::abs((param, repr_ty), pred)))
     },
 };
 

--- a/src/syntax/binary.rs
+++ b/src/syntax/binary.rs
@@ -17,6 +17,13 @@ impl Kind {
     }
 }
 
+/// An error that occurred when trying to convert a binary type to
+/// its host representation
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReprError<N> {
+    NoCorrespondingHostType(Type<N>),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeConst {
     Bit,
@@ -223,7 +230,7 @@ impl<N: Name> Type<N> {
         self.instantiate_at(0, ty);
     }
 
-    pub fn repr(&self) -> Result<host::Type<N>, ()> {
+    pub fn repr(&self) -> Result<host::Type<N>, ReprError<N>> {
         match *self {
             Type::Var(ref v) => Ok(host::Type::Var(v.clone()).into()),
             Type::Const(TypeConst::Bit) => Ok(host::Type::Const(host::TypeConst::Bit).into()),
@@ -248,7 +255,9 @@ impl<N: Name> Type<N> {
 
                 Ok(host::Type::Struct(repr_fields).into())
             }
-            Type::Abs(_, _) | Type::App(_, _) => Err(()),
+            Type::Abs(_, _) | Type::App(_, _) => {
+                Err(ReprError::NoCorrespondingHostType(self.clone()))
+            }
         }
     }
 }


### PR DESCRIPTION
This also ensures that the error reporting will be more targeted, pointing to the actual part of the type that wasn't able to be converted to a host type.