### PR TITLE
Reduce smart constructors

### DIFF
--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -9,7 +9,7 @@ pub use syntax::ast::Field;
 pub use syntax::ast::host::{Binop, Const, TypeConst, Unop};
 pub use syntax::ast::host::{FloatType, SignedType, UnsignedType};
 pub use syntax::ast::binary::TypeConst as BinaryTypeConst;
-use var::{BoundVar, ScopeIndex, Var};
+use var::{ScopeIndex, Var};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Program<N> {
@@ -270,14 +270,6 @@ pub enum Expr<N> {
 pub type RcExpr<N> = Rc<Expr<N>>;
 
 impl<N: Name> Expr<N> {
-    pub fn fvar<N1: Into<N>>(name: N1) -> Expr<N> {
-        Expr::Var(Var::free(name))
-    }
-
-    pub fn bvar<N1: Into<N>>(name: N1, var: BoundVar) -> Expr<N> {
-        Expr::Var(Var::bound(name, var))
-    }
-
     pub fn abstract_names_at(&mut self, names: &[N], scope: ScopeIndex) {
         match *self {
             Expr::Var(ref mut var) => var.abstract_names_at(names, scope),

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -81,7 +81,11 @@ where
             let item_path = path.append_child(item.name.clone());
             let ty = lower_value(item_path, &item.value);
 
-            Field::new(item.doc.clone(), item.name.clone(), ty)
+            Field {
+                doc: item.doc.clone(),
+                name: item.name.clone(),
+                value: ty,
+            }
         })
         .collect()
 }
@@ -230,11 +234,11 @@ fn struct_parser(
         )
     };
     let lower_to_expr_field = |field: &Field<String, binary::RcType<String>>| {
-        Field::new(
-            field.doc.clone(),
-            field.name.clone(),
-            Expr::Var(Var::free(field.name.clone())),
-        )
+        Field {
+            doc: field.doc.clone(),
+            name: field.name.clone(),
+            value: Rc::new(Expr::Var(Var::free(field.name.clone()))),
+        }
     };
 
     let parse_exprs = fields.iter().map(lower_to_field_parser);

--- a/src/syntax/ast/mod.rs
+++ b/src/syntax/ast/mod.rs
@@ -23,19 +23,6 @@ pub struct Field<N, T> {
 }
 
 impl<N, T> Field<N, T> {
-    pub fn new<D1, N1, T1>(doc: D1, name: N1, value: T1) -> Field<N, T>
-    where
-        D1: Into<Rc<str>>,
-        N1: Into<N>,
-        T1: Into<T>,
-    {
-        Field {
-            doc: doc.into(),
-            name: name.into(),
-            value: value.into(),
-        }
-    }
-
     /// Apply the function `f` to the field name and return the wrapped result
     pub fn map_name<M, F: FnMut(N) -> M>(self, mut f: F) -> Field<M, T> {
         Field {
@@ -90,21 +77,6 @@ pub struct Definition<N> {
     pub name: N,
     /// The binary type
     pub ty: binary::RcType<N>,
-}
-
-impl<N> Definition<N> {
-    pub fn new<D1, N1, T1>(doc: D1, name: N1, ty: T1) -> Definition<N>
-    where
-        D1: Into<Rc<str>>,
-        N1: Into<N>,
-        T1: Into<binary::RcType<N>>,
-    {
-        Definition {
-            doc: doc.into(),
-            name: name.into(),
-            ty: ty.into(),
-        }
-    }
 }
 
 impl<N: PartialEq> PartialEq for Definition<N> {

--- a/src/syntax/check/tests.rs
+++ b/src/syntax/check/tests.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use super::*;
+use super::host::TypeConst as Tc;
 
 mod ty_of {
     use super::*;
@@ -56,8 +57,9 @@ mod ty_of {
         let ctx = Context::new();
         let src = "!(1u8 == 2u8)";
         let expr = Rc::new(src.parse().unwrap());
+        let expected_ty = Rc::new(Type::Const(Tc::Bool));
 
-        assert_eq!(ty_of(&ctx, &expr), Ok(Rc::new(Type::bool())));
+        assert_eq!(ty_of(&ctx, &expr), Ok(expected_ty));
     }
 
     // #[test]
@@ -74,8 +76,9 @@ mod ty_of {
         let ctx = Context::new();
         let src = "1u8 + (1u8 * 2u8) == 3u8";
         let expr = Rc::new(src.parse().unwrap());
+        let expected_ty = Rc::new(Type::Const(Tc::Bool));
 
-        assert_eq!(ty_of(&ctx, &expr), Ok(Rc::new(Type::bool())));
+        assert_eq!(ty_of(&ctx, &expr), Ok(expected_ty));
     }
 
     #[test]
@@ -83,8 +86,9 @@ mod ty_of {
         let ctx = Context::new();
         let src = "1u8 + (1u8 * 2u8) != 3u8";
         let expr = Rc::new(src.parse().unwrap());
+        let expected_ty = Rc::new(Type::Const(Tc::Bool));
 
-        assert_eq!(ty_of(&ctx, &expr), Ok(Rc::new(Type::bool())));
+        assert_eq!(ty_of(&ctx, &expr), Ok(expected_ty));
     }
 
     #[test]
@@ -92,8 +96,9 @@ mod ty_of {
         let ctx = Context::new();
         let src = "(1u8 == 1u8) == (3u8 == 3u8)";
         let expr = Rc::new(src.parse().unwrap());
+        let expected_ty = Rc::new(Type::Const(Tc::Bool));
 
-        assert_eq!(ty_of(&ctx, &expr), Ok(Rc::new(Type::bool())));
+        assert_eq!(ty_of(&ctx, &expr), Ok(expected_ty));
     }
 
     #[test]
@@ -101,8 +106,9 @@ mod ty_of {
         let ctx = Context::new();
         let src = "(1u8 == 1u8) != (3u8 == 3u8)";
         let expr = Rc::new(src.parse().unwrap());
+        let expected_ty = Rc::new(Type::Const(Tc::Bool));
 
-        assert_eq!(ty_of(&ctx, &expr), Ok(Rc::new(Type::bool())));
+        assert_eq!(ty_of(&ctx, &expr), Ok(expected_ty));
     }
 
     #[test]
@@ -110,8 +116,9 @@ mod ty_of {
         let ctx = Context::new();
         let src = "(1u8 == 3u8) & (2u8 == 2u8) | (1u8 == 2u8)";
         let expr = Rc::new(src.parse().unwrap());
+        let expected_ty = Rc::new(Type::Const(Tc::Bool));
 
-        assert_eq!(ty_of(&ctx, &expr), Ok(Rc::new(Type::bool())));
+        assert_eq!(ty_of(&ctx, &expr), Ok(expected_ty));
     }
 }
 

--- a/src/syntax/parser/grammar.lalrpop
+++ b/src/syntax/parser/grammar.lalrpop
@@ -8,6 +8,7 @@ use syntax::ast::binary::{RcType, Type};
 use syntax::ast::host::{Binop, Const, Expr, RcExpr, Unop};
 use syntax::parser::GrammarError;
 use syntax::parser::lexer::Token;
+use var::Var;
 
 
 grammar<'input>();
@@ -72,24 +73,38 @@ pub Program: Program<String> = {
 
 Definition: Definition<String> = {
     <doc: "DocComment"*> <name: "Ident"> "=" <ty: PrimaryType> ";" => {
-        Definition::new(doc.join("\n"), name, ty)
+        Definition {
+            doc: doc.join("\n").into(),
+            name: name.to_owned(),
+            ty,
+        }
     },
     <doc: "DocComment"*> <name: "Ident"> <lo: @L>
         "(" <params: (<"Ident"> ",")*> <last: "Ident"> ")" "="
-        <ty: PrimaryType> <hi: @R> ";" =>
+        <body_ty: PrimaryType> <hi: @R> ";" =>
     {
         let params = params.into_iter()
             .chain(iter::once(last))
             .map(|p| p.to_owned())
             .collect::<Vec<String>>();
 
-        Definition::new(doc.join("\n"), name, Type::abs(Span::new(lo, hi), &params, ty))
+        let ty = Type::abs(Span::new(lo, hi), &params, body_ty).into();
+
+        Definition {
+            doc: doc.join("\n").into(),
+            name: name.to_owned(),
+            ty,
+        }
     },
 };
 
 Field: Field<String, RcType<String>> = {
     <doc: "DocComment"*> <name: "Ident"> ":" <ty: PrimaryType> => {
-        Field::new(doc.join("\n"), name, ty)
+        Field {
+            doc: doc.join("\n").into(),
+            name: name.to_owned(),
+            value: ty,
+        }
     },
 };
 
@@ -110,18 +125,18 @@ PrimaryType: RcType<String> = {
             pred,
         );
 
-        Type::assert(Span::new(lo1, hi), ty, pred_expr).into()
+        Type::Assert(Span::new(lo1, hi), ty, pred_expr.into()).into()
     },
 };
 
 AtomicType: RcType<String> = {
     <lo: @L> <name: "Ident"> <hi: @R> => {
-        Type::fvar(Span::new(lo, hi), name).into()
+        Type::Var(Span::new(lo, hi), Var::free(name)).into()
     },
     <lo: @L> <ty: AtomicType> "(" <arg_tys: (<Type> ",")*> <last: Type> ")" <hi: @R> => {
         let mut arg_tys = arg_tys;
         arg_tys.push(last);
-        Type::app(Span::new(lo, hi), ty, arg_tys).into()
+        Type::App(Span::new(lo, hi), ty, arg_tys).into()
     },
     "(" <ty: PrimaryType> ")" => ty,
     <lo: @L> "struct" "{" <fields: (<Field> ",")*> <last: Field?> "}" <hi: @R> => {
@@ -132,10 +147,10 @@ AtomicType: RcType<String> = {
     <lo: @L> "union" "{" <variants: (<Field> ",")*> <last: Field?> "}" <hi: @R> => {
         let mut variants = variants;
         variants.extend(last);
-        Type::union(Span::new(lo, hi), variants).into()
+        Type::Union(Span::new(lo, hi), variants).into()
     },
     <lo: @L> "[" <elem: PrimaryType> ";" <size: PrimaryExpr> "]" <hi: @R> => {
-        Type::array(Span::new(lo, hi), elem, size).into()
+        Type::Array(Span::new(lo, hi), elem, size).into()
     },
 };
 
@@ -152,66 +167,66 @@ pub Expr: RcExpr<String> = {
 PrimaryExpr: RcExpr<String> = {
     EqExpr,
     <lo: @L> <lhs: EqExpr> "|" <rhs: PrimaryExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Or, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Or, lhs, rhs).into()
     },
     <lo: @L> <lhs: EqExpr> "&" <rhs: PrimaryExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::And, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::And, lhs, rhs).into()
     },
 };
 
 EqExpr: RcExpr<String> = {
     CmpExpr,
     <lo: @L> <lhs: CmpExpr> "==" <rhs: EqExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Eq, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Eq, lhs, rhs).into()
     },
     <lo: @L> <lhs: CmpExpr> "!=" <rhs: EqExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Ne, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Ne, lhs, rhs).into()
     },
 };
 
 CmpExpr: RcExpr<String> = {
     AddExpr,
     <lo: @L> <lhs: AddExpr> "<=" <rhs: CmpExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Le, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Le, lhs, rhs).into()
     },
     <lo: @L> <lhs: AddExpr> "<" <rhs: CmpExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Lt, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Lt, lhs, rhs).into()
     },
     <lo: @L> <lhs: AddExpr> ">" <rhs: CmpExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Gt, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Gt, lhs, rhs).into()
     },
     <lo: @L> <lhs: AddExpr> ">=" <rhs: CmpExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Ge, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Ge, lhs, rhs).into()
     },
 };
 
 AddExpr: RcExpr<String> = {
     MulExpr,
     <lo: @L> <lhs: MulExpr> "+" <rhs: AddExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Add, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Add, lhs, rhs).into()
     },
     <lo: @L> <lhs: MulExpr> "-" <rhs: AddExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Sub, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Sub, lhs, rhs).into()
     },
 };
 
 MulExpr: RcExpr<String> = {
     PrefixExpr,
     <lo: @L> <lhs: PrefixExpr> "*" <rhs: MulExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Mul, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Mul, lhs, rhs).into()
     },
     <lo: @L> <lhs: PrefixExpr> "/" <rhs: MulExpr> <hi: @R> => {
-        Expr::binop(Span::new(lo, hi), Binop::Div, lhs, rhs).into()
+        Expr::Binop(Span::new(lo, hi), Binop::Div, lhs, rhs).into()
     },
 };
 
 PrefixExpr: RcExpr<String> = {
     AtomicExpr,
     <lo: @L> "-" <expr: AtomicExpr> <hi: @R> => {
-        Expr::unop(Span::new(lo, hi), Unop::Neg, expr).into()
+        Expr::Unop(Span::new(lo, hi), Unop::Neg, expr).into()
     },
     <lo: @L> "!" <value: AtomicExpr> <hi: @R> => {
-        Expr::unop(Span::new(lo, hi), Unop::Not, value).into()
+        Expr::Unop(Span::new(lo, hi), Unop::Not, value).into()
     },
 };
 
@@ -236,12 +251,12 @@ AtomicExpr: RcExpr<String> = {
         Ok(Expr::Const(Span::new(lo, hi), const_int).into())
     },
     <lo: @L> <name: "Ident"> <hi: @R> => {
-        Expr::fvar(Span::new(lo, hi), name).into()
+        Expr::Var(Span::new(lo, hi), Var::free(name)).into()
     },
     <lo: @L> <struct_expr: AtomicExpr> "." <field_name: "Ident"> <hi: @R> => {
-        Expr::proj(Span::new(lo, hi), struct_expr, field_name).into()
+        Expr::Proj(Span::new(lo, hi), struct_expr, field_name.into()).into()
     },
     <lo: @L> <array_expr: AtomicExpr> "[" <index_expr: PrimaryExpr> "]" <hi: @R> => {
-        Expr::subscript(Span::new(lo, hi), array_expr, index_expr).into()
+        Expr::Subscript(Span::new(lo, hi), array_expr, index_expr).into()
     },
 };


### PR DESCRIPTION
A purely structural change that just reduces the amount of boilerplatey constructors in favor of direct construction of variants and structs.