### PR TITLE
Expose uncurried abstractions in surface syntax

### DIFF
--- a/src/ir/nominal/ast.rs
+++ b/src/ir/nominal/ast.rs
@@ -201,7 +201,7 @@ fn lower_ty(
     ty: &binary::RcType<String>,
 ) -> Type<String> {
     use name::Named;
-    use syntax::ast::Var;
+    use var::Var;
 
     match **ty {
         binary::Type::Var(_, Var::Bound(Named(ref name, _))) => Type::path(name.as_str()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod test;
 
 pub mod name;
 pub mod source;
+pub mod var;
 
 pub mod ir;
 pub mod syntax;

--- a/src/syntax/ast/snapshots/binary.ty_abs_complex.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_complex.snap
@@ -3,7 +3,9 @@ Abs(
         lo: BytePos(0),
         hi: BytePos(0)
     },
-    Named("z", Type),
+    [
+        Named("z", ())
+    ],
     App(
         Span {
             lo: BytePos(0),
@@ -14,7 +16,9 @@ Abs(
                 lo: BytePos(0),
                 hi: BytePos(0)
             },
-            Named("y", Type),
+            [
+                Named("y", ())
+            ],
             App(
                 Span {
                     lo: BytePos(0),
@@ -25,50 +29,60 @@ Abs(
                         lo: BytePos(0),
                         hi: BytePos(0)
                     },
-                    Bound(Named("y", 0))
+                    Bound(Named("y", BoundVar(0, 0)))
                 ),
-                Abs(
+                [
+                    Abs(
+                        Span {
+                            lo: BytePos(0),
+                            hi: BytePos(0)
+                        },
+                        [
+                            Named("x", ())
+                        ],
+                        Var(
+                            Span {
+                                lo: BytePos(0),
+                                hi: BytePos(0)
+                            },
+                            Bound(Named("x", BoundVar(0, 0)))
+                        )
+                    )
+                ]
+            )
+        ),
+        [
+            Abs(
+                Span {
+                    lo: BytePos(0),
+                    hi: BytePos(0)
+                },
+                [
+                    Named("x", ())
+                ],
+                App(
                     Span {
                         lo: BytePos(0),
                         hi: BytePos(0)
                     },
-                    Named("x", Type),
                     Var(
                         Span {
                             lo: BytePos(0),
                             hi: BytePos(0)
                         },
-                        Bound(Named("x", 0))
-                    )
+                        Bound(Named("z", BoundVar(1, 0)))
+                    ),
+                    [
+                        Var(
+                            Span {
+                                lo: BytePos(0),
+                                hi: BytePos(0)
+                            },
+                            Bound(Named("x", BoundVar(0, 0)))
+                        )
+                    ]
                 )
             )
-        ),
-        Abs(
-            Span {
-                lo: BytePos(0),
-                hi: BytePos(0)
-            },
-            Named("x", Type),
-            App(
-                Span {
-                    lo: BytePos(0),
-                    hi: BytePos(0)
-                },
-                Var(
-                    Span {
-                        lo: BytePos(0),
-                        hi: BytePos(0)
-                    },
-                    Bound(Named("z", 1))
-                ),
-                Var(
-                    Span {
-                        lo: BytePos(0),
-                        hi: BytePos(0)
-                    },
-                    Bound(Named("x", 0))
-                )
-            )
-        )
+        ]
     )
 )

--- a/src/syntax/ast/snapshots/binary.ty_abs_id.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_id.snap
@@ -3,12 +3,14 @@ Abs(
         lo: BytePos(0),
         hi: BytePos(0)
     },
-    Named("x", Type),
+    [
+        Named("x", ())
+    ],
     Var(
         Span {
             lo: BytePos(0),
             hi: BytePos(0)
         },
-        Bound(Named("x", 0))
+        Bound(Named("x", BoundVar(0, 0)))
     )
 )

--- a/src/syntax/ast/snapshots/binary.ty_abs_k_combinator.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_k_combinator.snap
@@ -3,19 +3,23 @@ Abs(
         lo: BytePos(0),
         hi: BytePos(0)
     },
-    Named("x", Type),
+    [
+        Named("x", ())
+    ],
     Abs(
         Span {
             lo: BytePos(0),
             hi: BytePos(0)
         },
-        Named("y", Type),
+        [
+            Named("y", ())
+        ],
         Var(
             Span {
                 lo: BytePos(0),
                 hi: BytePos(0)
             },
-            Bound(Named("x", 1))
+            Bound(Named("x", BoundVar(1, 0)))
         )
     )
 )

--- a/src/syntax/ast/snapshots/binary.ty_abs_s_combinator.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_s_combinator.snap
@@ -3,19 +3,25 @@ Abs(
         lo: BytePos(0),
         hi: BytePos(0)
     },
-    Named("x", Type),
+    [
+        Named("x", ())
+    ],
     Abs(
         Span {
             lo: BytePos(0),
             hi: BytePos(0)
         },
-        Named("y", Type),
+        [
+            Named("y", ())
+        ],
         Abs(
             Span {
                 lo: BytePos(0),
                 hi: BytePos(0)
             },
-            Named("z", Type),
+            [
+                Named("z", ())
+            ],
             App(
                 Span {
                     lo: BytePos(0),
@@ -31,36 +37,42 @@ Abs(
                             lo: BytePos(0),
                             hi: BytePos(0)
                         },
-                        Bound(Named("x", 2))
+                        Bound(Named("x", BoundVar(2, 0)))
                     ),
-                    Var(
-                        Span {
-                            lo: BytePos(0),
-                            hi: BytePos(0)
-                        },
-                        Bound(Named("z", 0))
-                    )
+                    [
+                        Var(
+                            Span {
+                                lo: BytePos(0),
+                                hi: BytePos(0)
+                            },
+                            Bound(Named("z", BoundVar(0, 0)))
+                        )
+                    ]
                 ),
-                App(
-                    Span {
-                        lo: BytePos(0),
-                        hi: BytePos(0)
-                    },
-                    Var(
+                [
+                    App(
                         Span {
                             lo: BytePos(0),
                             hi: BytePos(0)
                         },
-                        Bound(Named("y", 1))
-                    ),
-                    Var(
-                        Span {
-                            lo: BytePos(0),
-                            hi: BytePos(0)
-                        },
-                        Bound(Named("z", 0))
+                        Var(
+                            Span {
+                                lo: BytePos(0),
+                                hi: BytePos(0)
+                            },
+                            Bound(Named("y", BoundVar(1, 0)))
+                        ),
+                        [
+                            Var(
+                                Span {
+                                    lo: BytePos(0),
+                                    hi: BytePos(0)
+                                },
+                                Bound(Named("z", BoundVar(0, 0)))
+                            )
+                        ]
                     )
-                )
+                ]
             )
         )
     )

--- a/src/syntax/check/context.rs
+++ b/src/syntax/check/context.rs
@@ -2,69 +2,74 @@
 
 use name::Named;
 use syntax::ast::{binary, host};
+use var::{BoundVar, ScopeIndex};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Binding<N> {
-    Expr(host::RcType<N>),
-    Type(binary::RcKind),
-    TypeDef(binary::RcType<N>, binary::RcKind),
+pub enum Scope<N> {
+    ExprAbs(Vec<Named<N, host::RcType<N>>>),
+    TypeAbs(Vec<Named<N, binary::Kind>>),
+    TypeDef(Vec<Named<N, (binary::RcType<N>, binary::Kind)>>),
 }
 
 #[derive(Debug, Clone)]
 pub struct Context<N> {
-    bindings: Vec<Named<N, Binding<N>>>,
+    scopes: Vec<Scope<N>>,
 }
 
 impl<N> Context<N> {
     pub fn new() -> Context<N> {
-        Context {
-            bindings: Vec::new(),
+        Context { scopes: Vec::new() }
+    }
+
+    pub fn extend(&mut self, scope: Scope<N>) {
+        self.scopes.push(scope);
+    }
+
+    pub fn lookup(&self, scope: ScopeIndex) -> &Scope<N> {
+        assert!(
+            self.scopes.len() > scope.0 as usize,
+            "ICE: Scope out of range"
+        );
+
+        &self.scopes[(self.scopes.len() - scope.0 as usize) - 1]
+    }
+
+    pub fn lookup_ty(&self, var: BoundVar) -> Result<(&N, &host::RcType<N>), &Scope<N>> {
+        match *self.lookup(var.scope) {
+            Scope::ExprAbs(ref tys) => Ok(
+                tys.get(var.binding.0 as usize)
+                    .map(|named| (&named.0, &named.1))
+                    .expect("ICE: Binder out of range"),
+            ),
+            ref scope => Err(scope),
         }
     }
 
-    pub fn extend(&mut self, name: N, binding: Binding<N>) {
-        self.bindings.push(Named(name, binding));
-    }
-
-    pub fn lookup(&self, i: u32) -> Named<&N, &Binding<N>> {
-        assert!(self.bindings.len() > i as usize, "ICE: Binder out of range");
-
-        let Named(ref name, ref binding) = self.bindings[self.bindings.len() - i as usize - 1];
-
-        Named(name, binding)
-    }
-
-    pub fn lookup_ty(&self, i: u32) -> Result<Named<&N, &host::RcType<N>>, Named<&N, &Binding<N>>> {
-        let Named(name, binding) = self.lookup(i);
-
-        match *binding {
-            Binding::Expr(ref ty) => Ok(Named(name, ty)),
-            _ => Err(Named(name, binding)),
+    pub fn lookup_ty_def(&self, var: BoundVar) -> Result<(&N, &binary::RcType<N>), &Scope<N>> {
+        match *self.lookup(var.scope) {
+            Scope::TypeDef(ref defs) => Ok(
+                defs.get(var.binding.0 as usize)
+                    .map(|named| (&named.0, &(named.1).0))
+                    .expect("ICE: Binder out of range"),
+            ),
+            ref scope => Err(scope),
         }
     }
 
-    pub fn lookup_ty_def(
-        &self,
-        i: u32,
-    ) -> Result<Named<&N, &binary::RcType<N>>, Named<&N, &Binding<N>>> {
-        let Named(name, binding) = self.lookup(i);
-
-        match *binding {
-            Binding::TypeDef(ref ty, _) => Ok(Named(name, ty)),
-            _ => Err(Named(name, binding)),
-        }
-    }
-
-    pub fn lookup_kind(
-        &self,
-        i: u32,
-    ) -> Result<Named<&N, &binary::RcKind>, Named<&N, &Binding<N>>> {
-        let Named(name, binding) = self.lookup(i);
-
-        match *binding {
-            Binding::Type(ref kind) => Ok(Named(name, kind)),
-            Binding::TypeDef(_, ref kind) => Ok(Named(name, kind)),
-            _ => Err(Named(name, binding)),
+    pub fn lookup_kind(&self, var: BoundVar) -> Result<(&N, &binary::Kind), &Scope<N>> {
+        match *self.lookup(var.scope) {
+            Scope::TypeAbs(ref kinds) => Ok(
+                kinds
+                    .get(var.binding.0 as usize)
+                    .map(|named| (&named.0, &named.1))
+                    .expect("ICE: Binder out of range"),
+            ),
+            Scope::TypeDef(ref defs) => Ok(
+                defs.get(var.binding.0 as usize)
+                    .map(|named| (&named.0, &(named.1).1))
+                    .expect("ICE: Binder out of range"),
+            ),
+            ref scope => Err(scope),
         }
     }
 }

--- a/src/syntax/parser/grammar.lalrpop
+++ b/src/syntax/parser/grammar.lalrpop
@@ -1,8 +1,11 @@
+use std::iter;
+
 use source::{BytePos, Span};
 use syntax::ast::{Definition, Field, Program};
 use syntax::ast::binary::{RcType, Type};
 use syntax::ast::host::{Binop, RcExpr, Expr, Unop};
 use syntax::parser::lexer::{Error as LexerError, Token};
+use name::Named;
 
 
 grammar<'input>();
@@ -68,6 +71,14 @@ Definition: Definition<String> = {
     <name: "Ident"> "=" <ty: PrimaryType> ";" => {
         Definition::new(name, ty)
     },
+    <name: "Ident"> <lo: @L> "(" <params: (<"Ident"> ",")*> <last: "Ident"> ")" "=" <ty: PrimaryType> <hi: @R> ";" => {
+        let params = params.into_iter()
+            .chain(iter::once(last))
+            .map(|p| p.to_owned())
+            .collect::<Vec<String>>();
+
+        Definition::new(name, Type::abs(Span::new(lo, hi), &params, ty))
+    },
 };
 
 Field: Field<String, RcType<String>> = {
@@ -87,7 +98,11 @@ PrimaryType: RcType<String> = {
     AtomicType,
     <lo1: @L> <ty: PrimaryType> "where" <lo2: @L> <param: "Ident"> "=>" <pred: PrimaryExpr> <hi: @R> => {
         let repr_ty = ty.repr();
-        let pred_expr = Expr::abs(Span::new(lo2, hi), (param, repr_ty), pred);
+        let pred_expr = Expr::abs(
+            Span::new(lo2, hi),
+            vec![Named(param.to_owned(), repr_ty)],
+            pred,
+        );
 
         Type::assert(Span::new(lo1, hi), ty, pred_expr).into()
     },
@@ -96,6 +111,11 @@ PrimaryType: RcType<String> = {
 AtomicType: RcType<String> = {
     <lo: @L> <name: "Ident"> <hi: @R> => {
         Type::fvar(Span::new(lo, hi), name).into()
+    },
+    <lo: @L> <ty: AtomicType> "(" <arg_tys: (<Type> ",")*> <last: Type> ")" <hi: @R> => {
+        let mut arg_tys = arg_tys;
+        arg_tys.push(last);
+        Type::app(Span::new(lo, hi), ty, arg_tys).into()
     },
     "(" <ty: PrimaryType> ")" => ty,
     <lo: @L> "struct" "{" <fields: (<Field> ",")*> <last: Field?> "}" <hi: @R> => {

--- a/src/syntax/parser/snapshots/tests.parse_definition.snap
+++ b/src/syntax/parser/snapshots/tests.parse_definition.snap
@@ -61,14 +61,14 @@ Program {
                                     lo: BytePos(154),
                                     hi: BytePos(159)
                                 },
-                                Bound(Named("Point", 1))
+                                Bound(Named("Point", BoundVar(1, 0)))
                             ),
                             Var(
                                 Span {
                                     lo: BytePos(161),
                                     hi: BytePos(164)
                                 },
-                                Bound(Named("len", 0))
+                                Bound(Named("len", BoundVar(0, 0)))
                             )
                         )
                     }
@@ -139,7 +139,7 @@ Program {
                                             lo: BytePos(309),
                                             hi: BytePos(314)
                                         },
-                                        Bound(Named("Point", 2))
+                                        Bound(Named("Point", BoundVar(2, 0)))
                                     )
                                 }
                             ]
@@ -170,7 +170,7 @@ Program {
                                             lo: BytePos(368),
                                             hi: BytePos(373)
                                         },
-                                        Bound(Named("Array", 1))
+                                        Bound(Named("Array", BoundVar(1, 0)))
                                     )
                                 }
                             ]

--- a/src/syntax/parser/snapshots/tests.parse_ty_array_dependent.snap
+++ b/src/syntax/parser/snapshots/tests.parse_ty_array_dependent.snap
@@ -33,7 +33,7 @@ Struct(
                         lo: BytePos(65),
                         hi: BytePos(68)
                     },
-                    Bound(Named("len", 0))
+                    Bound(Named("len", BoundVar(0, 0)))
                 )
             )
         },
@@ -64,7 +64,7 @@ Struct(
                                     lo: BytePos(128),
                                     hi: BytePos(131)
                                 },
-                                Bound(Named("len", 1))
+                                Bound(Named("len", BoundVar(1, 0)))
                             )
                         )
                     },
@@ -117,7 +117,7 @@ Struct(
                                     lo: BytePos(249),
                                     hi: BytePos(252)
                                 },
-                                Bound(Named("len", 2))
+                                Bound(Named("len", BoundVar(2, 0)))
                             )
                         )
                     }

--- a/src/syntax/parser/snapshots/tests.parse_ty_assert.snap
+++ b/src/syntax/parser/snapshots/tests.parse_ty_assert.snap
@@ -33,9 +33,11 @@ Assert(
                                 lo: BytePos(43),
                                 hi: BytePos(54)
                             },
-                            Named("x", Var(
-                                Free("u32")
-                            )),
+                            [
+                                Named("x", Var(
+                                    Free("u32")
+                                ))
+                            ],
                             Binop(
                                 Span {
                                     lo: BytePos(48),
@@ -47,7 +49,7 @@ Assert(
                                         lo: BytePos(48),
                                         hi: BytePos(49)
                                     },
-                                    Bound(Named("x", 0))
+                                    Bound(Named("x", BoundVar(0, 0)))
                                 ),
                                 Const(
                                     Span {
@@ -67,16 +69,18 @@ Assert(
                 lo: BytePos(80),
                 hi: BytePos(91)
             },
-            Named("x", Struct(
-                [
-                    Field {
-                        name: "x",
-                        value: Var(
-                            Free("u32")
-                        )
-                    }
-                ]
-            )),
+            [
+                Named("x", Struct(
+                    [
+                        Field {
+                            name: "x",
+                            value: Var(
+                                Free("u32")
+                            )
+                        }
+                    ]
+                ))
+            ],
             Binop(
                 Span {
                     lo: BytePos(85),
@@ -88,7 +92,7 @@ Assert(
                         lo: BytePos(85),
                         hi: BytePos(86)
                     },
-                    Bound(Named("x", 0))
+                    Bound(Named("x", BoundVar(0, 0)))
                 ),
                 Const(
                     Span {
@@ -105,16 +109,18 @@ Assert(
             lo: BytePos(106),
             hi: BytePos(117)
         },
-        Named("x", Struct(
-            [
-                Field {
-                    name: "x",
-                    value: Var(
-                        Free("u32")
-                    )
-                }
-            ]
-        )),
+        [
+            Named("x", Struct(
+                [
+                    Field {
+                        name: "x",
+                        value: Var(
+                            Free("u32")
+                        )
+                    }
+                ]
+            ))
+        ],
         Binop(
             Span {
                 lo: BytePos(111),
@@ -126,7 +132,7 @@ Assert(
                     lo: BytePos(111),
                     hi: BytePos(112)
                 },
-                Bound(Named("x", 0))
+                Bound(Named("x", BoundVar(0, 0)))
             ),
             Const(
                 Span {

--- a/src/syntax/parser/snapshots/tests.parse_type_params.snap
+++ b/src/syntax/parser/snapshots/tests.parse_type_params.snap
@@ -1,0 +1,177 @@
+Program {
+    defs: [
+        Definition {
+            name: "Pair",
+            ty: Abs(
+                Span {
+                    lo: BytePos(13),
+                    hi: BytePos(78)
+                },
+                [
+                    Named("T", ()),
+                    Named("U", ())
+                ],
+                Struct(
+                    Span {
+                        lo: BytePos(22),
+                        hi: BytePos(78)
+                    },
+                    [
+                        Field {
+                            name: "l",
+                            value: Var(
+                                Span {
+                                    lo: BytePos(47),
+                                    hi: BytePos(48)
+                                },
+                                Bound(Named("T", BoundVar(0, 0)))
+                            )
+                        },
+                        Field {
+                            name: "r",
+                            value: Var(
+                                Span {
+                                    lo: BytePos(66),
+                                    hi: BytePos(67)
+                                },
+                                Bound(Named("U", BoundVar(1, 1)))
+                            )
+                        }
+                    ]
+                )
+            )
+        },
+        Definition {
+            name: "Array",
+            ty: Abs(
+                Span {
+                    lo: BytePos(94),
+                    hi: BytePos(172)
+                },
+                [
+                    Named("T", ())
+                ],
+                Struct(
+                    Span {
+                        lo: BytePos(100),
+                        hi: BytePos(172)
+                    },
+                    [
+                        Field {
+                            name: "len",
+                            value: Var(
+                                Span {
+                                    lo: BytePos(127),
+                                    hi: BytePos(132)
+                                },
+                                Free("u16le")
+                            )
+                        },
+                        Field {
+                            name: "data",
+                            value: Array(
+                                Span {
+                                    lo: BytePos(153),
+                                    hi: BytePos(161)
+                                },
+                                Var(
+                                    Span {
+                                        lo: BytePos(154),
+                                        hi: BytePos(155)
+                                    },
+                                    Bound(Named("T", BoundVar(1, 0)))
+                                ),
+                                Var(
+                                    Span {
+                                        lo: BytePos(157),
+                                        hi: BytePos(160)
+                                    },
+                                    Bound(Named("len", BoundVar(0, 0)))
+                                )
+                            )
+                        }
+                    ]
+                )
+            )
+        },
+        Definition {
+            name: "Data",
+            ty: Abs(
+                Span {
+                    lo: BytePos(187),
+                    hi: BytePos(277)
+                },
+                [
+                    Named("T", ()),
+                    Named("U", ()),
+                    Named("V", ())
+                ],
+                Struct(
+                    Span {
+                        lo: BytePos(199),
+                        hi: BytePos(277)
+                    },
+                    [
+                        Field {
+                            name: "blah",
+                            value: Var(
+                                Span {
+                                    lo: BytePos(227),
+                                    hi: BytePos(228)
+                                },
+                                Bound(Named("U", BoundVar(0, 1)))
+                            )
+                        },
+                        Field {
+                            name: "data",
+                            value: App(
+                                Span {
+                                    lo: BytePos(249),
+                                    hi: BytePos(266)
+                                },
+                                Var(
+                                    Span {
+                                        lo: BytePos(249),
+                                        hi: BytePos(254)
+                                    },
+                                    Bound(Named("Array", BoundVar(2, 0)))
+                                ),
+                                [
+                                    App(
+                                        Span {
+                                            lo: BytePos(255),
+                                            hi: BytePos(265)
+                                        },
+                                        Var(
+                                            Span {
+                                                lo: BytePos(255),
+                                                hi: BytePos(259)
+                                            },
+                                            Bound(Named("Pair", BoundVar(3, 0)))
+                                        ),
+                                        [
+                                            Var(
+                                                Span {
+                                                    lo: BytePos(260),
+                                                    hi: BytePos(261)
+                                                },
+                                                Bound(Named("T", BoundVar(1, 0)))
+                                            ),
+                                            Var(
+                                                Span {
+                                                    lo: BytePos(263),
+                                                    hi: BytePos(264)
+                                                },
+                                                Bound(Named("V", BoundVar(1, 2)))
+                                            )
+                                        ]
+                                    )
+                                ]
+                            )
+                        }
+                    ]
+                )
+            )
+        }
+    ]
+}

--- a/src/syntax/parser/tests.rs
+++ b/src/syntax/parser/tests.rs
@@ -191,3 +191,25 @@ fn parse_definition() {
 
     assert_snapshot!(parse_definition, Program::from_str(src).unwrap());
 }
+
+#[test]
+fn parse_type_params() {
+    let src = "
+        Pair(T, U) = struct {
+            l : T,
+            r : U,
+        };
+
+        Array(T) = struct {
+            len : u16le,
+            data : [T; len],
+        };
+
+        Data(T, U, V) = struct {
+            blah : U,
+            data : Array(Pair(T, V)),
+        };
+    ";
+
+    assert_snapshot!(parse_type_params, Program::from_str(src).unwrap());
+}

--- a/src/var.rs
+++ b/src/var.rs
@@ -1,0 +1,135 @@
+//! Variable binding
+
+use std::fmt;
+use name::{Name, Named};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct ScopeIndex(pub u32);
+
+impl ScopeIndex {
+    pub fn succ(self) -> ScopeIndex {
+        ScopeIndex(self.0 + 1)
+    }
+
+    pub fn shift(self, amount: u32) -> ScopeIndex {
+        ScopeIndex(self.0 + amount)
+    }
+}
+
+impl fmt::Debug for ScopeIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ScopeIndex(")?;
+        self.0.fmt(f)?;
+        write!(f, ")")
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct BindingIndex(pub u32);
+
+impl fmt::Debug for BindingIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "BindingIndex(")?;
+        self.0.fmt(f)?;
+        write!(f, ")")
+    }
+}
+
+/// A reference to a bound variable
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct BoundVar {
+    /// The debruijn index of the scope that introduced the variable
+    pub scope: ScopeIndex,
+    /// The index of the binder within the scope that introduced this variable
+    pub binding: BindingIndex,
+}
+
+impl BoundVar {
+    pub fn new(scope: ScopeIndex, binding: BindingIndex) -> BoundVar {
+        BoundVar { scope, binding }
+    }
+}
+
+impl fmt::Debug for BoundVar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "BoundVar(")?;
+        self.scope.0.fmt(f)?;
+        write!(f, ", ")?;
+        self.binding.0.fmt(f)?;
+        write!(f, ")")
+    }
+}
+
+/// A variable that can either be free or bound
+///
+/// We use a locally nameless representation for variable binding.
+///
+/// # References
+///
+/// - [How I learned to stop worrying and love de Bruijn indices]
+///   (http://disciple-devel.blogspot.com.au/2011/08/how-i-learned-to-stop-worrying-and-love.html)
+/// - [The Locally Nameless Representation]
+///   (https://www.chargueraud.org/research/2009/ln/main.pdf)
+/// - [Locally nameless representation with cofinite quantification]
+///   (http://www.chargueraud.org/softs/ln/)
+/// - [A Locally-nameless Backend for Ott]
+///   (http://www.di.ens.fr/~zappa/projects/ln_ott/)
+/// - [Library STLC_Tutorial]
+///   (https://www.cis.upenn.edu/~plclub/popl08-tutorial/code/coqdoc/STLC_Tutorial.html)
+///
+/// ## Libraries
+///
+/// There are a number of libraries out there for other languages that abstract
+/// away handling locally nameless representations, but I've not yet figured out
+/// how to port them to Rust yet:
+///
+/// - DBLib: Facilities for working with de Bruijn indices in Coq
+///     - [Blog Post](http://gallium.inria.fr/blog/announcing-dblib/)
+///     - [Github](https://github.com/coq-contribs/dblib)
+/// - Bound: Bruijn indices for Haskell
+///     - [Blog Post](https://www.schoolofhaskell.com/user/edwardk/bound)
+///     - [Github](https://github.com/ekmett/bound/)
+///     - [Hackage](https://hackage.haskell.org/package/bound)
+/// - The Penn Locally Nameless Metatheory Library
+///     - [Github](https://github.com/plclub/metalib)
+#[derive(Clone, PartialEq, Eq)]
+pub enum Var<N> {
+    /// A free, unbound variable
+    Free(N),
+    /// A bound variable
+    Bound(Named<N, BoundVar>),
+}
+
+impl<N: Name> Var<N> {
+    pub fn abstract_names_at(&mut self, names: &[N], scope: ScopeIndex) {
+        *self = match *self {
+            Var::Free(ref n) => match names.iter().position(|name| name == n) {
+                Some(position) => {
+                    let bv = BoundVar {
+                        scope,
+                        binding: BindingIndex(position as u32),
+                    };
+                    Var::Bound(Named(n.clone(), bv))
+                }
+                None => return,
+            },
+            Var::Bound(_) => return,
+        };
+    }
+}
+
+impl<F: fmt::Debug> fmt::Debug for Var<F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Var::Free(ref x) => {
+                write!(f, "Free(")?;
+                x.fmt(f)?;
+            }
+            Var::Bound(ref i) => {
+                write!(f, "Bound(")?;
+                i.fmt(f)?;
+            }
+        }
+        write!(f, ")")
+    }
+}


### PR DESCRIPTION
I've decided to expose uncurried abstractions rather than attempting to do this during lowering. This should make implementing codegen easier. To do so I've started using multibindings, as described in the final section of [_The Locally Nameless Representation_](https://www.chargueraud.org/research/2009/ln/main.pdf). This will then pave the way for admitting mutual recursion in top-level type bindings.