### PR TITLE
Switch to nominal structs

### DIFF
--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -152,6 +152,7 @@ fn eval_print(
     use codespan::ByteIndex;
 
     use syntax::concrete::{ReplCommand, Term};
+    use syntax::core::Definition;
     use syntax::pretty::{self, ToDoc};
     use syntax::translation::{Desugar, Resugar};
 
@@ -206,7 +207,7 @@ fn eval_print(
 
             let free_var = desugar_env.on_binding(&name);
             tc_env.insert_declaration(free_var.clone(), inferred);
-            tc_env.insert_definition(free_var.clone(), term);
+            tc_env.insert_definition(free_var.clone(), Definition::Alias(term));
 
             return Ok(ControlFlow::Continue);
         },

--- a/src/semantics/env.rs
+++ b/src/semantics/env.rs
@@ -2,7 +2,7 @@ use im::HashMap;
 use moniker::FreeVar;
 use std::fmt;
 
-use syntax::core::{Literal, RcTerm, RcType, RcValue, Spine, Value};
+use syntax::core::{Definition, Literal, RcType, RcValue, Spine, Value};
 
 // Some helper traits for marshalling between Rust and Pikelet values
 //
@@ -255,11 +255,11 @@ pub trait DeclarationEnv: Clone {
 pub trait DefinitionEnv: Clone {
     fn get_extern_definition(&self, name: &str) -> Option<&Extern>;
     fn get_global_definition(&self, name: &str) -> Option<&RcValue>;
-    fn get_definition(&self, free_var: &FreeVar<String>) -> Option<&RcTerm>;
-    fn insert_definition(&mut self, free_var: FreeVar<String>, RcTerm);
+    fn get_definition(&self, free_var: &FreeVar<String>) -> Option<&Definition>;
+    fn insert_definition(&mut self, free_var: FreeVar<String>, Definition);
     fn extend_definitions<T>(&mut self, iter: T)
     where
-        T: IntoIterator<Item = (FreeVar<String>, RcTerm)>;
+        T: IntoIterator<Item = (FreeVar<String>, Definition)>;
 }
 
 /// The type checking environment
@@ -281,7 +281,7 @@ pub struct TcEnv {
     /// The type annotations of the binders we have passed over
     declarations: HashMap<FreeVar<String>, RcType>,
     /// Any definitions we have passed over
-    definitions: HashMap<FreeVar<String>, RcTerm>,
+    definitions: HashMap<FreeVar<String>, Definition>,
 }
 
 impl Default for TcEnv {
@@ -326,17 +326,17 @@ impl DefinitionEnv for TcEnv {
         self.global_definitions.get(name)
     }
 
-    fn get_definition(&self, free_var: &FreeVar<String>) -> Option<&RcTerm> {
+    fn get_definition(&self, free_var: &FreeVar<String>) -> Option<&Definition> {
         self.definitions.get(free_var)
     }
 
-    fn insert_definition(&mut self, free_var: FreeVar<String>, term: RcTerm) {
+    fn insert_definition(&mut self, free_var: FreeVar<String>, term: Definition) {
         self.definitions.insert(free_var, term);
     }
 
     fn extend_definitions<T>(&mut self, iter: T)
     where
-        T: IntoIterator<Item = (FreeVar<String>, RcTerm)>,
+        T: IntoIterator<Item = (FreeVar<String>, Definition)>,
     {
         self.definitions.extend(iter)
     }

--- a/src/semantics/tests/check_module.rs
+++ b/src/semantics/tests/check_module.rs
@@ -21,7 +21,6 @@ fn infer_bare_definition() {
 #[test]
 fn forward_declarations() {
     let mut codemap = CodeMap::new();
-    let writer = StandardStream::stdout(ColorChoice::Always);
 
     let src = "
         module test;
@@ -34,6 +33,7 @@ fn forward_declarations() {
 
     let raw_module = parse_module(&mut codemap, src);
     if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
         codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
         panic!("type error!")
     }
@@ -114,5 +114,241 @@ fn duplicate_definitions() {
         Ok(_) => panic!("expected error"),
         Err(TypeError::DuplicateDefinitions { .. }) => {},
         Err(err) => panic!("unexpected error: {}", err),
+    }
+}
+
+#[test]
+fn empty_struct() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Test {};
+
+        test : (Test : Type);
+        test = struct {};
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
+    }
+}
+
+#[test]
+fn simple_struct() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Test {
+            t : Type,
+            x : String,
+        };
+
+        test : (Test : Type 1);
+        test = struct {
+            t = String,
+            x = "hello",
+        };
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
+    }
+}
+
+#[test]
+fn dependent_struct() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Test {
+            t : Type,
+            x : t,
+        };
+
+        test : (Test : Type 1);
+        test = struct {
+            t = String,
+            x = "hello",
+        };
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
+    }
+}
+
+#[test]
+fn dependent_struct_propagate_types() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Test {
+            t : Type,
+            x : t,
+        };
+
+        test : (Test : Type 1);
+        test = struct {
+            t = S32,
+            x = 1,
+        };
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
+    }
+}
+
+#[test]
+fn simple_struct_proj() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Test {
+            t : Type,
+            x : String,
+        };
+
+        test : (Test : Type 1);
+        test = struct {
+            t = S32,
+            x = "hello",
+        };
+
+        test-x : String = test.x;
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
+    }
+}
+
+#[test]
+fn simple_struct_proj_missing() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Test {
+            x : String,
+        };
+
+        test : Test;
+        test = struct {
+            x = "hello",
+        };
+
+        test-bloop = test.bloop;
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    match check_module(&TcEnv::default(), &raw_module) {
+        Ok(_) => panic!("expected error"),
+        Err(TypeError::NoFieldInType { .. }) => {},
+        Err(err) => panic!("unexpected error: {}", err),
+    }
+}
+
+#[test]
+fn dependent_struct_proj_weird1() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Data {
+            t : Type,
+            x : t,
+        };
+
+        struct Test {
+            data : Data,
+            f : data.t -> Type,
+            test : f data.x,
+        };
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
+    }
+}
+
+#[test]
+fn dependent_struct_proj_weird2() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Data {
+            n : U16,
+            x : Array n S8,
+            y : Array n S8,
+        };
+
+        struct Test {
+            data : Data,
+            inner-prod : (len : U16) -> Array len S8 -> Array len S8 -> S32,
+
+            test1 : S32 -> Type,
+            test2 : test1 (inner-prod data.n data.x data.y),
+        };
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
+    }
+}
+
+#[test]
+fn dependent_struct_with_integer() {
+    let mut codemap = CodeMap::new();
+
+    let src = r#"
+        module test;
+
+        struct Test {
+            len : U16Be,
+            data : Array len U32Be,
+        };
+    "#;
+
+    let raw_module = parse_module(&mut codemap, src);
+    if let Err(err) = check_module(&TcEnv::default(), &raw_module) {
+        let writer = StandardStream::stdout(ColorChoice::Always);
+        codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
+        panic!("type error!")
     }
 }

--- a/src/semantics/tests/check_term.rs
+++ b/src/semantics/tests/check_term.rs
@@ -1,42 +1,6 @@
 use super::*;
 
 #[test]
-fn struct_() {
-    let mut codemap = CodeMap::new();
-    let tc_env = TcEnv::default();
-
-    let expected_ty = r"Struct { t : Type, x : String }";
-    let given_expr = r#"struct { t = String, x = "hello" }"#;
-
-    let expected_ty = parse_nf_term(&mut codemap, &tc_env, expected_ty);
-    parse_check_term(&mut codemap, &tc_env, given_expr, &expected_ty);
-}
-
-#[test]
-fn dependent_struct() {
-    let mut codemap = CodeMap::new();
-    let tc_env = TcEnv::default();
-
-    let expected_ty = r"Struct { t : Type, x : t }";
-    let given_expr = r#"struct { t = String, x = "hello" }"#;
-
-    let expected_ty = parse_nf_term(&mut codemap, &tc_env, expected_ty);
-    parse_check_term(&mut codemap, &tc_env, given_expr, &expected_ty);
-}
-
-#[test]
-fn dependent_struct_propagate_types() {
-    let mut codemap = CodeMap::new();
-    let tc_env = TcEnv::default();
-
-    let expected_ty = r"Struct { t : Type, x : t }";
-    let given_expr = r#"struct { t = S32, x = 1 }"#;
-
-    let expected_ty = parse_nf_term(&mut codemap, &tc_env, expected_ty);
-    parse_check_term(&mut codemap, &tc_env, given_expr, &expected_ty);
-}
-
-#[test]
 fn range_full() {
     let mut codemap = CodeMap::new();
     let tc_env = TcEnv::default();

--- a/src/semantics/tests/parser.rs
+++ b/src/semantics/tests/parser.rs
@@ -1,47 +1,11 @@
 use byteorder::{BigEndian, WriteBytesExt};
+use num_bigint::BigInt;
 use std::io::Cursor;
 
 use semantics::parser::{self, ParseError};
 use syntax::Label;
 
 use super::*;
-
-#[test]
-fn silly_format() {
-    let mut codemap = CodeMap::new();
-    let tc_env = TcEnv::default();
-
-    let given_format = r#"Struct {
-        len : U16Be,
-        data : Array len U32Be,
-    }"#;
-
-    let mut given_bytes = {
-        let mut given_bytes = Vec::new();
-
-        given_bytes.write_u16::<BigEndian>(3).unwrap(); // len
-        given_bytes.write_u32::<BigEndian>(1).unwrap(); // data[0]
-        given_bytes.write_u32::<BigEndian>(3).unwrap(); // data[1]
-        given_bytes.write_u32::<BigEndian>(6).unwrap(); // data[2]
-
-        Cursor::new(given_bytes)
-    };
-
-    let expected_term = r#"struct {
-        len = 3,
-        data = [1, 3, 6],
-    } : Struct {
-        len : U16,
-        data : Array len U32,
-    }"#;
-
-    let given_format = parse_nf_term(&mut codemap, &tc_env, given_format);
-    let expected_term = parse_nf_term(&mut codemap, &tc_env, expected_term);
-
-    let result_term = parser::parse_term(&tc_env, &given_format, &mut given_bytes).unwrap();
-
-    assert_term_eq!(result_term, expected_term);
-}
 
 #[test]
 fn silly_root() {
@@ -52,10 +16,9 @@ fn silly_root() {
         module silly;
 
         Data : U32 -> Type;
-        Silly : Type;
 
         Data len = Array len U32Be;
-        Silly = Struct {
+        struct Silly {
             len : U16Be,
             data : Data len,
         };
@@ -72,25 +35,30 @@ fn silly_root() {
         Cursor::new(given_bytes)
     };
 
-    let expected_term = r#"struct {
-        len = 3,
-        data = [1, 3, 6],
-    } : Struct {
-        len : U16,
-        data : Array len U32,
-    }"#;
-
     let given_format = parse_check_module(&mut codemap, &tc_env, given_format);
-    let expected_term = parse_nf_term(&mut codemap, &tc_env, expected_term);
 
-    let result_term = parser::parse_module(
-        &tc_env,
-        &Label(String::from("Silly")),
-        &given_format,
-        &mut given_bytes,
-    ).unwrap();
-
-    assert_term_eq!(result_term, expected_term);
+    assert_term_eq!(
+        parser::parse_module(
+            &tc_env,
+            &Label(String::from("Silly")),
+            &given_format,
+            &mut given_bytes,
+        ).unwrap(),
+        RcValue::from(Value::Struct(vec![
+            (
+                Label(String::from("len")),
+                RcValue::from(Value::Literal(Literal::Int(BigInt::from(3))))
+            ),
+            (
+                Label(String::from("data")),
+                RcValue::from(Value::Array(vec![
+                    RcValue::from(Value::Literal(Literal::Int(BigInt::from(1)))),
+                    RcValue::from(Value::Literal(Literal::Int(BigInt::from(3)))),
+                    RcValue::from(Value::Literal(Literal::Int(BigInt::from(6)))),
+                ])),
+            ),
+        ])),
+    );
 }
 
 #[test]

--- a/src/syntax/parse/grammar.lalrpop
+++ b/src/syntax/parse/grammar.lalrpop
@@ -3,7 +3,7 @@ use codespan::{ByteIndex, ByteSpan};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
-use syntax::concrete::{Item, Exposing, Literal, Module, Pattern, Term, ReplCommand};
+use syntax::concrete::{Definition, Exposing, Item, Literal, Module, Pattern, Term, ReplCommand};
 use syntax::parse::{LalrpopError, ParseError, Token};
 
 #[LALR]
@@ -35,7 +35,6 @@ extern {
         "import" => Token::Import,
         "of" => Token::Of,
         "struct" => Token::Struct,
-        "Struct" => Token::StructType,
         "then" => Token::Then,
         "Type" => Token::Type,
 
@@ -108,9 +107,18 @@ Item: Item = {
         Item::Declaration { name, ann }
     },
     <_comment: "doc comment"*> <name: IndexedIdent> <params: AtomicLamParam*> <return_ann: (":" <Term>)?> "="
-        <body: Term> ";" =>
+        <term: Term> ";" =>
     {
-        Item::Definition { name, params, return_ann: return_ann.map(Box::new), body }
+        let return_ann = return_ann.map(Box::new);
+        Item::Definition(Definition::Alias { name, params, return_ann, term })
+    },
+    <_comment: "doc comment"*> <start: @L> "struct" <name: IndexedIdent>
+        "{" <fields: (<StructTypeField> ",")*> <last: StructTypeField?> "}" <end: @R> ";" =>
+    {
+        let span = ByteSpan::new(start, end);
+        let mut fields = fields;
+        fields.extend(last);
+        Item::Definition(Definition::StructType { span, name, fields })
     },
     <start: @L> <recovered: !> <end: @R> ";" => {
         errors.push(super::errors::from_lalrpop(filemap, recovered.error));
@@ -252,11 +260,6 @@ AtomicTerm: Term = {
         } else {
             Term::Name(start, ident)
         }
-    },
-    <start: @L> "Struct" "{" <fields: (<StructTypeField> ",")*> <last: StructTypeField?> "}" <end: @R> => {
-        let mut fields = fields;
-        fields.extend(last);
-        Term::StructType(ByteSpan::new(start, end), fields)
     },
     <start: @L> "struct" "{" <fields: (<StructField> ",")*> <last: StructField?> "}" <end: @R> => {
         let mut fields = fields;

--- a/src/syntax/parse/lexer.rs
+++ b/src/syntax/parse/lexer.rs
@@ -102,20 +102,19 @@ pub enum Token<S> {
     FloatLiteral(f64),
 
     // Keywords
-    As,         // as
-    Case,       // case
-    Else,       // else
-    Extern,     // extern
-    If,         // if
-    Import,     // import
-    In,         // in
-    Let,        // let
-    Module,     // module
-    Of,         // of
-    Struct,     // struct
-    StructType, // Struct
-    Then,       // then
-    Type,       // Type
+    As,     // as
+    Case,   // case
+    Else,   // else
+    Extern, // extern
+    If,     // if
+    Import, // import
+    In,     // in
+    Let,    // let
+    Module, // module
+    Of,     // of
+    Struct, // struct
+    Then,   // then
+    Type,   // Type
 
     // Symbols
     BSlash,    // \
@@ -158,7 +157,6 @@ impl<S: fmt::Display> fmt::Display for Token<S> {
             Token::Module => write!(f, "module"),
             Token::Of => write!(f, "of"),
             Token::Struct => write!(f, "struct"),
-            Token::StructType => write!(f, "Struct"),
             Token::Then => write!(f, "then"),
             Token::Type => write!(f, "Type"),
             Token::BSlash => write!(f, "\\"),
@@ -201,7 +199,6 @@ impl<'input> From<Token<&'input str>> for Token<String> {
             Token::Module => Token::Module,
             Token::Of => Token::Of,
             Token::Struct => Token::Struct,
-            Token::StructType => Token::StructType,
             Token::Then => Token::Then,
             Token::Type => Token::Type,
             Token::BSlash => Token::BSlash,
@@ -349,7 +346,6 @@ impl<'input> Lexer<'input> {
             "module" => Token::Module,
             "of" => Token::Of,
             "struct" => Token::Struct,
-            "Struct" => Token::StructType,
             "then" => Token::Then,
             "Type" => Token::Type,
             ident => Token::Ident(ident),
@@ -575,20 +571,19 @@ mod tests {
     #[test]
     fn keywords() {
         test! {
-            "  as else extern if import in let module of struct Struct then Type  ",
-            "  ~~                                                                 " => Token::As,
-            "     ~~~~                                                            " => Token::Else,
-            "          ~~~~~~                                                     " => Token::Extern,
-            "                 ~~                                                  " => Token::If,
-            "                    ~~~~~~                                           " => Token::Import,
-            "                           ~~                                        " => Token::In,
-            "                              ~~~                                    " => Token::Let,
-            "                                  ~~~~~~                             " => Token::Module,
-            "                                         ~~                          " => Token::Of,
-            "                                            ~~~~~~                   " => Token::Struct,
-            "                                                   ~~~~~~            " => Token::StructType,
-            "                                                          ~~~~       " => Token::Then,
-            "                                                               ~~~~  " => Token::Type,
+            "  as else extern if import in let module of struct then Type  ",
+            "  ~~                                                          " => Token::As,
+            "     ~~~~                                                     " => Token::Else,
+            "          ~~~~~~                                              " => Token::Extern,
+            "                 ~~                                           " => Token::If,
+            "                    ~~~~~~                                    " => Token::Import,
+            "                           ~~                                 " => Token::In,
+            "                              ~~~                             " => Token::Let,
+            "                                  ~~~~~~                      " => Token::Module,
+            "                                         ~~                   " => Token::Of,
+            "                                            ~~~~~~            " => Token::Struct,
+            "                                                   ~~~~       " => Token::Then,
+            "                                                        ~~~~  " => Token::Type,
         };
     }
 

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -91,10 +91,6 @@ fn pretty_if(cond: &impl ToDoc, if_true: &impl ToDoc, if_false: &impl ToDoc) -> 
     )
 }
 
-fn pretty_struct_ty(inner: StaticDoc) -> StaticDoc {
-    sexpr("Struct", inner)
-}
-
 fn pretty_struct(inner: StaticDoc) -> StaticDoc {
     sexpr("struct", inner)
 }
@@ -171,18 +167,6 @@ impl ToDoc for raw::Term {
             raw::Term::If(_, ref cond, ref if_true, ref if_false) => {
                 pretty_if(&cond.inner, &if_true.inner, &if_false.inner)
             },
-            raw::Term::StructType(_, ref scope) => pretty_struct_ty(Doc::concat(
-                scope.unsafe_pattern.unsafe_patterns.iter().map(
-                    |&(ref label, _, Embed(ref ann))| {
-                        parens(
-                            Doc::as_string(label)
-                                .append(Doc::space())
-                                .append(ann.to_doc())
-                                .append(Doc::newline()),
-                        )
-                    },
-                ),
-            )),
             raw::Term::Struct(_, ref fields) => {
                 pretty_struct(Doc::concat(fields.iter().map(|&(ref label, ref term)| {
                     parens(
@@ -257,18 +241,6 @@ impl ToDoc for Term {
             Term::If(ref cond, ref if_true, ref if_false) => {
                 pretty_if(&cond.inner, &if_true.inner, &if_false.inner)
             },
-            Term::StructType(ref scope) => pretty_struct_ty(Doc::concat(
-                scope.unsafe_pattern.unsafe_patterns.iter().map(
-                    |&(ref label, _, Embed(ref ann))| {
-                        parens(
-                            Doc::as_string(label)
-                                .append(Doc::space())
-                                .append(ann.to_doc())
-                                .append(Doc::newline()),
-                        )
-                    },
-                ),
-            )),
             Term::Struct(ref fields) => {
                 pretty_struct(Doc::concat(fields.iter().map(|&(ref label, ref term)| {
                     parens(
@@ -311,18 +283,6 @@ impl ToDoc for Value {
                 &(scope.unsafe_pattern.1).0.inner,
                 &scope.unsafe_body.inner,
             ),
-            Value::StructType(ref scope) => pretty_struct_ty(Doc::concat(
-                scope.unsafe_pattern.unsafe_patterns.iter().map(
-                    |&(ref label, _, Embed(ref ann))| {
-                        parens(
-                            Doc::as_string(label)
-                                .append(Doc::space())
-                                .append(ann.to_doc())
-                                .append(Doc::newline()),
-                        )
-                    },
-                ),
-            )),
             Value::Struct(ref fields) => {
                 pretty_struct(Doc::concat(fields.iter().map(|&(ref label, ref term)| {
                     parens(


### PR DESCRIPTION
Here we switch to using nominal structs rather than structral structs. This will allow us to hide type recursion in these definitions later on, as seen in languages like OCaml, Haskell, and Rust. It will also make it easier to generate implementations for languages like Rust that have nominal structs as well.