### PR TITLE
Add option type in host language

### DIFF
--- a/experiments/lean/src/ddl/binary/repr.lean
+++ b/experiments/lean/src/ddl/binary/repr.lean
@@ -18,7 +18,7 @@ namespace ddl.binary
       | (struct_nil)          := host.type.struct_nil
       | (struct_cons l t₁ t₂) := host.type.struct_cons l t₁.repr t₂.repr
       | (array t e)           := host.type.array (t.repr)
-      | (cond t e)            := t.repr
+      | (cond t e)            := t.repr + host.type.struct_nil
       | (interp t e ht)       := ht
       | _                     := sorry
 
@@ -44,7 +44,7 @@ namespace ddl.binary
             exact host.type.well_formed.array hhtwf₁,
           },
           case well_formed.cond t₁ e hbtwf₁ hhtwf₁ {
-            exact hhtwf₁,
+            exact host.type.well_formed.sum hhtwf₁ host.type.well_formed.struct_nil
           },
           case well_formed.interp t₁ e ht hbtwf₁ hhtwf₁ {
             simp [repr],

--- a/src/structural/ast/binary.rs
+++ b/src/structural/ast/binary.rs
@@ -303,7 +303,11 @@ impl<N: Name> Type<N> {
 
                 Ok(Rc::new(host::Type::array(elem_repr_ty, size_expr)))
             }
-            Type::Cond(_, ref ty, _) => ty.repr(),
+            Type::Cond(_, ref ty, _) => {
+                let repr_ty = ty.repr()?;
+
+                Ok(Rc::new(host::Type::option(repr_ty)))
+            }
             Type::Interp(_, _, _, ref repr_ty) => Ok(repr_ty.clone()),
             Type::Union(_, ref tys) => {
                 let repr_tys = tys.iter().map(|ty| ty.repr()).collect::<Result<_, _>>()?;

--- a/src/structural/ast/host.rs
+++ b/src/structural/ast/host.rs
@@ -222,6 +222,8 @@ pub enum Type<N> {
     Const(TypeConst),
     /// Arrow type: eg. `T -> U`
     Arrow(RcType<N>, RcType<N>),
+    /// Option type: eg. `Option T`
+    Option(RcType<N>),
     /// An array of the specified type, with a size: eg. `[T; n]`
     Array(RcType<N>, RcExpr<N>),
     /// A union of types: eg. `union { T, ... }`
@@ -256,6 +258,11 @@ impl<N: Name> Type<N> {
     /// Integer type constant
     pub fn int() -> Type<N> {
         Type::Const(TypeConst::Int)
+    }
+
+    /// Option type: eg. `Option T`
+    pub fn option<T1: Into<RcType<N>>>(ty: T1) -> Type<N> {
+        Type::Option(ty.into())
     }
 
     /// Arrow type: eg. `T -> U`
@@ -318,6 +325,9 @@ impl<N: Name> Type<N> {
                 Rc::make_mut(lhs_ty).abstract_name_at(name, level);
                 Rc::make_mut(rhs_ty).abstract_name_at(name, level);
             }
+            Type::Option(ref mut ty) => {
+                Rc::make_mut(ty).abstract_name_at(name, level);
+            }
             Type::Array(ref mut elem_ty, ref mut size_expr) => {
                 Rc::make_mut(elem_ty).abstract_name_at(name, level);
                 Rc::make_mut(size_expr).abstract_name_at(name, level);
@@ -354,6 +364,9 @@ impl<N: Name> Type<N> {
             }
             Type::Array(ref mut elem_ty, _) => {
                 Rc::make_mut(elem_ty).instantiate_at(level, src);
+            }
+            Type::Option(ref mut ty) => {
+                Rc::make_mut(ty).instantiate_at(level, src);
             }
             Type::Union(ref mut tys) => for ty in tys {
                 Rc::make_mut(ty).instantiate_at(level, src);

--- a/src/structural/parser/snapshots/tests.parse_ty_where.snap
+++ b/src/structural/parser/snapshots/tests.parse_ty_where.snap
@@ -71,8 +71,10 @@ Cond(
                 [
                     Field {
                         name: "x",
-                        value: Var(
-                            Free("u32")
+                        value: Option(
+                            Var(
+                                Free("u32")
+                            )
                         )
                     }
                 ]
@@ -105,15 +107,19 @@ Cond(
             lo: BytePos(106),
             hi: BytePos(117)
         },
-        Named("x", Struct(
-            [
-                Field {
-                    name: "x",
-                    value: Var(
-                        Free("u32")
-                    )
-                }
-            ]
+        Named("x", Option(
+            Struct(
+                [
+                    Field {
+                        name: "x",
+                        value: Option(
+                            Var(
+                                Free("u32")
+                            )
+                        )
+                    }
+                ]
+            )
         )),
         Binop(
             Span {


### PR DESCRIPTION
This could be represented by `union { T, struct {} }`, but it’s probably easier to compile from this to ideomatic form in the concrete host language.