### PR TITLE
Fix application spines in values

### DIFF
--- a/src/semantics/context.rs
+++ b/src/semantics/context.rs
@@ -796,7 +796,10 @@ impl Context {
         })
     }
 
-    pub fn compute_array<'a>(&self, ty: &'a RcType) -> Option<(&'a BigInt, &'a RcType, &'a RcValue)> {
+    pub fn compute_array<'a>(
+        &self,
+        ty: &'a RcType,
+    ) -> Option<(&'a BigInt, &'a RcType, &'a RcValue)> {
         free_var_app(&self.globals.var_compute_array, ty).and_then(|spine| match spine {
             &[ref len, ref elem_ty, ref fun] => match **len {
                 Value::Literal(Literal::Int(ref len, _)) => Some((len, elem_ty, fun)),

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -71,10 +71,7 @@ impl InternalError {
 /// An error produced during type checking
 #[derive(Debug, Fail, Clone, PartialEq)]
 pub enum TypeError {
-    #[fail(
-        display = "Applied an argument to a non-function type `{}`",
-        found
-    )]
+    #[fail(display = "Applied an argument to a non-function type `{}`", found)]
     ArgAppliedToNonFunction {
         fn_span: ByteSpan,
         arg_span: ByteSpan,
@@ -89,19 +86,12 @@ pub enum TypeError {
         var_span: Option<ByteSpan>,
         name: FreeVar<String>,
     },
-    #[fail(
-        display = "Type annotation needed for the binder `{}`",
-        binder
-    )]
+    #[fail(display = "Type annotation needed for the binder `{}`", binder)]
     BinderNeedsAnnotation {
         span: ByteSpan,
         binder: Binder<String>,
     },
-    #[fail(
-        display = "found a `{}`, but expected a type `{}`",
-        found,
-        expected
-    )]
+    #[fail(display = "found a `{}`, but expected a type `{}`", found, expected)]
     LiteralMismatch {
         literal_span: ByteSpan,
         found: raw::Literal,
@@ -117,18 +107,14 @@ pub enum TypeError {
     AmbiguousExtern { span: ByteSpan },
     #[fail(display = "Empty match expressions need type annotations.")]
     AmbiguousEmptyMatch { span: ByteSpan },
-    #[fail(
-        display = "Unable to elaborate hole, expected: `{:?}`",
-        expected
-    )]
+    #[fail(display = "Unable to elaborate hole, expected: `{:?}`", expected)]
     UnableToElaborateHole {
         span: ByteSpan,
         expected: Option<Box<concrete::Term>>,
     },
     #[fail(
         display = "Type mismatch: found `{}` but `{}` was expected",
-        found,
-        expected
+        found, expected
     )]
     Mismatch {
         span: ByteSpan,
@@ -154,8 +140,7 @@ pub enum TypeError {
     UndefinedExternName { span: ByteSpan, name: String },
     #[fail(
         display = "Label mismatch: found label `{}` but `{}` was expected",
-        found,
-        expected
+        found, expected
     )]
     LabelMismatch {
         span: ByteSpan,
@@ -166,8 +151,7 @@ pub enum TypeError {
     AmbiguousStruct { span: ByteSpan },
     #[fail(
         display = "Mismatched array length: expected {} elements but found {}",
-        expected_len,
-        found_len
+        expected_len, found_len
     )]
     ArrayLengthMismatch {
         span: ByteSpan,
@@ -178,8 +162,7 @@ pub enum TypeError {
     AmbiguousArrayLiteral { span: ByteSpan },
     #[fail(
         display = "The type `{}` does not contain a field named `{}`.",
-        found,
-        expected_label
+        found, expected_label
     )]
     NoFieldInType {
         label_span: ByteSpan,
@@ -188,8 +171,7 @@ pub enum TypeError {
     },
     #[fail(
         display = "Mismatched record size: expected {} fields but found {}",
-        expected_size,
-        found_size
+        expected_size, found_size
     )]
     StructSizeMismatch {
         span: ByteSpan,

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -619,7 +619,7 @@ pub fn check_term(
                     span: Some(span),
                     message: "unexpected arguments to `Array`".to_owned(),
                 })),
-            }
+            };
         },
 
         (&raw::Term::Hole(span), _) => {

--- a/src/semantics/parser.rs
+++ b/src/semantics/parser.rs
@@ -335,7 +335,7 @@ where
         | core::Value::Array(_) => Err(ParseError::InvalidType(ty.clone())),
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
-        core::Value::Neutral(ref neutral, ref spine) => {
+        core::Value::Neutral(ref neutral) => {
             // Parse offsets
             if let Some((pos, ty)) = context.offset8(ty) { return queue_offset(pending, pos + bytes.read_u8()? as u64, ty); }
             if let Some((pos, ty)) = context.offset16le(ty) { return queue_offset(pending, pos + bytes.read_u16::<Le>()? as u64, ty); }
@@ -374,7 +374,7 @@ where
             }
 
             match **neutral {
-                core::Neutral::Head(core::Head::Var(Var::Free(ref free_var))) => {
+                core::Neutral::Head(core::Head::Var(Var::Free(ref free_var)), ref spine) => {
                     // Follow definitions
                     match context.get_definition(free_var) {
                         // FIXME: follow alias?
@@ -424,7 +424,7 @@ where
                     }
                 },
                 // Invalid parse types
-                core::Neutral::Head(_) | core::Neutral::Proj(_, _) | core::Neutral::Match(_, _) => {
+                core::Neutral::Head(..) | core::Neutral::Proj(..) | core::Neutral::Match(..) => {
                     Err(ParseError::InvalidType(ty.clone()))
                 },
             }

--- a/src/syntax/parse/errors.rs
+++ b/src/syntax/parse/errors.rs
@@ -27,8 +27,7 @@ pub enum ParseError {
     },
     #[fail(
         display = "Unexpected token {}, found, expected one of: {}.",
-        token,
-        expected
+        token, expected
     )]
     UnexpectedToken {
         span: ByteSpan,

--- a/src/syntax/parse/lexer.rs
+++ b/src/syntax/parse/lexer.rs
@@ -439,7 +439,7 @@ impl<'input> Lexer<'input> {
             Some((next, '\'')) => {
                 return Err(LexerError::EmptyCharLiteral {
                     span: ByteSpan::new(start, next + ByteOffset::from_char_utf8('\'')),
-                })
+                });
             },
             Some((_, ch)) => ch,
             None => return Err(LexerError::UnexpectedE { end: start }),

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -340,26 +340,30 @@ impl ToDoc for Value {
                     Doc::text(";").append(Doc::space()),
                 ))
                 .append("]"),
-            Value::Neutral(ref neutral, ref spine) if spine.is_empty() => neutral.to_doc(),
-            Value::Neutral(ref neutral, ref spine) => {
-                pretty_app(neutral.to_doc(), spine.iter().map(|arg| &arg.inner))
-            },
+            Value::Neutral(ref neutral) => neutral.to_doc(),
         }
     }
 }
 
 impl ToDoc for Neutral {
     fn to_doc(&self) -> StaticDoc {
-        match *self {
-            Neutral::Head(ref head) => head.to_doc(),
-            Neutral::Proj(ref expr, ref label) => pretty_proj(&expr.inner, label),
-            Neutral::Match(ref head, ref clauses) => pretty_match(
-                &head.inner,
-                clauses
-                    .iter()
-                    .map(|clause| (&clause.unsafe_pattern.inner, &clause.unsafe_body.inner)),
+        let (head, spine) = match *self {
+            Neutral::Head(ref head, ref spine) => (head.to_doc(), spine),
+            Neutral::Proj(ref expr, ref label, ref spine) => {
+                (pretty_proj(&expr.inner, label), spine)
+            },
+            Neutral::Match(ref head, ref clauses, ref spine) => (
+                pretty_match(
+                    &head.inner,
+                    clauses
+                        .iter()
+                        .map(|clause| (&clause.unsafe_pattern.inner, &clause.unsafe_body.inner)),
+                ),
+                spine,
             ),
-        }
+        };
+
+        pretty_app(head, spine.iter().map(|arg| &arg.inner))
     }
 }
 

--- a/tests/desugar.rs
+++ b/tests/desugar.rs
@@ -78,7 +78,7 @@ mod module {
     #[test]
     fn infer_bare_definition() {
         let mut codemap = CodeMap::new();
-        let desugar_env = DesugarEnv::new(hashmap!{
+        let desugar_env = DesugarEnv::new(hashmap! {
             "true".to_owned() => FreeVar::fresh_named("true"),
         });
 
@@ -98,7 +98,7 @@ mod module {
     #[test]
     fn forward_declarations() {
         let mut codemap = CodeMap::new();
-        let desugar_env = DesugarEnv::new(hashmap!{
+        let desugar_env = DesugarEnv::new(hashmap! {
             "Bool".to_owned() => FreeVar::fresh_named("Bool"),
             "true".to_owned() => FreeVar::fresh_named("true"),
             "false".to_owned() => FreeVar::fresh_named("false"),
@@ -161,7 +161,7 @@ mod module {
     #[test]
     fn declaration_after_definition() {
         let mut codemap = CodeMap::new();
-        let desugar_env = DesugarEnv::new(hashmap!{
+        let desugar_env = DesugarEnv::new(hashmap! {
             "Bool".to_owned() => FreeVar::fresh_named("Bool"),
             "true".to_owned() => FreeVar::fresh_named("true"),
         });
@@ -183,7 +183,7 @@ mod module {
     #[test]
     fn duplicate_declarations() {
         let mut codemap = CodeMap::new();
-        let desugar_env = DesugarEnv::new(hashmap!{
+        let desugar_env = DesugarEnv::new(hashmap! {
             "Bool".to_owned() => FreeVar::fresh_named("Bool"),
             "I32".to_owned() => FreeVar::fresh_named("I32"),
         });
@@ -205,7 +205,7 @@ mod module {
     #[test]
     fn duplicate_definitions() {
         let mut codemap = CodeMap::new();
-        let desugar_env = DesugarEnv::new(hashmap!{
+        let desugar_env = DesugarEnv::new(hashmap! {
             "Bool".to_owned() => FreeVar::fresh_named("Bool"),
             "I32".to_owned() => FreeVar::fresh_named("I32"),
         });
@@ -576,7 +576,7 @@ mod term {
 
         #[test]
         fn if_then_else() {
-            let env = DesugarEnv::new(hashmap!{
+            let env = DesugarEnv::new(hashmap! {
                 "true".to_owned() => FreeVar::fresh_named("true"),
                 "false".to_owned() => FreeVar::fresh_named("false"),
             });
@@ -589,7 +589,7 @@ mod term {
 
         #[test]
         fn struct_field_puns() {
-            let env = DesugarEnv::new(hashmap!{
+            let env = DesugarEnv::new(hashmap! {
                 "x".to_owned() => FreeVar::fresh_named("x"),
                 "y".to_owned() => FreeVar::fresh_named("y"),
             });

--- a/tests/normalize.rs
+++ b/tests/normalize.rs
@@ -96,10 +96,10 @@ mod nf_term {
                 (Binder(x.clone()), Embed(ty_arr)),
                 RcValue::from(Value::Lam(Scope::new(
                     (Binder(y.clone()), Embed(RcValue::from(Value::universe(0)))),
-                    RcValue::from(Value::Neutral(
-                        RcNeutral::from(Neutral::Head(Head::Var(Var::Free(x)))),
-                        vec![RcValue::from(Value::from(Var::Free(y)))],
-                    )),
+                    RcValue::from(Value::Neutral(RcNeutral::from(Neutral::Head(
+                        Head::Var(Var::Free(x)),
+                        vec![RcValue::from(Value::from(Var::Free(y)))]
+                    )),)),
                 ))),
             ))),
         );
@@ -128,10 +128,10 @@ mod nf_term {
                 (Binder(x.clone()), Embed(ty_arr)),
                 RcValue::from(Value::Pi(Scope::new(
                     (Binder(y.clone()), Embed(RcValue::from(Value::universe(0)))),
-                    RcValue::from(Value::Neutral(
-                        RcNeutral::from(Neutral::Head(Head::Var(Var::Free(x)))),
+                    RcValue::from(Value::Neutral(RcNeutral::from(Neutral::Head(
+                        Head::Var(Var::Free(x)),
                         vec![RcValue::from(Value::from(Var::Free(y)))],
-                    )),
+                    )),)),
                 ))),
             ))),
         );


### PR DESCRIPTION
This fixes the neutral terms so that we can actually represent terms in the form:

```
(foo x y).bar
```

and:

```
match foo x y { .. }
```