### PR TITLE
Rework names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ members = [
 failure = "0.1.1"
 heck = "0.3.0"
 lalrpop-util = "0.13.1"
-maplit = "1.0.0"
 pretty = "0.3.2"
 regex = "0.2.0"
 unicode-xid = "0.1.0"

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2,7 +2,7 @@ use pretty::{BoxAllocator, DocAllocator, DocBuilder};
 use std::fmt;
 
 use heck::CamelCase;
-use name::{Ident, Named};
+use name::{Ident, Name, Named};
 use ir::ast::{Definition, Expr, Field, Item, Module, ParseExpr, Path, RepeatBound, Type};
 use ir::ast::{RcExpr, RcParseExpr, RcType};
 use ir::ast::{Binop, Const, Unop};
@@ -121,7 +121,7 @@ fn lower_doc_comment<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
 fn lower_alias<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
     alloc: &'alloc A,
     path: &'a Path,
-    params: &'a [Ident],
+    params: &'a [Name],
     ty: &'a RcType,
 ) -> DocBuilder<'alloc, A> {
     alloc.text("pub type")
@@ -141,7 +141,7 @@ fn lower_alias<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
 fn lower_struct<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
     alloc: &'alloc A,
     path: &'a Path,
-    params: &'a [Ident],
+    params: &'a [Name],
     fields: &'a [Field<RcType>],
 ) -> DocBuilder<'alloc, A> {
     alloc.text("#[derive(Debug, Clone)]")
@@ -180,7 +180,7 @@ fn lower_struct<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
 fn lower_union<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
     alloc: &'alloc A,
     path: &'a Path,
-    params: &'a [Ident],
+    params: &'a [Name],
     variants: &'a [Field<RcType>],
 ) -> DocBuilder<'alloc, A> {
     use heck::CamelCase;
@@ -220,7 +220,7 @@ fn lower_union<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
 fn lower_from_binary_impl<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
     alloc: &'alloc A,
     path: &'a Path,
-    params: &'a [Ident],
+    params: &'a [Name],
     parse_expr: &'a RcParseExpr,
 ) -> DocBuilder<'alloc, A> {
     let base_header = alloc
@@ -284,7 +284,7 @@ fn lower_from_binary_impl<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
 
 fn lower_intro_ty_params<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
     alloc: &'alloc A,
-    params: &'a [Ident],
+    params: &'a [Name],
 ) -> DocBuilder<'alloc, A> {
     if params.is_empty() {
         alloc.nil()
@@ -411,11 +411,14 @@ fn lower_parse_expr<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
 
 fn lower_named_parse_expr<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(
     alloc: &'alloc A,
-    name: &'a Ident,
+    name: &'a Name,
 ) -> DocBuilder<'alloc, A> {
-    alloc
-        .text(name.0.to_camel_case())
-        .append(alloc.text("::from_binary(reader)"))
+    let name = match *name {
+        Name::Abstract => unimplemented!(),
+        Name::User(Ident(ref ident)) => ident.to_camel_case(),
+    };
+
+    alloc.text(name).append(alloc.text("::from_binary(reader)"))
 }
 
 fn lower_parse_ty_const<'alloc, 'a: 'alloc, A: DocAllocator<'alloc>>(

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::rc::Rc;
 
-use name::{Ident, Named};
+use name::{Ident, Name, Named};
 pub use syntax::ast::Field;
 pub use syntax::ast::host::{Binop, Const, IntSuffix, TypeConst, Unop};
 pub use syntax::ast::host::{FloatType, SignedType, UnsignedType};
@@ -101,7 +101,7 @@ pub struct Definition {
     /// The path of this definition (should be unique)
     pub path: Path,
     /// Type parameters for the definition
-    pub params: Vec<Ident>,
+    pub params: Vec<Name>,
     /// The defined item
     pub item: Item,
 }
@@ -217,7 +217,7 @@ impl fmt::Debug for RcParseExpr {
 }
 
 impl RcParseExpr {
-    pub fn abstract_names_at(&mut self, names: &[Ident], scope: ScopeIndex) {
+    pub fn abstract_names_at(&mut self, names: &[Name], scope: ScopeIndex) {
         match *Rc::make_mut(&mut self.inner) {
             ParseExpr::Var(ref mut var) => var.abstract_names_at(names, scope),
             ParseExpr::Const(_) => {}
@@ -251,7 +251,7 @@ impl RcParseExpr {
         }
     }
 
-    pub fn abstract_names(&mut self, names: &[Ident]) {
+    pub fn abstract_names(&mut self, names: &[Name]) {
         self.abstract_names_at(names, ScopeIndex(0));
     }
 }
@@ -269,7 +269,7 @@ pub enum Expr {
     Intro(Path, Ident, RcExpr),
     Subscript(RcExpr, RcExpr),
     Cast(RcExpr, RcType),
-    Lam(Vec<Named<Ident, RcType>>, RcExpr),
+    Lam(Vec<Named<Name, RcType>>, RcExpr),
     App(RcExpr, Vec<RcExpr>),
 }
 
@@ -293,7 +293,7 @@ impl fmt::Debug for RcExpr {
 }
 
 impl RcExpr {
-    pub fn abstract_names_at(&mut self, names: &[Ident], scope: ScopeIndex) {
+    pub fn abstract_names_at(&mut self, names: &[Name], scope: ScopeIndex) {
         match *Rc::make_mut(&mut self.inner) {
             Expr::Ann(ref mut expr, _) => {
                 expr.abstract_names_at(names, scope);
@@ -338,7 +338,7 @@ impl RcExpr {
         }
     }
 
-    pub fn abstract_names(&mut self, names: &[Ident]) {
+    pub fn abstract_names(&mut self, names: &[Name]) {
         self.abstract_names_at(names, ScopeIndex(0));
     }
 }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 
-use name::{Ident, Named};
+use name::{Ident, Name, Named};
 use syntax;
 use syntax::ast::{binary, host, Field};
 use ir::ast::{Definition, Expr, Item, Module, ParseExpr, Path, RepeatBound, Type};
@@ -335,7 +335,7 @@ fn struct_parser(path: &Path, fields: &[Field<binary::RcType>]) -> RcParseExpr {
         Field {
             doc: Rc::clone(&field.doc),
             name: field.name.clone(),
-            value: Expr::Var(Var::free(field.name.clone())).into(),
+            value: Expr::Var(Var::free(Name::user(field.name.clone()))).into(),
         }
     };
 
@@ -347,7 +347,7 @@ fn struct_parser(path: &Path, fields: &[Field<binary::RcType>]) -> RcParseExpr {
 
     for (name, mut parse_expr) in parse_exprs {
         for (scope, name) in seen_names.iter().rev().enumerate() {
-            parse_expr.abstract_names_at(&[name.clone()], ScopeIndex(scope as u32));
+            parse_expr.abstract_names_at(&[Name::user(name.clone())], ScopeIndex(scope as u32));
         }
 
         seen_names.push(name.clone());
@@ -356,7 +356,7 @@ fn struct_parser(path: &Path, fields: &[Field<binary::RcType>]) -> RcParseExpr {
 
     let mut expr: RcExpr = Expr::Struct(path.clone(), expr_fields.collect()).into();
     for (scope, name) in seen_names.iter().rev().enumerate() {
-        expr.abstract_names_at(&[name.clone()], ScopeIndex(scope as u32));
+        expr.abstract_names_at(&[Name::user(name.clone())], ScopeIndex(scope as u32));
     }
 
     ParseExpr::Sequence(named_exprs, expr).into()
@@ -377,7 +377,7 @@ fn cond_parser(path: &Path, options: &[Field<(host::RcCExpr, binary::RcType)>]) 
                 path.clone(),
                 option.name.clone(),
                 // FIXME: generate fresh name?
-                Expr::Var(Var::bound("x", BoundVar::new(Si(0), Bi(0)))).into(),
+                Expr::Var(Var::bound(Name::user("x"), BoundVar::new(Si(0), Bi(0)))).into(),
             ).into(),
         ).into();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ extern crate difference;
 extern crate failure;
 extern crate heck;
 extern crate lalrpop_util;
-#[macro_use]
-extern crate maplit;
 extern crate pretty;
 #[cfg(test)]
 #[macro_use]

--- a/src/name.rs
+++ b/src/name.rs
@@ -31,6 +31,42 @@ impl fmt::Display for Ident {
     }
 }
 
+/// The name of a free variable
+#[derive(Debug, Clone)]
+pub enum Name {
+    /// Names originating from user input
+    User(Ident),
+    /// Abstract names, `_`
+    ///
+    /// Comparing two abstract names will always return false because we cannot
+    /// be sure what they actually refer to.
+    Abstract,
+}
+
+impl Name {
+    pub fn user<S: Into<Ident>>(name: S) -> Name {
+        Name::User(name.into())
+    }
+}
+
+impl PartialEq for Name {
+    fn eq(&self, other: &Name) -> bool {
+        match (self, other) {
+            (&Name::User(ref lhs), &Name::User(ref rhs)) => lhs == rhs,
+            (&Name::Abstract, &Name::Abstract) | (_, _) => false,
+        }
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Name::User(ref name) => write!(f, "{}", name),
+            Name::Abstract => write!(f, "_"),
+        }
+    }
+}
+
 /// A variable with a name that is ignored for comparisons. This is useful for
 /// improving error reporting when converting free varables to a named form.
 #[derive(Debug, Clone, Eq, Ord)]

--- a/src/parser/snapshots/tests.parse_add_expr.snap
+++ b/src/parser/snapshots/tests.parse_add_expr.snap
@@ -10,7 +10,9 @@ Binop(
             hi: BytePos(1)
         },
         Free(
-            Ident("x")
+            User(
+                Ident("x")
+            )
         )
     ),
     Binop(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(5)
             },
             Free(
-                Ident("y")
+                User(
+                    Ident("y")
+                )
             )
         ),
         Var(
@@ -34,7 +38,9 @@ Binop(
                 hi: BytePos(9)
             },
             Free(
-                Ident("z")
+                User(
+                    Ident("z")
+                )
             )
         )
     )

--- a/src/parser/snapshots/tests.parse_add_expr_mixed.snap
+++ b/src/parser/snapshots/tests.parse_add_expr_mixed.snap
@@ -10,7 +10,9 @@ Binop(
             hi: BytePos(1)
         },
         Free(
-            Ident("x")
+            User(
+                Ident("x")
+            )
         )
     ),
     Binop(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(5)
             },
             Free(
-                Ident("y")
+                User(
+                    Ident("y")
+                )
             )
         ),
         Binop(
@@ -40,7 +44,9 @@ Binop(
                     hi: BytePos(9)
                 },
                 Free(
-                    Ident("z")
+                    User(
+                        Ident("z")
+                    )
                 )
             ),
             Binop(
@@ -55,7 +61,9 @@ Binop(
                         hi: BytePos(13)
                     },
                     Free(
-                        Ident("z")
+                        User(
+                            Ident("z")
+                        )
                     )
                 ),
                 Var(
@@ -64,7 +72,9 @@ Binop(
                         hi: BytePos(17)
                     },
                     Free(
-                        Ident("x")
+                        User(
+                            Ident("x")
+                        )
                     )
                 )
             )

--- a/src/parser/snapshots/tests.parse_array_with_constant_size.snap
+++ b/src/parser/snapshots/tests.parse_array_with_constant_size.snap
@@ -14,7 +14,9 @@ Module {
                         hi: BytePos(21)
                     },
                     Free(
-                        Ident("f32")
+                        User(
+                            Ident("f32")
+                        )
                     )
                 ),
                 Const(

--- a/src/parser/snapshots/tests.parse_definition.snap
+++ b/src/parser/snapshots/tests.parse_definition.snap
@@ -18,7 +18,9 @@ Module {
                                 hi: BytePos(47)
                             },
                             Free(
-                                Ident("u32be")
+                                User(
+                                    Ident("u32be")
+                                )
                             )
                         )
                     },
@@ -31,7 +33,9 @@ Module {
                                 hi: BytePos(70)
                             },
                             Free(
-                                Ident("u32be")
+                                User(
+                                    Ident("u32be")
+                                )
                             )
                         )
                     }
@@ -56,7 +60,9 @@ Module {
                                 hi: BytePos(201)
                             },
                             Free(
-                                Ident("u16le")
+                                User(
+                                    Ident("u16le")
+                                )
                             )
                         )
                     },
@@ -75,7 +81,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("Point"),
+                                        User(
+                                            Ident("Point")
+                                        ),
                                         BoundVar(1, 0)
                                     )
                                 )
@@ -87,7 +95,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("len"),
+                                        User(
+                                            Ident("len")
+                                        ),
                                         BoundVar(0, 0)
                                     )
                                 )
@@ -115,7 +125,9 @@ Module {
                                 hi: BytePos(298)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -146,7 +158,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("format"),
+                                                            User(
+                                                                Ident("format")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -166,7 +180,9 @@ Module {
                                                 hi: BytePos(424)
                                             },
                                             Free(
-                                                Ident("u16")
+                                                User(
+                                                    Ident("u16")
+                                                )
                                             )
                                         )
                                     )
@@ -189,7 +205,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("format"),
+                                                            User(
+                                                                Ident("format")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -210,7 +228,9 @@ Module {
                                             },
                                             Bound(
                                                 Named(
-                                                    Ident("Point"),
+                                                    User(
+                                                        Ident("Point")
+                                                    ),
                                                     BoundVar(2, 0)
                                                 )
                                             )
@@ -235,7 +255,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("format"),
+                                                            User(
+                                                                Ident("format")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -256,7 +278,9 @@ Module {
                                             },
                                             Bound(
                                                 Named(
-                                                    Ident("Array"),
+                                                    User(
+                                                        Ident("Array")
+                                                    ),
                                                     BoundVar(1, 0)
                                                 )
                                             )

--- a/src/parser/snapshots/tests.parse_div_expr.snap
+++ b/src/parser/snapshots/tests.parse_div_expr.snap
@@ -10,7 +10,9 @@ Binop(
             hi: BytePos(1)
         },
         Free(
-            Ident("x")
+            User(
+                Ident("x")
+            )
         )
     ),
     Binop(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(5)
             },
             Free(
-                Ident("y")
+                User(
+                    Ident("y")
+                )
             )
         ),
         Var(
@@ -34,7 +38,9 @@ Binop(
                 hi: BytePos(9)
             },
             Free(
-                Ident("z")
+                User(
+                    Ident("z")
+                )
             )
         )
     )

--- a/src/parser/snapshots/tests.parse_expr_bool_atomic.snap
+++ b/src/parser/snapshots/tests.parse_expr_bool_atomic.snap
@@ -16,7 +16,9 @@ Unop(
                 hi: BytePos(16)
             },
             Free(
-                Ident("true")
+                User(
+                    Ident("true")
+                )
             )
         ),
         Var(
@@ -25,7 +27,9 @@ Unop(
                 hi: BytePos(26)
             },
             Free(
-                Ident("false")
+                User(
+                    Ident("false")
+                )
             )
         )
     )

--- a/src/parser/snapshots/tests.parse_expr_bool_operators.snap
+++ b/src/parser/snapshots/tests.parse_expr_bool_operators.snap
@@ -16,7 +16,9 @@ Binop(
                 hi: BytePos(14)
             },
             Free(
-                Ident("true")
+                User(
+                    Ident("true")
+                )
             )
         ),
         Var(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(23)
             },
             Free(
-                Ident("false")
+                User(
+                    Ident("false")
+                )
             )
         )
     ),
@@ -41,7 +45,9 @@ Binop(
                 hi: BytePos(33)
             },
             Free(
-                Ident("true")
+                User(
+                    Ident("true")
+                )
             )
         ),
         Var(
@@ -50,7 +56,9 @@ Binop(
                 hi: BytePos(42)
             },
             Free(
-                Ident("false")
+                User(
+                    Ident("false")
+                )
             )
         )
     )

--- a/src/parser/snapshots/tests.parse_mixed_arithmetic_expr.snap
+++ b/src/parser/snapshots/tests.parse_mixed_arithmetic_expr.snap
@@ -10,7 +10,9 @@ Binop(
             hi: BytePos(1)
         },
         Free(
-            Ident("x")
+            User(
+                Ident("x")
+            )
         )
     ),
     Binop(
@@ -31,7 +33,9 @@ Binop(
                     hi: BytePos(5)
                 },
                 Free(
-                    Ident("y")
+                    User(
+                        Ident("y")
+                    )
                 )
             ),
             Binop(
@@ -46,7 +50,9 @@ Binop(
                         hi: BytePos(9)
                     },
                     Free(
-                        Ident("z")
+                        User(
+                            Ident("z")
+                        )
                     )
                 ),
                 Var(
@@ -55,7 +61,9 @@ Binop(
                         hi: BytePos(13)
                     },
                     Free(
-                        Ident("z")
+                        User(
+                            Ident("z")
+                        )
                     )
                 )
             )
@@ -72,7 +80,9 @@ Binop(
                     hi: BytePos(17)
                 },
                 Free(
-                    Ident("x")
+                    User(
+                        Ident("x")
+                    )
                 )
             ),
             Var(
@@ -81,7 +91,9 @@ Binop(
                     hi: BytePos(21)
                 },
                 Free(
-                    Ident("a")
+                    User(
+                        Ident("a")
+                    )
                 )
             )
         )

--- a/src/parser/snapshots/tests.parse_mixed_arithmetic_expr_parenthesized.snap
+++ b/src/parser/snapshots/tests.parse_mixed_arithmetic_expr_parenthesized.snap
@@ -16,7 +16,9 @@ Binop(
                 hi: BytePos(2)
             },
             Free(
-                Ident("x")
+                User(
+                    Ident("x")
+                )
             )
         ),
         Var(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(6)
             },
             Free(
-                Ident("y")
+                User(
+                    Ident("y")
+                )
             )
         )
     ),
@@ -41,7 +45,9 @@ Binop(
                 hi: BytePos(11)
             },
             Free(
-                Ident("z")
+                User(
+                    Ident("z")
+                )
             )
         ),
         Binop(
@@ -62,7 +68,9 @@ Binop(
                         hi: BytePos(16)
                     },
                     Free(
-                        Ident("z")
+                        User(
+                            Ident("z")
+                        )
                     )
                 ),
                 Var(
@@ -71,7 +79,9 @@ Binop(
                         hi: BytePos(20)
                     },
                     Free(
-                        Ident("x")
+                        User(
+                            Ident("x")
+                        )
                     )
                 )
             ),
@@ -81,7 +91,9 @@ Binop(
                     hi: BytePos(25)
                 },
                 Free(
-                    Ident("a")
+                    User(
+                        Ident("a")
+                    )
                 )
             )
         )

--- a/src/parser/snapshots/tests.parse_mul_expr.snap
+++ b/src/parser/snapshots/tests.parse_mul_expr.snap
@@ -10,7 +10,9 @@ Binop(
             hi: BytePos(1)
         },
         Free(
-            Ident("x")
+            User(
+                Ident("x")
+            )
         )
     ),
     Binop(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(5)
             },
             Free(
-                Ident("y")
+                User(
+                    Ident("y")
+                )
             )
         ),
         Var(
@@ -34,7 +38,9 @@ Binop(
                 hi: BytePos(9)
             },
             Free(
-                Ident("z")
+                User(
+                    Ident("z")
+                )
             )
         )
     )

--- a/src/parser/snapshots/tests.parse_mul_expr_mixed.snap
+++ b/src/parser/snapshots/tests.parse_mul_expr_mixed.snap
@@ -10,7 +10,9 @@ Binop(
             hi: BytePos(1)
         },
         Free(
-            Ident("x")
+            User(
+                Ident("x")
+            )
         )
     ),
     Binop(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(5)
             },
             Free(
-                Ident("y")
+                User(
+                    Ident("y")
+                )
             )
         ),
         Binop(
@@ -40,7 +44,9 @@ Binop(
                     hi: BytePos(9)
                 },
                 Free(
-                    Ident("z")
+                    User(
+                        Ident("z")
+                    )
                 )
             ),
             Binop(
@@ -55,7 +61,9 @@ Binop(
                         hi: BytePos(13)
                     },
                     Free(
-                        Ident("z")
+                        User(
+                            Ident("z")
+                        )
                     )
                 ),
                 Var(
@@ -64,7 +72,9 @@ Binop(
                         hi: BytePos(17)
                     },
                     Free(
-                        Ident("x")
+                        User(
+                            Ident("x")
+                        )
                     )
                 )
             )

--- a/src/parser/snapshots/tests.parse_proj_expr.snap
+++ b/src/parser/snapshots/tests.parse_proj_expr.snap
@@ -20,7 +20,9 @@ Unop(
                     hi: BytePos(4)
                 },
                 Free(
-                    Ident("foo")
+                    User(
+                        Ident("foo")
+                    )
                 )
             ),
             Ident("bar")

--- a/src/parser/snapshots/tests.parse_simple_definition.snap
+++ b/src/parser/snapshots/tests.parse_simple_definition.snap
@@ -9,7 +9,9 @@ Module {
                     hi: BytePos(23)
                 },
                 Free(
-                    Ident("u32")
+                    User(
+                        Ident("u32")
+                    )
                 )
             )
         }

--- a/src/parser/snapshots/tests.parse_sub_expr.snap
+++ b/src/parser/snapshots/tests.parse_sub_expr.snap
@@ -10,7 +10,9 @@ Binop(
             hi: BytePos(1)
         },
         Free(
-            Ident("x")
+            User(
+                Ident("x")
+            )
         )
     ),
     Binop(
@@ -25,7 +27,9 @@ Binop(
                 hi: BytePos(5)
             },
             Free(
-                Ident("y")
+                User(
+                    Ident("y")
+                )
             )
         ),
         Var(
@@ -34,7 +38,9 @@ Binop(
                 hi: BytePos(9)
             },
             Free(
-                Ident("z")
+                User(
+                    Ident("z")
+                )
             )
         )
     )

--- a/src/parser/snapshots/tests.parse_subscript_expr.snap
+++ b/src/parser/snapshots/tests.parse_subscript_expr.snap
@@ -20,7 +20,9 @@ Unop(
                     hi: BytePos(4)
                 },
                 Free(
-                    Ident("foo")
+                    User(
+                        Ident("foo")
+                    )
                 )
             ),
             Binop(
@@ -65,7 +67,9 @@ Unop(
                 hi: BytePos(33)
             },
             Free(
-                Ident("index")
+                User(
+                    Ident("index")
+                )
             )
         )
     )

--- a/src/parser/snapshots/tests.parse_ty_array_dependent.snap
+++ b/src/parser/snapshots/tests.parse_ty_array_dependent.snap
@@ -13,7 +13,9 @@ Struct(
                     hi: BytePos(38)
                 },
                 Free(
-                    Ident("u32")
+                    User(
+                        Ident("u32")
+                    )
                 )
             )
         },
@@ -31,7 +33,9 @@ Struct(
                         hi: BytePos(63)
                     },
                     Free(
-                        Ident("f32")
+                        User(
+                            Ident("f32")
+                        )
                     )
                 ),
                 Var(
@@ -41,7 +45,9 @@ Struct(
                     },
                     Bound(
                         Named(
-                            Ident("len"),
+                            User(
+                                Ident("len")
+                            ),
                             BoundVar(0, 0)
                         )
                     )
@@ -71,7 +77,9 @@ Struct(
                                     hi: BytePos(126)
                                 },
                                 Free(
-                                    Ident("f32")
+                                    User(
+                                        Ident("f32")
+                                    )
                                 )
                             ),
                             Var(
@@ -81,7 +89,9 @@ Struct(
                                 },
                                 Bound(
                                     Named(
-                                        Ident("len"),
+                                        User(
+                                            Ident("len")
+                                        ),
                                         BoundVar(1, 0)
                                     )
                                 )
@@ -97,7 +107,9 @@ Struct(
                                 hi: BytePos(158)
                             },
                             Free(
-                                Ident("u32")
+                                User(
+                                    Ident("u32")
+                                )
                             )
                         )
                     },
@@ -110,7 +122,9 @@ Struct(
                                 hi: BytePos(220)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -123,7 +137,9 @@ Struct(
                                 hi: BytePos(250)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -141,7 +157,9 @@ Struct(
                                     hi: BytePos(279)
                                 },
                                 Free(
-                                    Ident("f32")
+                                    User(
+                                        Ident("f32")
+                                    )
                                 )
                             ),
                             Var(
@@ -151,7 +169,9 @@ Struct(
                                 },
                                 Bound(
                                     Named(
-                                        Ident("len"),
+                                        User(
+                                            Ident("len")
+                                        ),
                                         BoundVar(2, 0)
                                     )
                                 )

--- a/src/parser/snapshots/tests.parse_ty_assert.snap
+++ b/src/parser/snapshots/tests.parse_ty_assert.snap
@@ -28,7 +28,9 @@ Assert(
                                 hi: BytePos(36)
                             },
                             Free(
-                                Ident("u32")
+                                User(
+                                    Ident("u32")
+                                )
                             )
                         ),
                         Inf(
@@ -39,10 +41,14 @@ Assert(
                                 },
                                 [
                                     Named(
-                                        Ident("x"),
+                                        User(
+                                            Ident("x")
+                                        ),
                                         Var(
                                             Free(
-                                                Ident("u32")
+                                                User(
+                                                    Ident("u32")
+                                                )
                                             )
                                         )
                                     )
@@ -60,7 +66,9 @@ Assert(
                                         },
                                         Bound(
                                             Named(
-                                                Ident("x"),
+                                                User(
+                                                    Ident("x")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -87,7 +95,9 @@ Assert(
                 },
                 [
                     Named(
-                        Ident("x"),
+                        User(
+                            Ident("x")
+                        ),
                         Struct(
                             [
                                 Field {
@@ -95,7 +105,9 @@ Assert(
                                     name: Ident("x"),
                                     value: Var(
                                         Free(
-                                            Ident("u32")
+                                            User(
+                                                Ident("u32")
+                                            )
                                         )
                                     )
                                 }
@@ -116,7 +128,9 @@ Assert(
                         },
                         Bound(
                             Named(
-                                Ident("x"),
+                                User(
+                                    Ident("x")
+                                ),
                                 BoundVar(0, 0)
                             )
                         )
@@ -140,7 +154,9 @@ Assert(
             },
             [
                 Named(
-                    Ident("x"),
+                    User(
+                        Ident("x")
+                    ),
                     Struct(
                         [
                             Field {
@@ -148,7 +164,9 @@ Assert(
                                 name: Ident("x"),
                                 value: Var(
                                     Free(
-                                        Ident("u32")
+                                        User(
+                                            Ident("u32")
+                                        )
                                     )
                                 )
                             }
@@ -169,7 +187,9 @@ Assert(
                     },
                     Bound(
                         Named(
-                            Ident("x"),
+                            User(
+                                Ident("x")
+                            ),
                             BoundVar(0, 0)
                         )
                     )

--- a/src/parser/snapshots/tests.parse_ty_var.snap
+++ b/src/parser/snapshots/tests.parse_ty_var.snap
@@ -4,6 +4,8 @@ Var(
         hi: BytePos(14)
     },
     Free(
-        Ident("Point")
+        User(
+            Ident("Point")
+        )
     )
 )

--- a/src/parser/snapshots/tests.parse_type_params.snap
+++ b/src/parser/snapshots/tests.parse_type_params.snap
@@ -10,11 +10,15 @@ Module {
                 },
                 [
                     Named(
-                        Ident("T"),
+                        User(
+                            Ident("T")
+                        ),
                         ()
                     ),
                     Named(
-                        Ident("U"),
+                        User(
+                            Ident("U")
+                        ),
                         ()
                     )
                 ],
@@ -34,7 +38,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("T"),
+                                        User(
+                                            Ident("T")
+                                        ),
                                         BoundVar(0, 0)
                                     )
                                 )
@@ -50,7 +56,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("U"),
+                                        User(
+                                            Ident("U")
+                                        ),
                                         BoundVar(1, 1)
                                     )
                                 )
@@ -70,7 +78,9 @@ Module {
                 },
                 [
                     Named(
-                        Ident("T"),
+                        User(
+                            Ident("T")
+                        ),
                         ()
                     )
                 ],
@@ -89,7 +99,9 @@ Module {
                                     hi: BytePos(132)
                                 },
                                 Free(
-                                    Ident("u16le")
+                                    User(
+                                        Ident("u16le")
+                                    )
                                 )
                             )
                         },
@@ -108,7 +120,9 @@ Module {
                                     },
                                     Bound(
                                         Named(
-                                            Ident("T"),
+                                            User(
+                                                Ident("T")
+                                            ),
                                             BoundVar(1, 0)
                                         )
                                     )
@@ -120,7 +134,9 @@ Module {
                                     },
                                     Bound(
                                         Named(
-                                            Ident("len"),
+                                            User(
+                                                Ident("len")
+                                            ),
                                             BoundVar(0, 0)
                                         )
                                     )
@@ -141,15 +157,21 @@ Module {
                 },
                 [
                     Named(
-                        Ident("T"),
+                        User(
+                            Ident("T")
+                        ),
                         ()
                     ),
                     Named(
-                        Ident("U"),
+                        User(
+                            Ident("U")
+                        ),
                         ()
                     ),
                     Named(
-                        Ident("V"),
+                        User(
+                            Ident("V")
+                        ),
                         ()
                     )
                 ],
@@ -169,7 +191,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("U"),
+                                        User(
+                                            Ident("U")
+                                        ),
                                         BoundVar(0, 1)
                                     )
                                 )
@@ -190,7 +214,9 @@ Module {
                                     },
                                     Bound(
                                         Named(
-                                            Ident("Array"),
+                                            User(
+                                                Ident("Array")
+                                            ),
                                             BoundVar(2, 0)
                                         )
                                     )
@@ -208,7 +234,9 @@ Module {
                                             },
                                             Bound(
                                                 Named(
-                                                    Ident("Pair"),
+                                                    User(
+                                                        Ident("Pair")
+                                                    ),
                                                     BoundVar(3, 0)
                                                 )
                                             )
@@ -221,7 +249,9 @@ Module {
                                                 },
                                                 Bound(
                                                     Named(
-                                                        Ident("T"),
+                                                        User(
+                                                            Ident("T")
+                                                        ),
                                                         BoundVar(1, 0)
                                                     )
                                                 )
@@ -233,7 +263,9 @@ Module {
                                                 },
                                                 Bound(
                                                     Named(
-                                                        Ident("V"),
+                                                        User(
+                                                            Ident("V")
+                                                        ),
                                                         BoundVar(1, 2)
                                                     )
                                                 )

--- a/src/syntax/ast/snapshots/binary.ty_abs_complex.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_complex.snap
@@ -5,7 +5,9 @@ Lam(
     },
     [
         Named(
-            Ident("z"),
+            User(
+                Ident("z")
+            ),
             ()
         )
     ],
@@ -21,7 +23,9 @@ Lam(
             },
             [
                 Named(
-                    Ident("y"),
+                    User(
+                        Ident("y")
+                    ),
                     ()
                 )
             ],
@@ -37,7 +41,9 @@ Lam(
                     },
                     Bound(
                         Named(
-                            Ident("y"),
+                            User(
+                                Ident("y")
+                            ),
                             BoundVar(0, 0)
                         )
                     )
@@ -50,7 +56,9 @@ Lam(
                         },
                         [
                             Named(
-                                Ident("x"),
+                                User(
+                                    Ident("x")
+                                ),
                                 ()
                             )
                         ],
@@ -61,7 +69,9 @@ Lam(
                             },
                             Bound(
                                 Named(
-                                    Ident("x"),
+                                    User(
+                                        Ident("x")
+                                    ),
                                     BoundVar(0, 0)
                                 )
                             )
@@ -78,7 +88,9 @@ Lam(
                 },
                 [
                     Named(
-                        Ident("x"),
+                        User(
+                            Ident("x")
+                        ),
                         ()
                     )
                 ],
@@ -94,7 +106,9 @@ Lam(
                         },
                         Bound(
                             Named(
-                                Ident("z"),
+                                User(
+                                    Ident("z")
+                                ),
                                 BoundVar(1, 0)
                             )
                         )
@@ -107,7 +121,9 @@ Lam(
                             },
                             Bound(
                                 Named(
-                                    Ident("x"),
+                                    User(
+                                        Ident("x")
+                                    ),
                                     BoundVar(0, 0)
                                 )
                             )

--- a/src/syntax/ast/snapshots/binary.ty_abs_id.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_id.snap
@@ -5,7 +5,9 @@ Lam(
     },
     [
         Named(
-            Ident("x"),
+            User(
+                Ident("x")
+            ),
             ()
         )
     ],
@@ -16,7 +18,9 @@ Lam(
         },
         Bound(
             Named(
-                Ident("x"),
+                User(
+                    Ident("x")
+                ),
                 BoundVar(0, 0)
             )
         )

--- a/src/syntax/ast/snapshots/binary.ty_abs_k_combinator.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_k_combinator.snap
@@ -5,7 +5,9 @@ Lam(
     },
     [
         Named(
-            Ident("x"),
+            User(
+                Ident("x")
+            ),
             ()
         )
     ],
@@ -16,7 +18,9 @@ Lam(
         },
         [
             Named(
-                Ident("y"),
+                User(
+                    Ident("y")
+                ),
                 ()
             )
         ],
@@ -27,7 +31,9 @@ Lam(
             },
             Bound(
                 Named(
-                    Ident("x"),
+                    User(
+                        Ident("x")
+                    ),
                     BoundVar(1, 0)
                 )
             )

--- a/src/syntax/ast/snapshots/binary.ty_abs_s_combinator.snap
+++ b/src/syntax/ast/snapshots/binary.ty_abs_s_combinator.snap
@@ -5,7 +5,9 @@ Lam(
     },
     [
         Named(
-            Ident("x"),
+            User(
+                Ident("x")
+            ),
             ()
         )
     ],
@@ -16,7 +18,9 @@ Lam(
         },
         [
             Named(
-                Ident("y"),
+                User(
+                    Ident("y")
+                ),
                 ()
             )
         ],
@@ -27,7 +31,9 @@ Lam(
             },
             [
                 Named(
-                    Ident("z"),
+                    User(
+                        Ident("z")
+                    ),
                     ()
                 )
             ],
@@ -48,7 +54,9 @@ Lam(
                         },
                         Bound(
                             Named(
-                                Ident("x"),
+                                User(
+                                    Ident("x")
+                                ),
                                 BoundVar(2, 0)
                             )
                         )
@@ -61,7 +69,9 @@ Lam(
                             },
                             Bound(
                                 Named(
-                                    Ident("z"),
+                                    User(
+                                        Ident("z")
+                                    ),
                                     BoundVar(0, 0)
                                 )
                             )
@@ -81,7 +91,9 @@ Lam(
                             },
                             Bound(
                                 Named(
-                                    Ident("y"),
+                                    User(
+                                        Ident("y")
+                                    ),
                                     BoundVar(1, 0)
                                 )
                             )
@@ -94,7 +106,9 @@ Lam(
                                 },
                                 Bound(
                                     Named(
-                                        Ident("z"),
+                                        User(
+                                            Ident("z")
+                                        ),
                                         BoundVar(0, 0)
                                     )
                                 )

--- a/src/syntax/check/context.rs
+++ b/src/syntax/check/context.rs
@@ -1,14 +1,14 @@
 //! The type checking context and binders
 
-use name::{Ident, Named};
+use name::{Name, Named};
 use syntax::ast::{binary, host};
 use var::{BoundVar, ScopeIndex};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Scope {
-    ExprLam(Vec<Named<Ident, host::RcType>>),
-    TypeLam(Vec<Named<Ident, binary::Kind>>),
-    TypeDef(Vec<Named<Ident, (binary::RcType, binary::Kind)>>),
+    ExprLam(Vec<Named<Name, host::RcType>>),
+    TypeLam(Vec<Named<Name, binary::Kind>>),
+    TypeDef(Vec<Named<Name, (binary::RcType, binary::Kind)>>),
 }
 
 #[derive(Debug, Clone)]
@@ -34,7 +34,7 @@ impl Context {
         &self.scopes[(self.scopes.len() - scope.0 as usize) - 1]
     }
 
-    pub fn lookup_ty(&self, var: BoundVar) -> Result<(&Ident, &host::RcType), &Scope> {
+    pub fn lookup_ty(&self, var: BoundVar) -> Result<(&Name, &host::RcType), &Scope> {
         match *self.lookup(var.scope) {
             Scope::ExprLam(ref tys) => Ok(
                 tys.get(var.binding.0 as usize)
@@ -45,7 +45,7 @@ impl Context {
         }
     }
 
-    pub fn lookup_ty_def(&self, var: BoundVar) -> Result<(&Ident, &binary::RcType), &Scope> {
+    pub fn lookup_ty_def(&self, var: BoundVar) -> Result<(&Name, &binary::RcType), &Scope> {
         match *self.lookup(var.scope) {
             Scope::TypeDef(ref defs) => Ok(
                 defs.get(var.binding.0 as usize)
@@ -56,7 +56,7 @@ impl Context {
         }
     }
 
-    pub fn lookup_kind(&self, var: BoundVar) -> Result<(&Ident, &binary::Kind), &Scope> {
+    pub fn lookup_kind(&self, var: BoundVar) -> Result<(&Name, &binary::Kind), &Scope> {
         match *self.lookup(var.scope) {
             Scope::TypeLam(ref kinds) => Ok(
                 kinds

--- a/src/syntax/check/mod.rs
+++ b/src/syntax/check/mod.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 
-use name::{Ident, Named};
+use name::{Ident, Name, Named};
 use syntax::ast::{binary, host, Field, Module};
 use self::context::{Context, Scope};
 use var::Var;
@@ -27,7 +27,7 @@ pub enum ExpectedType {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeError {
     /// A variable of the requested name was not bound in this scope
-    UnboundVariable { expr: host::RcIExpr, name: Ident },
+    UnboundVariable { expr: host::RcIExpr, name: Name },
     /// Variable bound in the context was not at the value level
     ExprBindingExpected { expr: host::RcIExpr, found: Scope },
     /// One type was expected, but another was found
@@ -381,7 +381,7 @@ fn simplify_ty(ctx: &Context, ty: &binary::RcType) -> binary::RcType {
 #[derive(Debug, Clone, PartialEq)]
 pub enum KindError {
     /// A variable of the requested name was not bound in this scope
-    UnboundVariable { ty: binary::RcType, name: Ident },
+    UnboundVariable { ty: binary::RcType, name: Name },
     /// Variable bound in the context was not at the type level
     TypeBindingExpected { ty: binary::RcType, found: Scope },
     /// One kind was expected, but another was found
@@ -529,7 +529,7 @@ pub fn infer_kind(ctx: &Context, ty: &binary::RcType) -> Result<binary::Kind, Ki
 
                 let field_ty = simplify_ty(&ctx, &field.value);
                 ctx.extend(Scope::ExprLam(
-                    vec![Named(field.name.clone(), field_ty.repr())],
+                    vec![Named(Name::user(field.name.clone()), field_ty.repr())],
                 ));
             }
 
@@ -556,7 +556,7 @@ pub fn check_module(module: &Module) -> Result<(), KindError> {
         let definition_kind = infer_kind(&ctx, &definition.body_ty)?;
         ctx.extend(Scope::TypeDef(vec![
             Named(
-                definition.name.clone(),
+                Name::user(definition.name.clone()),
                 (definition.body_ty.clone(), definition_kind),
             ),
         ]));

--- a/src/var.rs
+++ b/src/var.rs
@@ -1,7 +1,7 @@
 //! Variable binding
 
 use std::fmt;
-use name::{Ident, Named};
+use name::{Name, Named};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct ScopeIndex(pub u32);
@@ -92,24 +92,24 @@ impl fmt::Debug for BoundVar {
 ///     - [Hackage](https://hackage.haskell.org/package/bound)
 /// - The Penn Locally Nameless Metatheory Library
 ///     - [Github](https://github.com/plclub/metalib)
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Var {
     /// A free, unbound variable
-    Free(Ident),
+    Free(Name),
     /// A bound variable
-    Bound(Named<Ident, BoundVar>),
+    Bound(Named<Name, BoundVar>),
 }
 
 impl Var {
-    pub fn free<N: Into<Ident>>(name: N) -> Var {
+    pub fn free<N: Into<Name>>(name: N) -> Var {
         Var::Free(name.into())
     }
 
-    pub fn bound<N: Into<Ident>>(name: N, var: BoundVar) -> Var {
+    pub fn bound<N: Into<Name>>(name: N, var: BoundVar) -> Var {
         Var::Bound(Named(name.into(), var))
     }
 
-    pub fn abstract_names_at(&mut self, names: &[Ident], scope: ScopeIndex) {
+    pub fn abstract_names_at(&mut self, names: &[Name], scope: ScopeIndex) {
         *self = match *self {
             Var::Free(ref n) => match names.iter().position(|name| name == n) {
                 Some(position) => {

--- a/tests/snapshots/examples.bitmap_ir.snap
+++ b/tests/snapshots/examples.bitmap_ir.snap
@@ -86,7 +86,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("r"),
+                                                User(
+                                                    Ident("r")
+                                                ),
                                                 BoundVar(3, 0)
                                             )
                                         )
@@ -98,7 +100,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("g"),
+                                                User(
+                                                    Ident("g")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -110,7 +114,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("b"),
+                                                User(
+                                                    Ident("b")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -122,7 +128,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("a"),
+                                                User(
+                                                    Ident("a")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -241,7 +249,9 @@ Module {
                                                 value: Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("width"),
+                                                            User(
+                                                                Ident("width")
+                                                            ),
                                                             BoundVar(1, 0)
                                                         )
                                                     )
@@ -253,7 +263,9 @@ Module {
                                                 value: Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("height"),
+                                                            User(
+                                                                Ident("height")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -269,7 +281,9 @@ Module {
                                     Var(
                                         Bound(
                                             Named(
-                                                Ident("Pixel"),
+                                                User(
+                                                    Ident("Pixel")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -281,7 +295,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("extents"),
+                                                            User(
+                                                                Ident("extents")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -292,7 +308,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("extents"),
+                                                            User(
+                                                                Ident("extents")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -316,7 +334,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("extents"),
+                                                User(
+                                                    Ident("extents")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -328,7 +348,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("data"),
+                                                User(
+                                                    Ident("data")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )

--- a/tests/snapshots/examples.bitmap_module.snap
+++ b/tests/snapshots/examples.bitmap_module.snap
@@ -18,7 +18,9 @@ Module {
                                 hi: BytePos(27)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -31,7 +33,9 @@ Module {
                                 hi: BytePos(39)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -44,7 +48,9 @@ Module {
                                 hi: BytePos(51)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -57,7 +63,9 @@ Module {
                                 hi: BytePos(63)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     }
@@ -91,7 +99,9 @@ Module {
                                             hi: BytePos(131)
                                         },
                                         Free(
-                                            Ident("u32be")
+                                            User(
+                                                Ident("u32be")
+                                            )
                                         )
                                     )
                                 },
@@ -104,7 +114,9 @@ Module {
                                             hi: BytePos(155)
                                         },
                                         Free(
-                                            Ident("u32be")
+                                            User(
+                                                Ident("u32be")
+                                            )
                                         )
                                     )
                                 }
@@ -126,7 +138,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("Pixel"),
+                                        User(
+                                            Ident("Pixel")
+                                        ),
                                         BoundVar(1, 0)
                                     )
                                 )
@@ -149,7 +163,9 @@ Module {
                                         },
                                         Bound(
                                             Named(
-                                                Ident("extents"),
+                                                User(
+                                                    Ident("extents")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -168,7 +184,9 @@ Module {
                                         },
                                         Bound(
                                             Named(
-                                                Ident("extents"),
+                                                User(
+                                                    Ident("extents")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -191,7 +209,9 @@ Module {
                 },
                 Bound(
                     Named(
-                        Ident("Bitmap"),
+                        User(
+                            Ident("Bitmap")
+                        ),
                         BoundVar(0, 0)
                     )
                 )

--- a/tests/snapshots/examples.bson_ir.snap
+++ b/tests/snapshots/examples.bson_ir.snap
@@ -67,7 +67,9 @@ Module {
                                             Var(
                                                 Bound(
                                                     Named(
-                                                        Ident("len"),
+                                                        User(
+                                                            Ident("len")
+                                                        ),
                                                         BoundVar(1, 0)
                                                     )
                                                 )
@@ -94,7 +96,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("len"),
+                                                User(
+                                                    Ident("len")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -106,7 +110,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("subtype"),
+                                                User(
+                                                    Ident("subtype")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -118,7 +124,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("data"),
+                                                User(
+                                                    Ident("data")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -224,7 +232,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("epoch_time"),
+                                                User(
+                                                    Ident("epoch_time")
+                                                ),
                                                 BoundVar(3, 0)
                                             )
                                         )
@@ -236,7 +246,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("machine_id"),
+                                                User(
+                                                    Ident("machine_id")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -248,7 +260,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("process_id"),
+                                                User(
+                                                    Ident("process_id")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -260,7 +274,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("counter"),
+                                                User(
+                                                    Ident("counter")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -428,7 +444,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -459,7 +477,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -473,7 +493,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -489,7 +511,9 @@ Module {
                                                         Var(
                                                             Bound(
                                                                 Named(
-                                                                    Ident("BinData"),
+                                                                    User(
+                                                                        Ident("BinData")
+                                                                    ),
                                                                     BoundVar(2, 0)
                                                                 )
                                                             )
@@ -507,7 +531,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -521,7 +547,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -550,7 +578,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -564,7 +594,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -580,7 +612,9 @@ Module {
                                                         Var(
                                                             Bound(
                                                                 Named(
-                                                                    Ident("ObjectId"),
+                                                                    User(
+                                                                        Ident("ObjectId")
+                                                                    ),
                                                                     BoundVar(1, 0)
                                                                 )
                                                             )
@@ -598,7 +632,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -612,7 +648,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -641,7 +679,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -655,7 +695,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -686,7 +728,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -700,7 +744,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -729,7 +775,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -743,7 +791,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -774,7 +824,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -788,7 +840,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -819,7 +873,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -833,7 +889,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -864,7 +922,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("x"),
+                                                                User(
+                                                                    Ident("x")
+                                                                ),
                                                                 BoundVar(0, 0)
                                                             )
                                                         )
@@ -888,7 +948,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("elem_type"),
+                                                User(
+                                                    Ident("elem_type")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -900,7 +962,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("content"),
+                                                User(
+                                                    Ident("content")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -961,7 +1025,9 @@ Module {
                                     Var(
                                         Bound(
                                             Named(
-                                                Ident("Element"),
+                                                User(
+                                                    Ident("Element")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -986,7 +1052,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("len"),
+                                                User(
+                                                    Ident("len")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -998,7 +1066,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("fields"),
+                                                User(
+                                                    Ident("fields")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )

--- a/tests/snapshots/examples.bson_module.snap
+++ b/tests/snapshots/examples.bson_module.snap
@@ -18,7 +18,9 @@ Module {
                                 hi: BytePos(85)
                             },
                             Free(
-                                Ident("i32be")
+                                User(
+                                    Ident("i32be")
+                                )
                             )
                         )
                     },
@@ -31,7 +33,9 @@ Module {
                                 hi: BytePos(343)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -49,7 +53,9 @@ Module {
                                     hi: BytePos(382)
                                 },
                                 Free(
-                                    Ident("u8")
+                                    User(
+                                        Ident("u8")
+                                    )
                                 )
                             ),
                             Cast(
@@ -64,7 +70,9 @@ Module {
                                     },
                                     Bound(
                                         Named(
-                                            Ident("len"),
+                                            User(
+                                                Ident("len")
+                                            ),
                                             BoundVar(1, 0)
                                         )
                                     )
@@ -98,7 +106,9 @@ Module {
                                 hi: BytePos(442)
                             },
                             Free(
-                                Ident("i32be")
+                                User(
+                                    Ident("i32be")
+                                )
                             )
                         )
                     },
@@ -111,7 +121,9 @@ Module {
                                 hi: BytePos(465)
                             },
                             Free(
-                                Ident("u24be")
+                                User(
+                                    Ident("u24be")
+                                )
                             )
                         )
                     },
@@ -124,7 +136,9 @@ Module {
                                 hi: BytePos(488)
                             },
                             Free(
-                                Ident("u16be")
+                                User(
+                                    Ident("u16be")
+                                )
                             )
                         )
                     },
@@ -137,7 +151,9 @@ Module {
                                 hi: BytePos(508)
                             },
                             Free(
-                                Ident("u24be")
+                                User(
+                                    Ident("u24be")
+                                )
                             )
                         )
                     }
@@ -162,7 +178,9 @@ Module {
                                 hi: BytePos(551)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -193,7 +211,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -213,7 +233,9 @@ Module {
                                                 hi: BytePos(652)
                                             },
                                             Free(
-                                                Ident("f64le")
+                                                User(
+                                                    Ident("f64le")
+                                                )
                                             )
                                         )
                                     )
@@ -236,7 +258,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -257,7 +281,9 @@ Module {
                                             },
                                             Bound(
                                                 Named(
-                                                    Ident("BinData"),
+                                                    User(
+                                                        Ident("BinData")
+                                                    ),
                                                     BoundVar(2, 0)
                                                 )
                                             )
@@ -282,7 +308,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -302,7 +330,9 @@ Module {
                                                 hi: BytePos(1116)
                                             },
                                             Free(
-                                                Ident("empty")
+                                                User(
+                                                    Ident("empty")
+                                                )
                                             )
                                         )
                                     )
@@ -325,7 +355,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -346,7 +378,9 @@ Module {
                                             },
                                             Bound(
                                                 Named(
-                                                    Ident("ObjectId"),
+                                                    User(
+                                                        Ident("ObjectId")
+                                                    ),
                                                     BoundVar(1, 0)
                                                 )
                                             )
@@ -371,7 +405,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -391,7 +427,9 @@ Module {
                                                 hi: BytePos(1322)
                                             },
                                             Free(
-                                                Ident("u8")
+                                                User(
+                                                    Ident("u8")
+                                                )
                                             )
                                         )
                                     )
@@ -414,7 +452,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -434,7 +474,9 @@ Module {
                                                 hi: BytePos(1400)
                                             },
                                             Free(
-                                                Ident("i64le")
+                                                User(
+                                                    Ident("i64le")
+                                                )
                                             )
                                         )
                                     )
@@ -457,7 +499,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -477,7 +521,9 @@ Module {
                                                 hi: BytePos(1468)
                                             },
                                             Free(
-                                                Ident("empty")
+                                                User(
+                                                    Ident("empty")
+                                                )
                                             )
                                         )
                                     )
@@ -500,7 +546,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -520,7 +568,9 @@ Module {
                                                 hi: BytePos(2000)
                                             },
                                             Free(
-                                                Ident("i32le")
+                                                User(
+                                                    Ident("i32le")
+                                                )
                                             )
                                         )
                                     )
@@ -543,7 +593,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -563,7 +615,9 @@ Module {
                                                 hi: BytePos(2072)
                                             },
                                             Free(
-                                                Ident("u64le")
+                                                User(
+                                                    Ident("u64le")
+                                                )
                                             )
                                         )
                                     )
@@ -586,7 +640,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("elem_type"),
+                                                            User(
+                                                                Ident("elem_type")
+                                                            ),
                                                             BoundVar(0, 0)
                                                         )
                                                     )
@@ -606,7 +662,9 @@ Module {
                                                 hi: BytePos(2144)
                                             },
                                             Free(
-                                                Ident("i64le")
+                                                User(
+                                                    Ident("i64le")
+                                                )
                                             )
                                         )
                                     )
@@ -635,7 +693,9 @@ Module {
                                 hi: BytePos(2419)
                             },
                             Free(
-                                Ident("i32be")
+                                User(
+                                    Ident("i32be")
+                                )
                             )
                         )
                     },
@@ -654,7 +714,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("Element"),
+                                        User(
+                                            Ident("Element")
+                                        ),
                                         BoundVar(1, 0)
                                     )
                                 )

--- a/tests/snapshots/examples.edid_ir.snap
+++ b/tests/snapshots/examples.edid_ir.snap
@@ -105,7 +105,9 @@ Module {
                                     Lam(
                                         [
                                             Named(
-                                                Ident("magic"),
+                                                User(
+                                                    Ident("magic")
+                                                ),
                                                 Const(
                                                     Unsigned(
                                                         U64
@@ -118,7 +120,9 @@ Module {
                                             Var(
                                                 Bound(
                                                     Named(
-                                                        Ident("magic"),
+                                                        User(
+                                                            Ident("magic")
+                                                        ),
                                                         BoundVar(0, 0)
                                                     )
                                                 )
@@ -172,7 +176,7 @@ Module {
                                     Lam(
                                         [
                                             Named(
-                                                Ident("_"),
+                                                Abstract,
                                                 Const(
                                                     Unit
                                                 )
@@ -184,7 +188,9 @@ Module {
                                                 Var(
                                                     Bound(
                                                         Named(
-                                                            Ident("mfg_year_mod"),
+                                                            User(
+                                                                Ident("mfg_year_mod")
+                                                            ),
                                                             BoundVar(2, 0)
                                                         )
                                                     )
@@ -230,7 +236,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("magic"),
+                                                User(
+                                                    Ident("magic")
+                                                ),
                                                 BoundVar(8, 0)
                                             )
                                         )
@@ -242,7 +250,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("mfg_bytes"),
+                                                User(
+                                                    Ident("mfg_bytes")
+                                                ),
                                                 BoundVar(7, 0)
                                             )
                                         )
@@ -254,7 +264,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("product_code"),
+                                                User(
+                                                    Ident("product_code")
+                                                ),
                                                 BoundVar(6, 0)
                                             )
                                         )
@@ -266,7 +278,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("serial"),
+                                                User(
+                                                    Ident("serial")
+                                                ),
                                                 BoundVar(5, 0)
                                             )
                                         )
@@ -278,7 +292,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("mfg_week"),
+                                                User(
+                                                    Ident("mfg_week")
+                                                ),
                                                 BoundVar(4, 0)
                                             )
                                         )
@@ -290,7 +306,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("mfg_year_mod"),
+                                                User(
+                                                    Ident("mfg_year_mod")
+                                                ),
                                                 BoundVar(3, 0)
                                             )
                                         )
@@ -302,7 +320,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("mfg_year"),
+                                                User(
+                                                    Ident("mfg_year")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -314,7 +334,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("edid_version_major"),
+                                                User(
+                                                    Ident("edid_version_major")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -326,7 +348,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("edid_version_minor"),
+                                                User(
+                                                    Ident("edid_version_minor")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -435,7 +459,7 @@ Module {
                                     Lam(
                                         [
                                             Named(
-                                                Ident("_"),
+                                                Abstract,
                                                 Const(
                                                     Unit
                                                 )
@@ -449,7 +473,9 @@ Module {
                                                     Var(
                                                         Bound(
                                                             Named(
-                                                                Ident("gamma_mod"),
+                                                                User(
+                                                                    Ident("gamma_mod")
+                                                                ),
                                                                 BoundVar(2, 0)
                                                             )
                                                         )
@@ -493,7 +519,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("input_flags"),
+                                                User(
+                                                    Ident("input_flags")
+                                                ),
                                                 BoundVar(5, 0)
                                             )
                                         )
@@ -505,7 +533,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("screen_size_h"),
+                                                User(
+                                                    Ident("screen_size_h")
+                                                ),
                                                 BoundVar(4, 0)
                                             )
                                         )
@@ -517,7 +547,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("screen_size_v"),
+                                                User(
+                                                    Ident("screen_size_v")
+                                                ),
                                                 BoundVar(3, 0)
                                             )
                                         )
@@ -529,7 +561,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("gamma_mod"),
+                                                User(
+                                                    Ident("gamma_mod")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -541,7 +575,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("gamma"),
+                                                User(
+                                                    Ident("gamma")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -553,7 +589,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("features_flags"),
+                                                User(
+                                                    Ident("features_flags")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -605,7 +643,9 @@ Module {
                                 Var(
                                     Bound(
                                         Named(
-                                            Ident("Header"),
+                                            User(
+                                                Ident("Header")
+                                            ),
                                             BoundVar(1, 0)
                                         )
                                     )
@@ -616,7 +656,9 @@ Module {
                                 Var(
                                     Bound(
                                         Named(
-                                            Ident("DisplayParams"),
+                                            User(
+                                                Ident("DisplayParams")
+                                            ),
                                             BoundVar(1, 0)
                                         )
                                     )
@@ -635,7 +677,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("header"),
+                                                User(
+                                                    Ident("header")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -647,7 +691,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("display_params"),
+                                                User(
+                                                    Ident("display_params")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )

--- a/tests/snapshots/examples.edid_module.snap
+++ b/tests/snapshots/examples.edid_module.snap
@@ -23,7 +23,9 @@ Module {
                                     hi: BytePos(63)
                                 },
                                 Free(
-                                    Ident("u64le")
+                                    User(
+                                        Ident("u64le")
+                                    )
                                 )
                             ),
                             Inf(
@@ -34,10 +36,14 @@ Module {
                                     },
                                     [
                                         Named(
-                                            Ident("magic"),
+                                            User(
+                                                Ident("magic")
+                                            ),
                                             Var(
                                                 Free(
-                                                    Ident("u64le")
+                                                    User(
+                                                        Ident("u64le")
+                                                    )
                                                 )
                                             )
                                         )
@@ -55,7 +61,9 @@ Module {
                                             },
                                             Bound(
                                                 Named(
-                                                    Ident("magic"),
+                                                    User(
+                                                        Ident("magic")
+                                                    ),
                                                     BoundVar(0, 0)
                                                 )
                                             )
@@ -81,7 +89,9 @@ Module {
                                 hi: BytePos(155)
                             },
                             Free(
-                                Ident("u16le")
+                                User(
+                                    Ident("u16le")
+                                )
                             )
                         )
                     },
@@ -94,7 +104,9 @@ Module {
                                 hi: BytePos(214)
                             },
                             Free(
-                                Ident("u16le")
+                                User(
+                                    Ident("u16le")
+                                )
                             )
                         )
                     },
@@ -107,7 +119,9 @@ Module {
                                 hi: BytePos(255)
                             },
                             Free(
-                                Ident("u32le")
+                                User(
+                                    Ident("u32le")
+                                )
                             )
                         )
                     },
@@ -120,7 +134,9 @@ Module {
                                 hi: BytePos(358)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -133,7 +149,9 @@ Module {
                                 hi: BytePos(478)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -156,7 +174,7 @@ Module {
                                     },
                                     [
                                         Named(
-                                            Ident("_"),
+                                            Abstract,
                                             Const(
                                                 Unit
                                             )
@@ -180,7 +198,9 @@ Module {
                                                 },
                                                 Bound(
                                                     Named(
-                                                        Ident("mfg_year_mod"),
+                                                        User(
+                                                            Ident("mfg_year_mod")
+                                                        ),
                                                         BoundVar(2, 0)
                                                     )
                                                 )
@@ -217,7 +237,9 @@ Module {
                                 hi: BytePos(667)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -230,7 +252,9 @@ Module {
                                 hi: BytePos(738)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     }
@@ -255,7 +279,9 @@ Module {
                                 hi: BytePos(826)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -268,7 +294,9 @@ Module {
                                 hi: BytePos(952)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -281,7 +309,9 @@ Module {
                                 hi: BytePos(1084)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -294,7 +324,9 @@ Module {
                                 hi: BytePos(1282)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     },
@@ -317,7 +349,7 @@ Module {
                                     },
                                     [
                                         Named(
-                                            Ident("_"),
+                                            Abstract,
                                             Const(
                                                 Unit
                                             )
@@ -347,7 +379,9 @@ Module {
                                                     },
                                                     Bound(
                                                         Named(
-                                                            Ident("gamma_mod"),
+                                                            User(
+                                                                Ident("gamma_mod")
+                                                            ),
                                                             BoundVar(2, 0)
                                                         )
                                                     )
@@ -392,7 +426,9 @@ Module {
                                 hi: BytePos(1458)
                             },
                             Free(
-                                Ident("u8")
+                                User(
+                                    Ident("u8")
+                                )
                             )
                         )
                     }
@@ -418,7 +454,9 @@ Module {
                             },
                             Bound(
                                 Named(
-                                    Ident("Header"),
+                                    User(
+                                        Ident("Header")
+                                    ),
                                     BoundVar(1, 0)
                                 )
                             )
@@ -434,7 +472,9 @@ Module {
                             },
                             Bound(
                                 Named(
-                                    Ident("DisplayParams"),
+                                    User(
+                                        Ident("DisplayParams")
+                                    ),
                                     BoundVar(1, 0)
                                 )
                             )

--- a/tests/snapshots/examples.object_id_ir.snap
+++ b/tests/snapshots/examples.object_id_ir.snap
@@ -94,7 +94,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("epoch_time"),
+                                                User(
+                                                    Ident("epoch_time")
+                                                ),
                                                 BoundVar(3, 0)
                                             )
                                         )
@@ -106,7 +108,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("machine_id"),
+                                                User(
+                                                    Ident("machine_id")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -118,7 +122,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("process_id"),
+                                                User(
+                                                    Ident("process_id")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -130,7 +136,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("counter"),
+                                                User(
+                                                    Ident("counter")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )

--- a/tests/snapshots/examples.object_id_module.snap
+++ b/tests/snapshots/examples.object_id_module.snap
@@ -18,7 +18,9 @@ Module {
                                 hi: BytePos(104)
                             },
                             Free(
-                                Ident("i32be")
+                                User(
+                                    Ident("i32be")
+                                )
                             )
                         )
                     },
@@ -31,7 +33,9 @@ Module {
                                 hi: BytePos(127)
                             },
                             Free(
-                                Ident("u24be")
+                                User(
+                                    Ident("u24be")
+                                )
                             )
                         )
                     },
@@ -44,7 +48,9 @@ Module {
                                 hi: BytePos(150)
                             },
                             Free(
-                                Ident("u16be")
+                                User(
+                                    Ident("u16be")
+                                )
                             )
                         )
                     },
@@ -57,7 +63,9 @@ Module {
                                 hi: BytePos(170)
                             },
                             Free(
-                                Ident("u24be")
+                                User(
+                                    Ident("u24be")
+                                )
                             )
                         )
                     }

--- a/tests/snapshots/examples.stl_ir.snap
+++ b/tests/snapshots/examples.stl_ir.snap
@@ -77,7 +77,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("x"),
+                                                User(
+                                                    Ident("x")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -89,7 +91,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("y"),
+                                                User(
+                                                    Ident("y")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -101,7 +105,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("z"),
+                                                User(
+                                                    Ident("z")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -164,7 +170,9 @@ Module {
                                 Var(
                                     Bound(
                                         Named(
-                                            Ident("Vec3d"),
+                                            User(
+                                                Ident("Vec3d")
+                                            ),
                                             BoundVar(0, 0)
                                         )
                                     )
@@ -176,7 +184,9 @@ Module {
                                     Var(
                                         Bound(
                                             Named(
-                                                Ident("Vec3d"),
+                                                User(
+                                                    Ident("Vec3d")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -209,7 +219,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("normal"),
+                                                User(
+                                                    Ident("normal")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -221,7 +233,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("vertices"),
+                                                User(
+                                                    Ident("vertices")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -233,7 +247,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("attribute_bytes"),
+                                                User(
+                                                    Ident("attribute_bytes")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )
@@ -318,7 +334,9 @@ Module {
                                     Var(
                                         Bound(
                                             Named(
-                                                Ident("Triangle"),
+                                                User(
+                                                    Ident("Triangle")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -327,7 +345,9 @@ Module {
                                         Var(
                                             Bound(
                                                 Named(
-                                                    Ident("num_triangles"),
+                                                    User(
+                                                        Ident("num_triangles")
+                                                    ),
                                                     BoundVar(0, 0)
                                                 )
                                             )
@@ -348,7 +368,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("header"),
+                                                User(
+                                                    Ident("header")
+                                                ),
                                                 BoundVar(2, 0)
                                             )
                                         )
@@ -360,7 +382,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("num_triangles"),
+                                                User(
+                                                    Ident("num_triangles")
+                                                ),
                                                 BoundVar(1, 0)
                                             )
                                         )
@@ -372,7 +396,9 @@ Module {
                                     value: Var(
                                         Bound(
                                             Named(
-                                                Ident("triangles"),
+                                                User(
+                                                    Ident("triangles")
+                                                ),
                                                 BoundVar(0, 0)
                                             )
                                         )

--- a/tests/snapshots/examples.stl_module.snap
+++ b/tests/snapshots/examples.stl_module.snap
@@ -18,7 +18,9 @@ Module {
                                 hi: BytePos(29)
                             },
                             Free(
-                                Ident("f32le")
+                                User(
+                                    Ident("f32le")
+                                )
                             )
                         )
                     },
@@ -31,7 +33,9 @@ Module {
                                 hi: BytePos(43)
                             },
                             Free(
-                                Ident("f32le")
+                                User(
+                                    Ident("f32le")
+                                )
                             )
                         )
                     },
@@ -44,7 +48,9 @@ Module {
                                 hi: BytePos(57)
                             },
                             Free(
-                                Ident("f32le")
+                                User(
+                                    Ident("f32le")
+                                )
                             )
                         )
                     }
@@ -70,7 +76,9 @@ Module {
                             },
                             Bound(
                                 Named(
-                                    Ident("Vec3d"),
+                                    User(
+                                        Ident("Vec3d")
+                                    ),
                                     BoundVar(0, 0)
                                 )
                             )
@@ -91,7 +99,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("Vec3d"),
+                                        User(
+                                            Ident("Vec3d")
+                                        ),
                                         BoundVar(1, 0)
                                     )
                                 )
@@ -114,7 +124,9 @@ Module {
                                 hi: BytePos(404)
                             },
                             Free(
-                                Ident("u16le")
+                                User(
+                                    Ident("u16le")
+                                )
                             )
                         )
                     }
@@ -144,7 +156,9 @@ Module {
                                     hi: BytePos(518)
                                 },
                                 Free(
-                                    Ident("u8")
+                                    User(
+                                        Ident("u8")
+                                    )
                                 )
                             ),
                             Const(
@@ -165,7 +179,9 @@ Module {
                                 hi: BytePos(591)
                             },
                             Free(
-                                Ident("u32le")
+                                User(
+                                    Ident("u32le")
+                                )
                             )
                         )
                     },
@@ -184,7 +200,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("Triangle"),
+                                        User(
+                                            Ident("Triangle")
+                                        ),
                                         BoundVar(2, 0)
                                     )
                                 )
@@ -196,7 +214,9 @@ Module {
                                 },
                                 Bound(
                                     Named(
-                                        Ident("num_triangles"),
+                                        User(
+                                            Ident("num_triangles")
+                                        ),
                                         BoundVar(0, 0)
                                     )
                                 )


### PR DESCRIPTION
This adds a few layers of type safety over names in preparation for implementing modules (see issue #88). The `name::Name` enumeration could be extended in the future to add a `Gen` variant for freshly generated names, and also a `Path` variant for module paths. I've had to do a bit more annoying cloning to support this, but the overhead of this could be reduced once we add some interning (see #23).