### PR TITLE
Move some cleanups from Pikelet into Fathom

### DIFF
--- a/experiments/makam-spec/src/lang/core/semantics.makam
+++ b/experiments/makam-spec/src/lang/core/semantics.makam
@@ -10,10 +10,13 @@
 
     % The result of evaluating a term.
     value : type.
-    % Neutral values are computations that are currently 'stuck' on some
-    % as-yet unknown computation. We build up a 'spine' of eliminations
-    % that cannot yet reduce in preperation for if they become 'unstuck'.
-    neutral : type.
+    % Values that are currently 'stuck' on some as-yet unknown computation.
+    % We build up a 'spine' of eliminations that cannot yet reduce in
+    % preperation for if they become 'unstuck'.
+    %
+    % These are also known as 'neutral values' or 'accumulators'
+    % in other presentations of normalization-by-evaluation.
+    stuck : type.
     % Closures are terms from the core syntax that have yet to be evaluated.
     % They capture an environment of values to be used later, when they are
     % finally evaluated.
@@ -25,7 +28,7 @@
     choice_closure : type.
 
     % Neutral values
-    neutral : neutral -> value.
+    stuck : stuck -> value.
 
     % Universes
     type_type : value.
@@ -84,15 +87,15 @@
     format_intro_absorb : value -> value.
 
     % Variables
-    local : int -> neutral. % Local variables (using De Bruijn levels)
+    local : int -> stuck. % Local variables (using De Bruijn levels)
 
     % Suspended eliminations
-    function_elim : neutral -> value -> neutral.
-    record_elim : neutral -> string -> neutral.
-    enum_elim : choice_closure -> neutral -> neutral.
-    %  stage_elim : neutral -> neutral.
-    %  array_elim : neutral -> value -> neutral.
-    format_elim : neutral -> neutral.
+    function_elim : stuck -> value -> stuck.
+    record_elim : stuck -> string -> stuck.
+    enum_elim : choice_closure -> stuck -> stuck.
+    %  stage_elim : stuck -> stuck.
+    %  array_elim : stuck -> value -> stuck.
+    format_elim : stuck -> stuck.
 
     closure : list value -> term -> closure.
     field_closure : list value -> list (string * term) -> field_closure.
@@ -108,7 +111,7 @@
     function_elim : value -> value -> value -> prop.
     record_elim : value -> string -> value -> prop.
     %  stage_elim : value -> value -> prop.
-    %  array_elim : value -> value -> neutral.
+    %  array_elim : value -> value -> stuck.
     format_elim : value -> value -> prop.
 
     eval Values (local Index) Value :-
@@ -146,7 +149,7 @@
     eval Values (array_intro Elems Type) (array_intro Elems' Type') :-
         map (pfun Elem Elem' => eval Values Elem Elem') Elems Elems',
         eval Values Type Type'.
-    % FIXME: This breaks for neutral terms! We should use `array_elim` here.
+    % FIXME: This breaks for stuck terms! We should use `array_elim` here.
     eval Values (array_elim ArrayElem IndexElem) ElemValue :-
         eval Values ArrayElem (array_intro ElemValues _),
         eval Values IndexElem (int_intro Index),
@@ -188,24 +191,24 @@
 
     % Eliminations
 
-    function_elim (neutral Neutral) InputValue (neutral (function_elim Neutral InputValue)).
+    function_elim (stuck Neutral) InputValue (stuck (function_elim Neutral InputValue)).
     function_elim (function_intro _ Closure) InputValue OutputValue :-
         apply Closure InputValue OutputValue.
     function_elim
         (enum_elim (choice_closure Values Clauses OutputType))
-        (neutral Neutral)
-        (neutral (enum_elim (choice_closure Values Clauses OutputType) Neutral)).
+        (stuck Neutral)
+        (stuck (enum_elim (choice_closure Values Clauses OutputType) Neutral)).
     function_elim (enum_elim (choice_closure Values Clauses _)) (enum_intro Label _) OutputValue :-
         map.find Clauses Label OutputElem,
         eval Values OutputElem OutputValue.
 
-    record_elim (neutral Neutral) Label (neutral (record_elim Neutral Label)).
+    record_elim (stuck Neutral) Label (stuck (record_elim Neutral Label)).
     record_elim (record_intro ElemFields _) Label FieldElem :-
         map.find ElemFields Label FieldElem.
 
     % TODO: stage_elim
 
-    format_elim (neutral Neutral) (neutral (format_elim Neutral)).
+    format_elim (stuck Neutral) (stuck (format_elim Neutral)).
     format_elim format_intro_void (enum_type []).
     format_elim format_intro_unit (record_type (field_closure [] [])).
     format_elim format_intro_u8 int_type.
@@ -247,19 +250,19 @@
 
     % Readback of values into terms in normal form
 
-    readback : int -> neutral -> term -> prop.
+    readback : int -> stuck -> term -> prop.
     readback : int -> value -> term -> prop.
 
-    readback Length (local Level : neutral) (local Index) :-
+    readback Length (local Level : stuck) (local Index) :-
         % Convert De Bruijn levels to De Bruijn indices
         functional.do !(minus Length !(plus Level 1)) Index.
-    readback Length (function_elim Neutral InputValue : neutral) (function_elim Elem InputElem) :-
+    readback Length (function_elim Neutral InputValue : stuck) (function_elim Elem InputElem) :-
         readback Length Neutral Elem,
         readback Length InputValue InputElem.
-    readback Length (record_elim Neutral Label : neutral) (record_elim Elem Label) :-
+    readback Length (record_elim Neutral Label : stuck) (record_elim Elem Label) :-
         readback Length Neutral Elem.
     readback Length
-        (enum_elim (choice_closure Values Clauses OutputType) Neutral : neutral)
+        (enum_elim (choice_closure Values Clauses OutputType) Neutral : stuck)
         (function_elim (enum_elim Clauses' OutputType'') Elem)
     :-
         length Values ChoiceLength,
@@ -267,24 +270,24 @@
             eval Values Elem Value,
             readback Length Value Elem'
         )) Clauses Clauses',
-        eval (neutral (local Length) :: Values) OutputType OutputType',
+        eval (stuck (local Length) :: Values) OutputType OutputType',
         plus Length 1 Length1,
         readback Length1 OutputType' OutputType'',
         readback Length Neutral Elem.
-    readback Length (format_elim Neutral : neutral) (format_elim Elem) :-
+    readback Length (format_elim Neutral : stuck) (format_elim Elem) :-
         readback Length Neutral Elem.
 
-    readback Length (neutral Neutral) Elem :-
+    readback Length (stuck Neutral) Elem :-
         readback Length Neutral Elem.
     readback Length type_type type_type.
     readback Length (function_type InputType Closure) (function_type InputType' OutputType') :-
         readback Length InputType InputType',
-        apply Closure (neutral (local Length)) OutputType,
+        apply Closure (stuck (local Length)) OutputType,
         plus Length 1 Length1,
         readback Length1 OutputType OutputType'.
     readback Length (function_intro InputType Closure) (function_intro InputType' OutputElem') :-
         readback Length InputType InputType',
-        apply Closure (neutral (local Length)) OutputElem,
+        apply Closure (stuck (local Length)) OutputElem,
         plus Length 1 Length1,
         readback Length1 OutputElem OutputElem'.
     readback Length (record_type (field_closure Values [])) (record_type []).
@@ -296,7 +299,7 @@
         readback Length Type' Type'',
         plus Length 1 Length1,
         readback Length1
-            (record_type (field_closure (neutral (local Length) :: Values) Fields))
+            (record_type (field_closure (stuck (local Length) :: Values) Fields))
             (record_type Fields').
     readback Length (record_intro ElemFields FieldClosure) (record_intro ElemFields' TypeFields) :-
         map.mapvalues (pfun Elem Elem' => readback Length Elem Elem') ElemFields ElemFields',
@@ -308,7 +311,7 @@
             eval Values Elem Value,
             readback Length Value Elem'
         )) Clauses Clauses',
-        eval (neutral (local Length) :: Values) OutputType OutputType',
+        eval (stuck (local Length) :: Values) OutputType OutputType',
         plus Length 1 Length1,
         readback Length1 OutputType' OutputType''.
     readback Length int_type int_type.
@@ -348,7 +351,7 @@
         readback Length Type' Type'',
         plus Length 1 Length1,
         readback Length1
-            (format_intro_record (field_closure (neutral (local Length) :: Values) Fields))
+            (format_intro_record (field_closure (stuck (local Length) :: Values) Fields))
             (format_intro_record Fields').
     readback Length (format_intro_compute Elem Type) (format_intro_compute Elem' Type') :-
         readback Length Elem Elem',
@@ -372,45 +375,45 @@
 
     % Equality of values
 
-    is_equal : int -> neutral -> neutral -> prop.
+    is_equal : int -> stuck -> stuck -> prop.
     is_equal : int -> value -> value -> prop.
 
-    is_equal Length (local Level : neutral) (local Level : neutral).
+    is_equal Length (local Level : stuck) (local Level : stuck).
     is_equal Length
-        (function_elim Neutral1 InputValue1 : neutral)
-        (function_elim Neutral2 InputValue2 : neutral)
+        (function_elim Neutral1 InputValue1 : stuck)
+        (function_elim Neutral2 InputValue2 : stuck)
     :-
         is_equal Length Neutral1 Neutral2,
         is_equal Length InputValue1 InputValue2.
     is_equal Length
-        (enum_elim (choice_closure Values1 Clauses1 OutputType1) Neutral1 : neutral)
-        (enum_elim (choice_closure Values2 Clauses2 OutputType1) Neutral2 : neutral)
+        (enum_elim (choice_closure Values1 Clauses1 OutputType1) Neutral1 : stuck)
+        (enum_elim (choice_closure Values2 Clauses2 OutputType1) Neutral2 : stuck)
     :-
         map.mapvalues (pfun Elem1 Elem2 => [Value1 Value2] (
             eval Values1 Elem1 Value1,
             eval Values2 Elem2 Value2,
             is_equal Length Value1 Value2
         )) Clauses1 Clauses2,
-        eval (neutral (local Length) :: Values1) OutputType1 OutputType1',
-        eval (neutral (local Length) :: Values2) OutputType2 OutputType2',
+        eval (stuck (local Length) :: Values1) OutputType1 OutputType1',
+        eval (stuck (local Length) :: Values2) OutputType2 OutputType2',
         is_equal Length OutputType1' OutputType2',
         is_equal Length Neutral1 Neutral2.
-    is_equal Length (format_elim Neutral1 : neutral) (format_elim Neutral2 : neutral) :-
+    is_equal Length (format_elim Neutral1 : stuck) (format_elim Neutral2 : stuck) :-
         is_equal Length Neutral1 Neutral2.
 
-    is_equal Length (neutral Neutral1) (neutral Neutral2) :-
+    is_equal Length (stuck Neutral1) (stuck Neutral2) :-
         is_equal Length Neutral1 Neutral2.
     is_equal Length type_type type_type.
     is_equal Length (function_type InputType1 Closure1) (function_type InputType2 Closure2) :-
         is_equal Length InputType1 InputType2,
-        apply Closure1 (neutral (local Length)) OutputType1,
-        apply Closure2 (neutral (local Length)) OutputType2,
+        apply Closure1 (stuck (local Length)) OutputType1,
+        apply Closure2 (stuck (local Length)) OutputType2,
         plus Length 1 Length1,
         is_equal Length1 OutputType1 OutputType2.
     is_equal Length (function_intro InputType1 Closure1) (function_intro InputType2 Closure2) :-
         is_equal Length InputType1 InputType2,
-        apply Closure1 (neutral (local Length)) OutputValue1,
-        apply Closure2 (neutral (local Length)) OutputValue2,
+        apply Closure1 (stuck (local Length)) OutputValue1,
+        apply Closure2 (stuck (local Length)) OutputValue2,
         plus Length 1 Length1,
         is_equal Length1 OutputValue1 OutputValue2.
     is_equal Length
@@ -426,8 +429,8 @@
         is_equal Length Type1' Type2',
         plus Length 1 Length1,
         is_equal Length1
-            (record_type (field_closure (neutral (local Length) :: Values1) Fields1))
-            (record_type (field_closure (neutral (local Length) :: Values2) Fields2)).
+            (record_type (field_closure (stuck (local Length) :: Values1) Fields1))
+            (record_type (field_closure (stuck (local Length) :: Values2) Fields2)).
     is_equal Length
         (record_intro ElemFields1 FieldClosure1)
         (record_intro ElemFields2 FieldClosure2)
@@ -448,8 +451,8 @@
             eval Values2 Elem2 Value2,
             is_equal Length Value1 Value2
         )) Clauses1 Clauses2,
-        eval (neutral (local Length) :: Values1) OutputType1 OutputType1',
-        eval (neutral (local Length) :: Values2) OutputType2 OutputType2',
+        eval (stuck (local Length) :: Values1) OutputType1 OutputType1',
+        eval (stuck (local Length) :: Values2) OutputType2 OutputType2',
         is_equal Length OutputType1' OutputType2'.
     is_equal Length int_type int_type.
     is_equal Length (int_intro Int) (int_intro Int).
@@ -492,8 +495,8 @@
         is_equal Length Type1' Type2',
         plus Length 1 Length1,
         is_equal Length1
-            (format_intro_record (field_closure (neutral (local Length) :: Values1) Fields1))
-            (format_intro_record (field_closure (neutral (local Length) :: Values2) Fields2)).
+            (format_intro_record (field_closure (stuck (local Length) :: Values1) Fields1))
+            (format_intro_record (field_closure (stuck (local Length) :: Values2) Fields2)).
     is_equal Length (format_intro_compute Elem1 Type1) (format_intro_compute Elem2 Type2) :-
         is_equal Length Elem1 Elem2,
         is_equal Length Type1 Type2.

--- a/experiments/makam-spec/src/lang/core/typing.makam
+++ b/experiments/makam-spec/src/lang/core/typing.makam
@@ -27,7 +27,7 @@
 
 
         next_local : context -> value -> prop.
-        next_local (context Entries) (neutral (local Level)) :-
+        next_local (context Entries) (stuck (local Level)) :-
             length Entries Level.
 
 

--- a/experiments/makam-spec/src/pass/surface_to_core.makam
+++ b/experiments/makam-spec/src/pass/surface_to_core.makam
@@ -31,7 +31,7 @@
 
 
         next_local : context -> value -> prop.
-        next_local (context Entries) (neutral (local Level)) :-
+        next_local (context Entries) (stuck (local Level)) :-
             length Entries Level.
 
 

--- a/experiments/makam-spec/test/lang/core/semantics.makam
+++ b/experiments/makam-spec/test/lang/core/semantics.makam
@@ -27,7 +27,7 @@
 >> Yes:
 >> Term := int_intro 1.
 
->> normalize [neutral (local 0) ] (function_elim (local 0) (int_intro 1)) Term ?
+>> normalize [stuck (local 0) ] (function_elim (local 0) (int_intro 1)) Term ?
 >> Yes:
 >> Term := function_elim (local 0) (int_intro 1).
 
@@ -105,7 +105,7 @@
 >> Yes:
 >> Term := array_intro [int_intro 1, int_intro 2] int_type.
 
->> normalize [ neutral (local 0) ] (record_elim (local 0) "data") Term ?
+>> normalize [ stuck (local 0) ] (record_elim (local 0) "data") Term ?
 >> Yes:
 >> Term := record_elim (local 0) "data".
 
@@ -168,7 +168,7 @@
 >> Term := int_intro 1.
 
 >> normalize
-    [ neutral (local 0) ]
+    [ stuck (local 0) ]
     (function_elim
         (enum_elim
             [ ( "true", int_intro 0 )
@@ -252,7 +252,7 @@
 >> Term := int_intro 30.
 
 % FIXME:
-%  >> normalize [neutral (local 0), int_intro 25, int_intro 30] (array_elim (array_intro [local 1, local 2]) (local 0)) Term ?
+%  >> normalize [stuck (local 0), int_intro 25, int_intro 30] (array_elim (array_intro [local 1, local 2]) (local 0)) Term ?
 %  >> Yes:
 %  >> Term := array_elim (array_intro [int_intro 25, int_intro 30]) (local 0).
 
@@ -317,7 +317,7 @@
 >> Yes:
 >> Term := format_intro_absorb format_intro_u8.
 
->> normalize [ neutral (local 0) ] (format_elim (local 0)) Term ?
+>> normalize [ stuck (local 0) ] (format_elim (local 0)) Term ?
 >> Yes:
 >> Term := format_elim (local 0).
 

--- a/fathom-test/src/support/mod.rs
+++ b/fathom-test/src/support/mod.rs
@@ -198,7 +198,7 @@ impl Test {
             eprintln!();
         }
 
-        if delaborated_core_module != *core_module {
+        if !is_equal_module(&delaborated_core_module, core_module) {
             let arena = pretty::Arena::new();
 
             let pretty_core_module = {
@@ -289,7 +289,7 @@ impl Test {
             eprintln!();
         }
 
-        if *core_module != parsed_core_module {
+        if !is_equal_module(core_module, &parsed_core_module) {
             self.failed_checks
                 .push("roundtrip_pretty_core: core != parse(pretty(core))");
 
@@ -566,5 +566,83 @@ fn eprintln_indented(indent: usize, prefix: &str, output: &str) {
             prefix = prefix,
             line = line,
         );
+    }
+}
+
+fn is_equal_module(
+    module0: &fathom::lang::core::Module,
+    module1: &fathom::lang::core::Module,
+) -> bool {
+    module0.doc == module1.doc
+        && module0.items.len() == module0.items.len()
+        && Iterator::zip(module0.items.iter(), module0.items.iter())
+            .all(|(item0, item1)| is_equal_item(item0, item1))
+}
+
+fn is_equal_item(item0: &fathom::lang::core::Item, item1: &fathom::lang::core::Item) -> bool {
+    use fathom::lang::core::ItemData;
+
+    match (&item0.data, &item1.data) {
+        (ItemData::Alias(alias0), ItemData::Alias(alias1)) => {
+            alias0.doc == alias1.doc
+                && alias0.name == alias1.name
+                && is_equal_term(&alias0.term, &alias1.term)
+        }
+        (ItemData::Struct(struct_ty0), ItemData::Struct(struct_ty1)) => {
+            struct_ty0.doc == struct_ty1.doc
+                && struct_ty0.name == struct_ty1.name
+                && struct_ty0.fields.len() == struct_ty1.fields.len()
+                && Iterator::zip(struct_ty0.fields.iter(), struct_ty1.fields.iter()).all(
+                    |(field0, field1)| {
+                        field0.doc == field1.doc
+                            && field0.name == field1.name
+                            && is_equal_term(&field0.term, &field1.term)
+                    },
+                )
+        }
+        (_, _) => false,
+    }
+}
+
+fn is_equal_term(term0: &fathom::lang::core::Term, term1: &fathom::lang::core::Term) -> bool {
+    use fathom::lang::core::TermData;
+
+    match (&term0.data, &term1.data) {
+        (TermData::Global(name0), TermData::Global(name1)) => name0 == name1,
+        (TermData::Item(name0), TermData::Item(name1)) => name0 == name1,
+        (TermData::Ann(term0, type0), TermData::Ann(term1, type1)) => {
+            is_equal_term(term0, term1) && is_equal_term(type0, type1)
+        }
+        (TermData::TypeType, TermData::TypeType) => true,
+        (
+            TermData::FunctionType(param_type0, body_type0),
+            TermData::FunctionType(param_type1, body_type1),
+        ) => is_equal_term(param_type0, param_type1) && is_equal_term(body_type0, body_type1),
+        (TermData::FunctionElim(head0, argument0), TermData::FunctionElim(head1, argument1)) => {
+            is_equal_term(head0, head1) && is_equal_term(argument0, argument1)
+        }
+        (TermData::Constant(constant0), TermData::Constant(constant1)) => constant0 == constant1,
+        (
+            TermData::BoolElim(head0, if_true0, if_false0),
+            TermData::BoolElim(head1, if_true1, if_false1),
+        ) => {
+            is_equal_term(head0, head1)
+                && is_equal_term(if_true0, if_true1)
+                && is_equal_term(if_false0, if_false1)
+        }
+        (
+            TermData::IntElim(head0, branches0, default0),
+            TermData::IntElim(head1, branches1, default1),
+        ) => {
+            is_equal_term(head0, head1)
+                && branches0.len() == branches1.len()
+                && Iterator::zip(branches0.iter(), branches1.iter()).all(
+                    |((int0, body0), (int1, body1))| int0 == int1 && is_equal_term(body0, body1),
+                )
+                && is_equal_term(default0, default1)
+        }
+        (TermData::FormatType, TermData::FormatType) => true,
+        (TermData::Error, TermData::Error) => true,
+        (_, _) => false,
     }
 }

--- a/fathom-test/src/support/mod.rs
+++ b/fathom-test/src/support/mod.rs
@@ -149,7 +149,7 @@ impl Test {
 
         // The core syntax from the elaborator should always be well-formed!
         let mut validation_diagnostics = Vec::new();
-        fathom::lang::core::typing::wf_module(&GLOBALS, &core_module, &mut |d| {
+        fathom::lang::core::typing::is_module(&GLOBALS, &core_module, &mut |d| {
             validation_diagnostics.push(d)
         });
         if !validation_diagnostics.is_empty() {

--- a/fathom-test/src/support/mod.rs
+++ b/fathom-test/src/support/mod.rs
@@ -428,10 +428,7 @@ impl Test {
 
     fn compile_doc(&mut self, surface_module: &fathom::lang::surface::Module) {
         let mut output = Vec::new();
-        surface_to_doc::from_module(&mut output, surface_module, &mut |d| {
-            self.found_diagnostics.push(d)
-        })
-        .unwrap();
+        surface_to_doc::from_module(&mut output, surface_module).unwrap();
 
         if let Err(error) =
             snapshot::compare(&self.snapshot_filename.with_extension("html"), &output)

--- a/fathom/src/diagnostics.rs
+++ b/fathom/src/diagnostics.rs
@@ -8,22 +8,6 @@ use std::ops::Range;
 use crate::lang::core;
 use crate::pass::{core_to_surface, surface_to_pretty};
 
-pub fn field_redeclaration(
-    severity: Severity,
-    file_id: usize,
-    name: &str,
-    found: Range<usize>,
-    original: Range<usize>,
-) -> Diagnostic<usize> {
-    Diagnostic::new(severity)
-        .with_message(format!("field `{}` is already declared", name))
-        .with_labels(vec![
-            Label::primary(file_id, found).with_message("field already declared"),
-            Label::secondary(file_id, original).with_message("previous field declaration here"),
-        ])
-        .with_notes(vec![format!("`{}` must be defined only per struct", name)])
-}
-
 pub fn item_redefinition(
     severity: Severity,
     file_id: usize,
@@ -262,6 +246,21 @@ pub mod error {
         DisplayExpected(items)
     }
 
+    pub fn field_redeclaration(
+        file_id: usize,
+        name: &str,
+        found: Range<usize>,
+        original: Range<usize>,
+    ) -> Diagnostic<usize> {
+        Diagnostic::error()
+            .with_message(format!("field `{}` is already declared", name))
+            .with_labels(vec![
+                Label::primary(file_id, found).with_message("field already declared"),
+                Label::secondary(file_id, original).with_message("previous field declaration here"),
+            ])
+            .with_notes(vec![format!("`{}` must be defined only per struct", name)])
+    }
+
     pub fn var_name_not_found(
         file_id: usize,
         name: &str,
@@ -336,6 +335,18 @@ pub mod error {
 
 pub mod bug {
     pub use super::*;
+
+    pub fn field_redeclaration(
+        file_id: usize,
+        name: &str,
+        record_range: Range<usize>,
+    ) -> Diagnostic<usize> {
+        Diagnostic::bug()
+            .with_message(format!("field `{}` is already declared", name))
+            .with_labels(vec![Label::primary(file_id, record_range)
+                .with_message(format!("field `{}` declared twice", name))])
+            .with_notes(vec![format!("`{}` must be defined only per struct", name)])
+    }
 
     pub fn not_yet_implemented(
         file_id: usize,

--- a/fathom/src/diagnostics.rs
+++ b/fathom/src/diagnostics.rs
@@ -47,26 +47,26 @@ pub fn type_mismatch(
     severity: Severity,
     file_id: usize,
     term_range: Range<usize>,
-    expected_ty: &core::semantics::Value,
-    found_ty: &core::semantics::Value,
+    expected_type: &core::semantics::Value,
+    found_type: &core::semantics::Value,
 ) -> Diagnostic<usize> {
     let arena = pretty::Arena::new();
 
-    let expected_ty = core_to_surface::from_term(&core::semantics::read_back(expected_ty));
-    let found_ty = core_to_surface::from_term(&core::semantics::read_back(found_ty));
-    let pretty::DocBuilder(_, expected_ty) = surface_to_pretty::from_term(&arena, &expected_ty);
-    let pretty::DocBuilder(_, found_ty) = surface_to_pretty::from_term(&arena, &found_ty);
-    let expected_ty = expected_ty.pretty(100);
-    let found_ty = found_ty.pretty(100);
+    let expected_type = core_to_surface::from_term(&core::semantics::read_back(expected_type));
+    let found_type = core_to_surface::from_term(&core::semantics::read_back(found_type));
+    let pretty::DocBuilder(_, expected_type) = surface_to_pretty::from_term(&arena, &expected_type);
+    let pretty::DocBuilder(_, found_type) = surface_to_pretty::from_term(&arena, &found_type);
+    let expected_type = expected_type.pretty(100);
+    let found_type = found_type.pretty(100);
 
     Diagnostic::new(severity)
         .with_message("type mismatch")
         .with_labels(vec![Label::primary(file_id, term_range).with_message(
-            format!("expected `{}`, found `{}`", expected_ty, found_ty),
+            format!("expected `{}`, found `{}`", expected_type, found_type),
         )])
         .with_notes(vec![[
-            format!("expected `{}`", expected_ty),
-            format!("   found `{}`", found_ty),
+            format!("expected `{}`", expected_type),
+            format!("   found `{}`", found_type),
         ]
         .join("\n")])
 }
@@ -75,21 +75,22 @@ pub fn universe_mismatch(
     severity: Severity,
     file_id: usize,
     term_range: Range<usize>,
-    found_ty: &core::semantics::Value,
+    found_type: &core::semantics::Value,
 ) -> Diagnostic<usize> {
     let arena = pretty::Arena::new();
 
-    let found_ty = core_to_surface::from_term(&core::semantics::read_back(found_ty));
-    let pretty::DocBuilder(_, found_ty) = surface_to_pretty::from_term(&arena, &found_ty);
-    let found_ty = found_ty.pretty(100);
+    let found_type = core_to_surface::from_term(&core::semantics::read_back(found_type));
+    let pretty::DocBuilder(_, found_type) = surface_to_pretty::from_term(&arena, &found_type);
+    let found_type = found_type.pretty(100);
 
     Diagnostic::new(severity)
         .with_message("universe mismatch")
-        .with_labels(vec![Label::primary(file_id, term_range)
-            .with_message(format!("expected a universe, found `{}`", found_ty))])
+        .with_labels(vec![Label::primary(file_id, term_range).with_message(
+            format!("expected a universe, found `{}`", found_type),
+        )])
         .with_notes(vec![[
             format!("expected a universe"),
-            format!("   found `{}`", found_ty),
+            format!("   found `{}`", found_type),
         ]
         .join("\n")])
 }
@@ -112,14 +113,14 @@ pub fn not_a_function(
     severity: Severity,
     file_id: usize,
     head: Range<usize>,
-    head_ty: &core::semantics::Value,
+    head_type: &core::semantics::Value,
     argument: Range<usize>,
 ) -> Diagnostic<usize> {
     let arena = pretty::Arena::new();
 
-    let head_ty = core_to_surface::from_term(&core::semantics::read_back(head_ty));
-    let pretty::DocBuilder(_, found_ty) = surface_to_pretty::from_term(&arena, &head_ty);
-    let head_ty = found_ty.pretty(100);
+    let head_type = core_to_surface::from_term(&core::semantics::read_back(head_type));
+    let pretty::DocBuilder(_, found_type) = surface_to_pretty::from_term(&arena, &head_type);
+    let head_type = found_type.pretty(100);
 
     Diagnostic::new(severity)
         .with_message(format!(
@@ -127,12 +128,12 @@ pub fn not_a_function(
         ))
         .with_labels(vec![
             Label::primary(file_id, head)
-                .with_message(format!("expected a function, found `{}`", head_ty)),
+                .with_message(format!("expected a function, found `{}`", head_type)),
             Label::secondary(file_id, argument).with_message("applied to this argument"),
         ])
         .with_notes(vec![[
             format!("expected a function"),
-            format!("   found `{}`", head_ty),
+            format!("   found `{}`", head_type),
         ]
         .join("\n")])
 }
@@ -277,22 +278,22 @@ pub mod error {
     pub fn numeric_literal_not_supported(
         file_id: usize,
         range: Range<usize>,
-        found_ty: &core::semantics::Value,
+        found_type: &core::semantics::Value,
     ) -> Diagnostic<usize> {
         let arena = pretty::Arena::new();
 
-        let found_ty = core_to_surface::from_term(&core::semantics::read_back(found_ty));
-        let pretty::DocBuilder(_, found_ty) = surface_to_pretty::from_term(&arena, &found_ty);
-        let found_ty = found_ty.pretty(100);
+        let found_type = core_to_surface::from_term(&core::semantics::read_back(found_type));
+        let pretty::DocBuilder(_, found_type) = surface_to_pretty::from_term(&arena, &found_type);
+        let found_type = found_type.pretty(100);
 
         Diagnostic::error()
             .with_message(format!(
                 "cannot construct a `{}` from a numeric literal",
-                found_ty,
+                found_type,
             ))
             .with_labels(vec![Label::primary(file_id, range).with_message(format!(
                 "numeric literals not supported for type `{}`",
-                found_ty,
+                found_type,
             ))])
     }
 
@@ -304,21 +305,21 @@ pub mod error {
             ])
     }
 
-    pub fn unsupported_pattern_ty(
+    pub fn unsupported_pattern_type(
         file_id: usize,
         range: Range<usize>,
-        found_ty: &core::semantics::Value,
+        found_type: &core::semantics::Value,
     ) -> Diagnostic<usize> {
         let arena = pretty::Arena::new();
 
-        let found_ty = core_to_surface::from_term(&core::semantics::read_back(found_ty));
-        let pretty::DocBuilder(_, found_ty) = surface_to_pretty::from_term(&arena, &found_ty);
-        let found_ty = found_ty.pretty(100);
+        let found_type = core_to_surface::from_term(&core::semantics::read_back(found_type));
+        let pretty::DocBuilder(_, found_type) = surface_to_pretty::from_term(&arena, &found_type);
+        let found_type = found_type.pretty(100);
 
         Diagnostic::error()
-            .with_message(format!("unsupported pattern type: `{}`", found_ty))
+            .with_message(format!("unsupported pattern type: `{}`", found_type))
             .with_labels(vec![Label::primary(file_id, range)
-                .with_message(format!("unsupported pattern type: `{}`", found_ty))])
+                .with_message(format!("unsupported pattern type: `{}`", found_type))])
             .with_notes(vec![
                 "can only currently match against terms of type `Bool` or `Int`".to_owned(),
             ])

--- a/fathom/src/lang.rs
+++ b/fathom/src/lang.rs
@@ -1,7 +1,35 @@
 //! Intermediate languages of the Fathom compiler.
 
+use std::ops::Range;
+
 pub mod surface;
 //       🠃
 pub mod core;
 //       🠃
 //      ...
+
+/// Data that covers some range of source code.
+#[derive(Debug, Clone)]
+pub struct Ranged<Data> {
+    pub range: Range<usize>,
+    pub data: Data,
+}
+
+impl<Data> Ranged<Data> {
+    pub fn new(range: Range<usize>, data: Data) -> Ranged<Data> {
+        Ranged { range, data }
+    }
+
+    pub fn range(&self) -> Range<usize> {
+        self.range.clone()
+    }
+}
+
+impl<Data> From<Data> for Ranged<Data> {
+    #![allow(clippy::reversed_empty_ranges)]
+    fn from(data: Data) -> Ranged<Data> {
+        // TODO: Use a better marker for data that does not originate from to a
+        // specific source location.
+        Ranged::new(0..0, data)
+    }
+}

--- a/fathom/src/lang/core.rs
+++ b/fathom/src/lang/core.rs
@@ -3,9 +3,9 @@
 use codespan_reporting::diagnostic::Diagnostic;
 use num_bigint::BigInt;
 use std::collections::BTreeMap;
-use std::ops::Range;
 use std::sync::Arc;
 
+use crate::lang::Ranged;
 use crate::lexer::SpannedToken;
 use crate::{diagnostics, ieee754};
 
@@ -48,45 +48,21 @@ impl Module {
     }
 }
 
-impl PartialEq for Module {
-    fn eq(&self, other: &Module) -> bool {
-        self.items == other.items
-    }
-}
+/// Items in the core language.
+pub type Item = Ranged<ItemData>;
 
 /// Items in a module.
 #[derive(Debug, Clone)]
-pub enum Item {
+pub enum ItemData {
     /// Alias definitions
     Alias(Alias),
     /// Struct definitions.
     Struct(StructType),
 }
 
-impl Item {
-    pub fn range(&self) -> Range<usize> {
-        match self {
-            Item::Struct(struct_type) => struct_type.range.clone(),
-            Item::Alias(alias) => alias.range.clone(),
-        }
-    }
-}
-
-impl PartialEq for Item {
-    fn eq(&self, other: &Item) -> bool {
-        match (self, other) {
-            (Item::Alias(alias0), Item::Alias(alias1)) => *alias0 == *alias1,
-            (Item::Struct(struct_ty0), Item::Struct(struct_ty1)) => *struct_ty0 == *struct_ty1,
-            (_, _) => false,
-        }
-    }
-}
-
 /// An alias definition.
 #[derive(Debug, Clone)]
 pub struct Alias {
-    /// The full source range of this definition.
-    pub range: Range<usize>,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// Name of this definition.
@@ -95,17 +71,9 @@ pub struct Alias {
     pub term: Arc<Term>,
 }
 
-impl PartialEq for Alias {
-    fn eq(&self, other: &Alias) -> bool {
-        self.name == other.name && self.term == other.term
-    }
-}
-
 /// A struct type definition.
 #[derive(Debug, Clone)]
 pub struct StructType {
-    /// The full source range of this definition.
-    pub range: Range<usize>,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// Name of this definition.
@@ -114,31 +82,12 @@ pub struct StructType {
     pub fields: Vec<TypeField>,
 }
 
-impl PartialEq for StructType {
-    fn eq(&self, other: &StructType) -> bool {
-        self.name == other.name && self.fields == other.fields
-    }
-}
-
 /// A field in a struct type definition.
 #[derive(Debug, Clone)]
 pub struct TypeField {
     pub doc: Arc<[String]>,
-    pub start: usize,
     pub name: String,
     pub term: Arc<Term>,
-}
-
-impl TypeField {
-    pub fn range(&self) -> Range<usize> {
-        self.start..self.term.range().end
-    }
-}
-
-impl PartialEq for TypeField {
-    fn eq(&self, other: &TypeField) -> bool {
-        self.name == other.name && self.term == other.term
-    }
 }
 
 /// Constants.
@@ -163,87 +112,35 @@ impl PartialEq for Constant {
     }
 }
 
+/// Terms in the core language.
+pub type Term = Ranged<TermData>;
+
 /// Terms.
 #[derive(Debug, Clone)]
-pub enum Term {
+pub enum TermData {
     /// Global variables.
-    Global(Range<usize>, String),
+    Global(String),
     /// Item variables.
-    Item(Range<usize>, String),
+    Item(String),
     /// Terms annotated with types.
     Ann(Arc<Term>, Arc<Term>),
     /// Type of types.
-    TypeType(Range<usize>),
+    TypeType,
     /// Function types.
     FunctionType(Arc<Term>, Arc<Term>),
     /// Function eliminations (function application).
     FunctionElim(Arc<Term>, Arc<Term>),
     /// Constants.
-    Constant(Range<usize>, Constant),
+    Constant(Constant),
     /// A boolean elimination.
-    BoolElim(Range<usize>, Arc<Term>, Arc<Term>, Arc<Term>),
+    BoolElim(Arc<Term>, Arc<Term>, Arc<Term>),
     /// A integer elimination.
-    IntElim(
-        Range<usize>,
-        Arc<Term>,
-        BTreeMap<BigInt, Arc<Term>>,
-        Arc<Term>,
-    ),
+    IntElim(Arc<Term>, BTreeMap<BigInt, Arc<Term>>, Arc<Term>),
     /// Type of format types.
-    FormatType(Range<usize>),
+    FormatType,
 
     /// Error sentinel.
-    Error(Range<usize>),
-}
-
-impl Term {
-    pub fn range(&self) -> Range<usize> {
-        match self {
-            Term::Global(range, _)
-            | Term::Item(range, _)
-            | Term::TypeType(range)
-            | Term::Constant(range, _)
-            | Term::BoolElim(range, _, _, _)
-            | Term::IntElim(range, _, _, _)
-            | Term::FormatType(range)
-            | Term::Error(range) => range.clone(),
-            Term::Ann(term, r#type) => term.range().start..r#type.range().end,
-            Term::FunctionType(param_type, body_type) => {
-                param_type.range().start..body_type.range().end
-            }
-            Term::FunctionElim(head, argument) => head.range().start..argument.range().end,
-        }
-    }
-}
-
-impl PartialEq for Term {
-    fn eq(&self, other: &Term) -> bool {
-        match (self, other) {
-            (Term::Global(_, name0), Term::Global(_, name1)) => name0 == name1,
-            (Term::Item(_, name0), Term::Item(_, name1)) => name0 == name1,
-            (Term::Ann(term0, type0), Term::Ann(term1, type1)) => term0 == term1 && type0 == type1,
-            (Term::TypeType(_), Term::TypeType(_)) => true,
-            (
-                Term::FunctionType(param_type0, body_type0),
-                Term::FunctionType(param_type1, body_type1),
-            ) => param_type0 == param_type1 && body_type0 == body_type1,
-            (Term::FunctionElim(head0, argument0), Term::FunctionElim(head1, argument1)) => {
-                head0 == head1 && argument0 == argument1
-            }
-            (Term::Constant(_, constant0), Term::Constant(_, constant1)) => constant0 == constant1,
-            (
-                Term::BoolElim(_, head0, if_true0, if_false0),
-                Term::BoolElim(_, head1, if_true1, if_false1),
-            ) => head0 == head1 && if_true0 == if_true1 && if_false0 == if_false1,
-            (
-                Term::IntElim(_, head0, branches0, default0),
-                Term::IntElim(_, head1, branches1, default1),
-            ) => head0 == head1 && branches0 == branches1 && default0 == default1,
-            (Term::FormatType(_), Term::FormatType(_)) => true,
-            (Term::Error(_), Term::Error(_)) => true,
-            (_, _) => false,
-        }
-    }
+    Error,
 }
 
 /// An environment of global definitions.
@@ -267,59 +164,61 @@ impl Globals {
 
 impl Default for Globals {
     fn default() -> Globals {
+        use self::TermData::*;
+
         let mut entries = BTreeMap::new();
 
-        entries.insert("U8".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("U16Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("U16Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("U32Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("U32Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("U64Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("U64Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("S8".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("S16Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("S16Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("S32Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("S32Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("S64Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("S64Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("F32Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("F32Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("F64Le".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
-        entries.insert("F64Be".to_owned(), (Arc::new(Term::FormatType(0..0)), None));
+        entries.insert("U8".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("U16Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("U16Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("U32Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("U32Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("U64Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("U64Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("S8".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("S16Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("S16Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("S32Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("S32Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("S64Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("S64Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("F32Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("F32Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("F64Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("F64Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
 
-        entries.insert("Int".to_owned(), (Arc::new(Term::TypeType(0..0)), None));
-        entries.insert("F32".to_owned(), (Arc::new(Term::TypeType(0..0)), None));
-        entries.insert("F64".to_owned(), (Arc::new(Term::TypeType(0..0)), None));
-        entries.insert("Bool".to_owned(), (Arc::new(Term::TypeType(0..0)), None));
+        entries.insert("Int".to_owned(), (Arc::new(Term::from(TypeType)), None));
+        entries.insert("F32".to_owned(), (Arc::new(Term::from(TypeType)), None));
+        entries.insert("F64".to_owned(), (Arc::new(Term::from(TypeType)), None));
+        entries.insert("Bool".to_owned(), (Arc::new(Term::from(TypeType)), None));
         entries.insert(
             "true".to_owned(),
-            (Arc::new(Term::Global(0..0, "Bool".to_owned())), None),
+            (Arc::new(Term::from(Global("Bool".to_owned()))), None),
         );
         entries.insert(
             "false".to_owned(),
-            (Arc::new(Term::Global(0..0, "Bool".to_owned())), None),
+            (Arc::new(Term::from(Global("Bool".to_owned()))), None),
         );
         entries.insert(
             "FormatArray".to_owned(),
             (
-                Arc::new(Term::FunctionType(
-                    Arc::new(Term::Global(0..0, "Int".to_owned())),
-                    Arc::new(Term::FunctionType(
-                        Arc::new(Term::FormatType(0..0)),
-                        Arc::new(Term::FormatType(0..0)),
-                    )),
-                )),
+                Arc::new(Term::from(FunctionType(
+                    Arc::new(Term::from(Global("Int".to_owned()))),
+                    Arc::new(Term::from(FunctionType(
+                        Arc::new(Term::from(FormatType)),
+                        Arc::new(Term::from(FormatType)),
+                    ))),
+                ))),
                 None,
             ),
         );
         entries.insert(
             "List".to_owned(),
             (
-                Arc::new(Term::FunctionType(
-                    Arc::new(Term::TypeType(0..0)),
-                    Arc::new(Term::TypeType(0..0)),
-                )),
+                Arc::new(Term::from(FunctionType(
+                    Arc::new(Term::from(TypeType)),
+                    Arc::new(Term::from(TypeType)),
+                ))),
                 None,
             ),
         );

--- a/fathom/src/lang/core.rs
+++ b/fathom/src/lang/core.rs
@@ -66,7 +66,7 @@ pub enum Item {
 impl Item {
     pub fn range(&self) -> Range<usize> {
         match self {
-            Item::Struct(struct_ty) => struct_ty.range.clone(),
+            Item::Struct(struct_type) => struct_type.range.clone(),
             Item::Alias(alias) => alias.range.clone(),
         }
     }
@@ -207,8 +207,10 @@ impl Term {
             | Term::IntElim(range, _, _, _)
             | Term::FormatType(range)
             | Term::Error(range) => range.clone(),
-            Term::Ann(term, ty) => term.range().start..ty.range().end,
-            Term::FunctionType(param_ty, body_ty) => param_ty.range().start..body_ty.range().end,
+            Term::Ann(term, r#type) => term.range().start..r#type.range().end,
+            Term::FunctionType(param_type, body_type) => {
+                param_type.range().start..body_type.range().end
+            }
             Term::FunctionElim(head, argument) => head.range().start..argument.range().end,
         }
     }
@@ -219,11 +221,12 @@ impl PartialEq for Term {
         match (self, other) {
             (Term::Global(_, name0), Term::Global(_, name1)) => name0 == name1,
             (Term::Item(_, name0), Term::Item(_, name1)) => name0 == name1,
-            (Term::Ann(term0, ty0), Term::Ann(term1, ty1)) => term0 == term1 && ty0 == ty1,
+            (Term::Ann(term0, type0), Term::Ann(term1, type1)) => term0 == term1 && type0 == type1,
             (Term::TypeType(_), Term::TypeType(_)) => true,
-            (Term::FunctionType(param_ty0, body_ty0), Term::FunctionType(param_ty1, body_ty1)) => {
-                param_ty0 == param_ty1 && body_ty0 == body_ty1
-            }
+            (
+                Term::FunctionType(param_type0, body_type0),
+                Term::FunctionType(param_type1, body_type1),
+            ) => param_type0 == param_type1 && body_type0 == body_type1,
             (Term::FunctionElim(head0, argument0), Term::FunctionElim(head1, argument1)) => {
                 head0 == head1 && argument0 == argument1
             }

--- a/fathom/src/lang/core/binary/read.rs
+++ b/fathom/src/lang/core/binary/read.rs
@@ -14,7 +14,7 @@ pub struct Context<'me> {
 }
 
 impl<'me> Context<'me> {
-    /// Create a new item context.
+    /// Create a new context.
     pub fn new(globals: &'me Globals, reader: fathom_runtime::FormatReader<'me>) -> Context<'me> {
         Context {
             globals,
@@ -23,103 +23,106 @@ impl<'me> Context<'me> {
         }
     }
 
-    /// Read some binary data in the context.
+    /// Read a module item in the context.
+    pub fn read_item(
+        &mut self,
+        module: &'me Module,
+        name: &str,
+    ) -> Result<Term, fathom_runtime::ReadError> {
+        for item in &module.items {
+            match item {
+                Item::Alias(alias) if alias.name == name => {
+                    let value = semantics::eval(self.globals, &self.items, &alias.term);
+                    return self.read_format(&value);
+                }
+                Item::Struct(struct_ty) if struct_ty.name == name => {
+                    return self.read_struct_format(struct_ty);
+                }
+                Item::Alias(alias) => {
+                    self.items.insert(&alias.name, item.clone());
+                }
+                Item::Struct(struct_ty) => {
+                    self.items.insert(&struct_ty.name, item.clone());
+                }
+            }
+        }
+
+        Err(fathom_runtime::ReadError::InvalidDataDescription)
+    }
+
     fn read<T: ReadFormat<'me>>(&mut self) -> Result<T::Host, fathom_runtime::ReadError> {
         self.reader.read::<T>()
     }
-}
 
-pub fn from_module_item<'module>(
-    context: &mut Context<'module>,
-    module: &'module Module,
-    name: &str,
-) -> Result<Term, fathom_runtime::ReadError> {
-    for item in &module.items {
-        match item {
-            Item::Alias(alias) if alias.name == name => {
-                let value = semantics::eval(context.globals, &context.items, &alias.term);
-                return from_ty(context, &value);
-            }
-            Item::Struct(struct_ty) if struct_ty.name == name => {
-                return from_struct_ty(context, struct_ty);
-            }
-            Item::Alias(alias) => {
-                context.items.insert(&alias.name, item.clone());
-            }
-            Item::Struct(struct_ty) => {
-                context.items.insert(&struct_ty.name, item.clone());
-            }
-        }
+    fn read_struct_format(
+        &mut self,
+        struct_ty: &StructType,
+    ) -> Result<Term, fathom_runtime::ReadError> {
+        let fields = struct_ty
+            .fields
+            .iter()
+            .map(|field| {
+                let value = semantics::eval(self.globals, &self.items, &field.term);
+                Ok((field.name.clone(), self.read_format(&value)?))
+            })
+            .collect::<Result<_, fathom_runtime::ReadError>>()?;
+
+        Ok(Term::Struct(fields))
     }
 
-    Err(fathom_runtime::ReadError::InvalidDataDescription)
-}
-
-pub fn from_struct_ty(
-    context: &mut Context<'_>,
-    struct_ty: &StructType,
-) -> Result<Term, fathom_runtime::ReadError> {
-    let fields = struct_ty
-        .fields
-        .iter()
-        .map(|field| {
-            let value = semantics::eval(context.globals, &context.items, &field.term);
-            Ok((field.name.clone(), from_ty(context, &value)?))
-        })
-        .collect::<Result<_, fathom_runtime::ReadError>>()?;
-
-    Ok(Term::Struct(fields))
-}
-
-pub fn from_ty(context: &mut Context<'_>, ty: &Value) -> Result<Term, fathom_runtime::ReadError> {
-    match ty {
-        Value::Neutral(Head::Global(_, name), elims) => match (name.as_str(), elims.as_slice()) {
-            ("U8", []) => Ok(Term::int(context.read::<fathom_runtime::U8>()?)),
-            ("U16Le", []) => Ok(Term::int(context.read::<fathom_runtime::U16Le>()?)),
-            ("U16Be", []) => Ok(Term::int(context.read::<fathom_runtime::U16Be>()?)),
-            ("U32Le", []) => Ok(Term::int(context.read::<fathom_runtime::U32Le>()?)),
-            ("U32Be", []) => Ok(Term::int(context.read::<fathom_runtime::U32Be>()?)),
-            ("U64Le", []) => Ok(Term::int(context.read::<fathom_runtime::U64Le>()?)),
-            ("U64Be", []) => Ok(Term::int(context.read::<fathom_runtime::U64Be>()?)),
-            ("S8", []) => Ok(Term::int(context.read::<fathom_runtime::I8>()?)),
-            ("S16Le", []) => Ok(Term::int(context.read::<fathom_runtime::I16Le>()?)),
-            ("S16Be", []) => Ok(Term::int(context.read::<fathom_runtime::I16Be>()?)),
-            ("S32Le", []) => Ok(Term::int(context.read::<fathom_runtime::I32Le>()?)),
-            ("S32Be", []) => Ok(Term::int(context.read::<fathom_runtime::I32Be>()?)),
-            ("S64Le", []) => Ok(Term::int(context.read::<fathom_runtime::I64Le>()?)),
-            ("S64Be", []) => Ok(Term::int(context.read::<fathom_runtime::I64Be>()?)),
-            ("F32Le", []) => Ok(Term::F32(context.read::<fathom_runtime::F32Le>()?)),
-            ("F32Be", []) => Ok(Term::F32(context.read::<fathom_runtime::F32Be>()?)),
-            ("F64Le", []) => Ok(Term::F64(context.read::<fathom_runtime::F64Le>()?)),
-            ("F64Be", []) => Ok(Term::F64(context.read::<fathom_runtime::F64Be>()?)),
-            ("FormatArray", [Elim::Function(_, len), Elim::Function(_, elem_ty)]) => {
-                match len.as_ref() {
-                    Value::Constant(_, Constant::Int(len)) => match len.to_usize() {
-                        Some(len) => Ok(Term::Seq(
-                            (0..len)
-                                .map(|_| from_ty(context, elem_ty))
-                                .collect::<Result<_, _>>()?,
-                        )),
-                        None => Err(fathom_runtime::ReadError::InvalidDataDescription),
-                    },
-                    _ => Err(fathom_runtime::ReadError::InvalidDataDescription),
+    fn read_format(&mut self, format: &Value) -> Result<Term, fathom_runtime::ReadError> {
+        match format {
+            Value::Neutral(Head::Global(_, name), elims) => match (name.as_str(), elims.as_slice())
+            {
+                ("U8", []) => Ok(Term::int(self.read::<fathom_runtime::U8>()?)),
+                ("U16Le", []) => Ok(Term::int(self.read::<fathom_runtime::U16Le>()?)),
+                ("U16Be", []) => Ok(Term::int(self.read::<fathom_runtime::U16Be>()?)),
+                ("U32Le", []) => Ok(Term::int(self.read::<fathom_runtime::U32Le>()?)),
+                ("U32Be", []) => Ok(Term::int(self.read::<fathom_runtime::U32Be>()?)),
+                ("U64Le", []) => Ok(Term::int(self.read::<fathom_runtime::U64Le>()?)),
+                ("U64Be", []) => Ok(Term::int(self.read::<fathom_runtime::U64Be>()?)),
+                ("S8", []) => Ok(Term::int(self.read::<fathom_runtime::I8>()?)),
+                ("S16Le", []) => Ok(Term::int(self.read::<fathom_runtime::I16Le>()?)),
+                ("S16Be", []) => Ok(Term::int(self.read::<fathom_runtime::I16Be>()?)),
+                ("S32Le", []) => Ok(Term::int(self.read::<fathom_runtime::I32Le>()?)),
+                ("S32Be", []) => Ok(Term::int(self.read::<fathom_runtime::I32Be>()?)),
+                ("S64Le", []) => Ok(Term::int(self.read::<fathom_runtime::I64Le>()?)),
+                ("S64Be", []) => Ok(Term::int(self.read::<fathom_runtime::I64Be>()?)),
+                ("F32Le", []) => Ok(Term::F32(self.read::<fathom_runtime::F32Le>()?)),
+                ("F32Be", []) => Ok(Term::F32(self.read::<fathom_runtime::F32Be>()?)),
+                ("F64Le", []) => Ok(Term::F64(self.read::<fathom_runtime::F64Le>()?)),
+                ("F64Be", []) => Ok(Term::F64(self.read::<fathom_runtime::F64Be>()?)),
+                ("FormatArray", [Elim::Function(_, len), Elim::Function(_, elem_ty)]) => {
+                    match len.as_ref() {
+                        Value::Constant(_, Constant::Int(len)) => match len.to_usize() {
+                            Some(len) => Ok(Term::Seq(
+                                (0..len)
+                                    .map(|_| self.read_format(elem_ty))
+                                    .collect::<Result<_, _>>()?,
+                            )),
+                            None => Err(fathom_runtime::ReadError::InvalidDataDescription),
+                        },
+                        _ => Err(fathom_runtime::ReadError::InvalidDataDescription),
+                    }
+                }
+                ("List", [Elim::Function(_, _)]) | (_, _) => {
+                    Err(fathom_runtime::ReadError::InvalidDataDescription)
+                }
+            },
+            Value::Neutral(Head::Item(_, name), elims) => {
+                match (self.items.get(name.as_str()).cloned(), elims.as_slice()) {
+                    (Some(Item::Struct(struct_ty)), []) => self.read_struct_format(&struct_ty),
+                    (Some(_), _) | (None, _) => {
+                        Err(fathom_runtime::ReadError::InvalidDataDescription)
+                    }
                 }
             }
-            ("List", [Elim::Function(_, _)]) | (_, _) => {
-                Err(fathom_runtime::ReadError::InvalidDataDescription)
-            }
-        },
-        Value::Neutral(Head::Item(_, name), elims) => {
-            match (context.items.get(name.as_str()).cloned(), elims.as_slice()) {
-                (Some(Item::Struct(struct_ty)), []) => from_struct_ty(context, &struct_ty),
-                (Some(_), _) | (None, _) => Err(fathom_runtime::ReadError::InvalidDataDescription),
-            }
+            Value::Neutral(Head::Error(_), _)
+            | Value::TypeType(_)
+            | Value::FunctionType(_, _)
+            | Value::Constant(_, _)
+            | Value::FormatType(_)
+            | Value::Error(_) => Err(fathom_runtime::ReadError::InvalidDataDescription),
         }
-        Value::Neutral(Head::Error(_), _)
-        | Value::TypeType(_)
-        | Value::FunctionType(_, _)
-        | Value::Constant(_, _)
-        | Value::FormatType(_)
-        | Value::Error(_) => Err(fathom_runtime::ReadError::InvalidDataDescription),
     }
 }

--- a/fathom/src/lang/core/binary/read.rs
+++ b/fathom/src/lang/core/binary/read.rs
@@ -72,8 +72,7 @@ impl<'me> Context<'me> {
 
     fn read_format(&mut self, format: &Value) -> Result<Term, fathom_runtime::ReadError> {
         match format {
-            Value::Neutral(Head::Global(_, name), elims) => match (name.as_str(), elims.as_slice())
-            {
+            Value::Stuck(Head::Global(_, name), elims) => match (name.as_str(), elims.as_slice()) {
                 ("U8", []) => Ok(Term::int(self.read::<fathom_runtime::U8>()?)),
                 ("U16Le", []) => Ok(Term::int(self.read::<fathom_runtime::U16Le>()?)),
                 ("U16Be", []) => Ok(Term::int(self.read::<fathom_runtime::U16Be>()?)),
@@ -109,7 +108,7 @@ impl<'me> Context<'me> {
                     Err(fathom_runtime::ReadError::InvalidDataDescription)
                 }
             },
-            Value::Neutral(Head::Item(_, name), elims) => {
+            Value::Stuck(Head::Item(_, name), elims) => {
                 match (self.items.get(name.as_str()).cloned(), elims.as_slice()) {
                     (Some(Item::Struct(struct_type)), []) => self.read_struct_format(&struct_type),
                     (Some(_), _) | (None, _) => {
@@ -117,7 +116,7 @@ impl<'me> Context<'me> {
                     }
                 }
             }
-            Value::Neutral(Head::Error(_), _)
+            Value::Stuck(Head::Error(_), _)
             | Value::TypeType(_)
             | Value::FunctionType(_, _)
             | Value::Constant(_, _)

--- a/fathom/src/lang/core/grammar.lalrpop
+++ b/fathom/src/lang/core/grammar.lalrpop
@@ -1,7 +1,8 @@
 use codespan_reporting::diagnostic::Diagnostic;
 use std::sync::Arc;
 
-use crate::lang::core::{Alias, Constant, Item, Module, StructType, Term, TypeField};
+use crate::lang::Ranged;
+use crate::lang::core::{Alias, Constant, ItemData, Module, StructType, Term, TermData, TypeField};
 use crate::lexer::Token;
 use crate::literal;
 
@@ -49,103 +50,104 @@ extern {
 }
 
 pub Module: Module = {
-    <doc: "inner doc comment"*>
-    <items: Item*> => {
+    <doc: "inner doc comment"*> <items: Ranged<ItemData>*> => {
         let doc = Arc::from(doc);
 
         Module { file_id, doc, items }
     },
 };
 
-Item: Item = {
-    <doc: "doc comment"*>
-    <start: @L> <name: "identifier"> "=" <term: Term> ";" <end: @R> => {
-        let range = start..end;
+ItemData: ItemData = {
+    <doc: "doc comment"*> <name: "identifier"> "=" <term: Term> ";" => {
         let doc = Arc::from(doc);
         let term = Arc::new(term);
 
-        Item::Alias(Alias { range, doc, name, term })
+        ItemData::Alias(Alias { doc, name, term })
     },
     <docs: "doc comment"*>
-    <start: @L> "struct" <name: "identifier">  "{"
+    "struct" <name: "identifier">  "{"
         <mut fields: (<Field> ",")*>
         <last: Field?>
-    "}" <end: @R> => {
-        let range = start..end;
+    "}" => {
         let doc = Arc::from(docs);
         fields.extend(last);
 
-        Item::Struct(StructType { range, doc, name, fields })
+        ItemData::Struct(StructType { doc, name, fields })
     },
 };
 
 Field: TypeField = {
-    <doc: "doc comment"*>
-    <start: @L> <name: "identifier"> ":" <term: Term> => {
+    <doc: "doc comment"*> <name: "identifier"> ":" <term: Term> => {
         let doc = Arc::from(doc);
         let term = Arc::new(term);
 
-        TypeField { doc, start, name, term }
+        TypeField { doc, name, term }
     },
 };
 
-Term: Term = {
-    ArrowTerm,
-    <term: ArrowTerm> ":" <ty: Term> => Term::Ann(Arc::new(term), Arc::new(ty)),
+#[inline] Term: Term = Ranged<TermData>;
+#[inline] ArrowTerm: Term = Ranged<ArrowTermData>;
+#[inline] AppTerm: Term = Ranged<AppTermData>;
+#[inline] AtomicTerm: Term = Ranged<AtomicTermData>;
+
+TermData: TermData = {
+    ArrowTermData,
+    <term: ArrowTerm> ":" <ty: Term> => TermData::Ann(Arc::new(term), Arc::new(ty)),
 };
 
-ArrowTerm: Term = {
-    AppTerm,
+ArrowTermData: TermData = {
+    AppTermData,
     <param_type: AppTerm> "->" <body_type: ArrowTerm> => {
-        Term::FunctionType(Arc::new(param_type), Arc::new(body_type))
+        TermData::FunctionType(Arc::new(param_type), Arc::new(body_type))
     },
 };
 
-AppTerm: Term = {
-    AtomicTerm,
+AppTermData: TermData = {
+    AtomicTermData,
     <head: AtomicTerm> <argument: AtomicTerm> => {
-        Term::FunctionElim(Arc::new(head), Arc::new(argument))
+        TermData::FunctionElim(Arc::new(head), Arc::new(argument))
     },
 };
 
-AtomicTerm: Term = {
-    "(" <term: Term> ")" => term,
-    <start: @L> "!" <end: @R> => Term::Error(start..end),
-    <start: @L> "global" <name: "identifier"> <end: @R> => Term::Global(start..end, name),
-    <start: @L> "item" <name: "identifier"> <end: @R> => Term::Item(start..end, name),
-    <start: @L> "Type" <end: @R> => Term::TypeType(start..end),
-    <start: @L> "bool_elim" <head: Term> "{" <if_true: Term> "," <if_false: Term> "}" <end: @R> => {
-        Term::BoolElim(start..end, Arc::new(head), Arc::new(if_true), Arc::new(if_false))
+AtomicTermData: TermData = {
+    "(" <term: TermData> ")" => term,
+    "!" => TermData::Error,
+    "global" <name: "identifier"> => TermData::Global(name),
+    "item" <name: "identifier"> => TermData::Item(name),
+    "Type" => TermData::TypeType,
+    "bool_elim" <head: Term> "{" <if_true: Term> "," <if_false: Term> "}" => {
+        TermData::BoolElim(Arc::new(head), Arc::new(if_true), Arc::new(if_false))
     },
-    <start: @L> "int_elim" <head: Term> "{" <branches: (<"numeric literal"> "=>" <Term> ",")*> <default: Term> "}" <end: @R> => {
+    "int_elim" <head: Term> "{" <branches: (<"numeric literal"> "=>" <Term> ",")*> <default: Term> "}" => {
         let branches = branches
             .into_iter()
             .filter_map(|(literal, term)| {
                 Some((literal.parse_big_int(file_id, report)?, Arc::new(term)))
             }).collect();
 
-        Term::IntElim(start..end, Arc::new(head), branches, Arc::new(default))
+        TermData::IntElim(Arc::new(head), branches, Arc::new(default))
     },
-    <start: @L> "int" <literal: "numeric literal"> <end: @R> => {
-        let range = start..end;
+    "int" <literal: "numeric literal"> => {
         match literal.parse_big_int(file_id, report) {
-            Some(value) => Term::Constant(range, Constant::Int(value)),
-            None => Term::Error(range),
+            Some(value) => TermData::Constant(Constant::Int(value)),
+            None => TermData::Error,
         }
     },
-    <start: @L> "f32" <literal: "numeric literal"> <end: @R> => {
-        let range = start..end;
+    "f32" <literal: "numeric literal"> => {
         match literal.parse_float(file_id, report) {
-            Some(value) => Term::Constant(range, Constant::F32(value)),
-            None => Term::Error(range),
+            Some(value) => TermData::Constant(Constant::F32(value)),
+            None => TermData::Error,
         }
     },
-    <start: @L> "f64" <literal: "numeric literal"> <end: @R> => {
-        let range = start..end;
+    "f64" <literal: "numeric literal"> => {
         match literal.parse_float(file_id, report) {
-            Some(value) => Term::Constant(range, Constant::F64(value)),
-            None => Term::Error(range),
+            Some(value) => TermData::Constant(Constant::F64(value)),
+            None => TermData::Error,
         }
     },
-    <start: @L> "Format" <end: @R> => Term::FormatType(start..end),
+    "Format" => TermData::FormatType,
+};
+
+#[inline] Ranged<T>: Ranged<T> = {
+    <start: @L> <data: T> <end: @R> => Ranged::new(start..end, data),
 };

--- a/fathom/src/lang/core/semantics.rs
+++ b/fathom/src/lang/core/semantics.rs
@@ -38,7 +38,9 @@ impl Value {
             | Value::Constant(range, _)
             | Value::FormatType(range)
             | Value::Error(range) => range.clone(),
-            Value::FunctionType(param_ty, body_ty) => param_ty.range().start..body_ty.range().end,
+            Value::FunctionType(param_type, body_type) => {
+                param_type.range().start..body_type.range().end
+            }
             Value::Neutral(head, elims) => match elims.last() {
                 Some(elim) => head.range().start..elim.range().end,
                 None => head.range(),
@@ -219,9 +221,10 @@ pub fn read_back(value: &Value) -> Term {
     match value {
         Value::Neutral(head, elims) => read_back_neutral(head, elims),
         Value::TypeType(range) => Term::TypeType(range.clone()),
-        Value::FunctionType(param_ty, body_ty) => {
-            Term::FunctionType(Arc::new(read_back(param_ty)), Arc::new(read_back(body_ty)))
-        }
+        Value::FunctionType(param_type, body_type) => Term::FunctionType(
+            Arc::new(read_back(param_type)),
+            Arc::new(read_back(body_type)),
+        ),
         Value::Constant(range, constant) => Term::Constant(range.clone(), constant.clone()),
         Value::FormatType(range) => Term::FormatType(range.clone()),
         Value::Error(range) => Term::Error(range.clone()),
@@ -235,9 +238,10 @@ pub fn equal(val1: &Value, val2: &Value) -> bool {
             read_back_neutral(head0, elims0) == read_back_neutral(head1, elims1)
         }
         (Value::TypeType(_), Value::TypeType(_)) => true,
-        (Value::FunctionType(param_ty0, body_ty0), Value::FunctionType(param_ty1, body_ty1)) => {
-            equal(param_ty1, param_ty0) && equal(body_ty0, body_ty1)
-        }
+        (
+            Value::FunctionType(param_type0, body_type0),
+            Value::FunctionType(param_type1, body_type1),
+        ) => equal(param_type1, param_type0) && equal(body_type0, body_type1),
         (Value::Constant(_, constant0), Value::Constant(_, constant1)) => constant0 == constant1,
         (Value::FormatType(_), Value::FormatType(_)) => true,
         // Errors are always treated as equal

--- a/fathom/src/lang/core/semantics.rs
+++ b/fathom/src/lang/core/semantics.rs
@@ -3,13 +3,12 @@
 use num_bigint::BigInt;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::ops::Range;
 use std::sync::Arc;
 
-use crate::lang::core::{Constant, Globals, Item, Term};
+use crate::lang::core::{Constant, Globals, Item, ItemData, Term, TermData};
 
 /// Values.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Value {
     /// A suspended elimination.
     ///
@@ -22,80 +21,46 @@ pub enum Value {
     Stuck(Head, Vec<Elim>),
 
     /// Type of types.
-    TypeType(Range<usize>),
+    TypeType,
     /// Function types.
     FunctionType(Arc<Value>, Arc<Value>),
     /// Constants.
-    Constant(Range<usize>, Constant),
+    Constant(Constant),
     /// Type of format types.
-    FormatType(Range<usize>),
+    FormatType,
 
     /// Error sentinel.
-    Error(Range<usize>),
+    Error,
 }
 
 impl Value {
     /// Create a global variable.
-    pub fn global(range: Range<usize>, name: impl Into<String>) -> Value {
-        Value::Stuck(Head::Global(range, name.into()), Vec::new())
-    }
-
-    pub fn range(&self) -> Range<usize> {
-        match self {
-            Value::TypeType(range)
-            | Value::Constant(range, _)
-            | Value::FormatType(range)
-            | Value::Error(range) => range.clone(),
-            Value::FunctionType(param_type, body_type) => {
-                param_type.range().start..body_type.range().end
-            }
-            Value::Stuck(head, elims) => match elims.last() {
-                Some(elim) => head.range().start..elim.range().end,
-                None => head.range(),
-            },
-        }
+    pub fn global(name: impl Into<String>) -> Value {
+        Value::Stuck(Head::Global(name.into()), Vec::new())
     }
 }
 
-/// The head of a neutral term.
-#[derive(Debug, Clone, PartialEq)]
+/// The head of a stuck elimination.
+#[derive(Debug, Clone)]
 pub enum Head {
     /// Global variables.
-    Global(Range<usize>, String),
+    Global(String),
     /// Item variables.
-    Item(Range<usize>, String),
+    Item(String),
     /// Errors.
-    Error(Range<usize>),
+    Error,
 }
 
-impl Head {
-    pub fn range(&self) -> Range<usize> {
-        match self {
-            Head::Global(range, _) | Head::Item(range, _) | Head::Error(range) => range.clone(),
-        }
-    }
-}
-
-/// An eliminator that is 'stuck' on some head.
-#[derive(Debug, Clone, PartialEq)]
+/// An eliminator that cannot be reduced further is 'stuck' on some [`Head`].
+#[derive(Debug, Clone)]
 pub enum Elim {
     /// Function eliminatiors (function application).
-    Function(Range<usize>, Arc<Value>),
+    Function(Arc<Value>),
     /// Boolean eliminators.
     // FIXME: environment?
-    Bool(Range<usize>, Arc<Term>, Arc<Term>),
+    Bool(Arc<Term>, Arc<Term>),
     /// Integer eliminators.
-    Int(Range<usize>, BTreeMap<BigInt, Arc<Term>>, Arc<Term>),
-}
-
-impl Elim {
-    pub fn range(&self) -> Range<usize> {
-        match self {
-            Elim::Function(range, _) | Elim::Bool(range, _, _) | Elim::Int(range, _, _) => {
-                range.clone()
-            }
-        }
-    }
+    Int(BTreeMap<BigInt, Arc<Term>>, Arc<Term>),
 }
 
 /// Evaluate a [`core::Term`] into a [`Value`].
@@ -103,94 +68,83 @@ impl Elim {
 /// [`Value`]: crate::lang::core::semantics::Value
 /// [`core::Term`]: crate::lang::core::Term
 pub fn eval(globals: &Globals, items: &HashMap<&str, Item>, term: &Term) -> Arc<Value> {
-    match term {
-        Term::Global(range, name) => match globals.get(name) {
-            None => Arc::new(Value::Error(range.clone())),
-            Some((_, term)) => match term {
-                Some(term) => eval(globals, items, term),
-                None => Arc::new(Value::Stuck(
-                    Head::Global(range.clone(), name.clone()),
-                    Vec::new(),
-                )),
+    match &term.data {
+        TermData::Global(name) => match globals.get(name) {
+            None => Arc::new(Value::Error),
+            Some((_, global_term)) => match global_term {
+                Some(global_term) => eval(globals, items, global_term),
+                None => Arc::new(Value::Stuck(Head::Global(name.clone()), Vec::new())),
             },
         },
-        Term::Item(range, name) => match items.get(name.as_str()) {
-            None => Arc::new(Value::Error(range.clone())),
-            Some(Item::Alias(alias)) => eval(globals, items, &alias.term),
-            Some(Item::Struct(_)) => Arc::new(Value::Stuck(
-                Head::Item(range.clone(), name.clone()),
-                Vec::new(),
-            )),
+        TermData::Item(name) => match items.get(name.as_str()) {
+            None => Arc::new(Value::Error),
+            Some(item) => match &item.data {
+                ItemData::Alias(alias) => eval(globals, items, &alias.term),
+                ItemData::Struct(_) => Arc::new(Value::Stuck(Head::Item(name.clone()), Vec::new())),
+            },
         },
-        Term::Ann(term, _) => eval(globals, items, term),
-        Term::TypeType(range) => Arc::new(Value::TypeType(range.clone())),
-        Term::FunctionType(param_type, body_type) => {
+        TermData::Ann(term, _) => eval(globals, items, term),
+        TermData::TypeType => Arc::new(Value::TypeType),
+        TermData::FunctionType(param_type, body_type) => {
             let param_type = eval(globals, items, param_type);
             let body_type = eval(globals, items, body_type);
 
             Arc::new(Value::FunctionType(param_type, body_type))
         }
-        Term::FunctionElim(head, argument) => match eval(globals, items, head).as_ref() {
+        TermData::FunctionElim(head, argument) => match eval(globals, items, head).as_ref() {
             Value::Stuck(head, elims) => {
                 let mut elims = elims.clone(); // FIXME: clone?
-                elims.push(Elim::Function(term.range(), eval(globals, items, argument)));
+                elims.push(Elim::Function(eval(globals, items, argument)));
                 Arc::new(Value::Stuck(head.clone(), elims))
             }
-            _ => Arc::new(Value::Error(term.range())),
+            _ => Arc::new(Value::Error),
         },
-        Term::Constant(range, constant) => {
-            Arc::new(Value::Constant(range.clone(), constant.clone()))
-        }
-        Term::BoolElim(range, head, if_true, if_false) => {
+        TermData::Constant(constant) => Arc::new(Value::Constant(constant.clone())),
+        TermData::BoolElim(head, if_true, if_false) => {
             match eval(globals, items, head).as_ref() {
-                Value::Stuck(Head::Global(head_range, name), elims) if elims.is_empty() => {
+                Value::Stuck(Head::Global(name), elims) if elims.is_empty() => {
                     match name.as_str() {
                         "true" => eval(globals, items, if_true),
                         "false" => eval(globals, items, if_false),
                         _ => {
                             let mut elims = elims.clone(); // FIXME: clone?
-                            elims.push(Elim::Bool(
-                                range.clone(),
-                                if_true.clone(),
-                                if_false.clone(),
-                            ));
-                            Arc::new(Value::Stuck(
-                                Head::Global(head_range.clone(), name.clone()),
-                                elims,
-                            ))
+                            elims.push(Elim::Bool(if_true.clone(), if_false.clone()));
+                            Arc::new(Value::Stuck(Head::Global(name.clone()), elims))
                         }
                     }
                 }
                 Value::Stuck(head, elims) => {
                     let mut elims = elims.clone(); // FIXME: clone?
-                    elims.push(Elim::Bool(range.clone(), if_true.clone(), if_false.clone()));
+                    elims.push(Elim::Bool(if_true.clone(), if_false.clone()));
                     Arc::new(Value::Stuck(head.clone(), elims))
                 }
                 _ => Arc::new(Value::Stuck(
-                    Head::Error(head.range()),
-                    vec![Elim::Bool(range.clone(), if_true.clone(), if_false.clone())],
+                    Head::Error,
+                    vec![Elim::Bool(if_true.clone(), if_false.clone())],
                 )),
             }
         }
-        Term::IntElim(range, head, branches, default) => {
+        TermData::IntElim(head, branches, default) => {
             match eval(globals, items, head).as_ref() {
-                Value::Constant(_, Constant::Int(value)) => match branches.get(&value) {
+                Value::Constant(Constant::Int(value)) => match branches.get(&value) {
                     Some(term) => eval(globals, items, term),
                     None => eval(globals, items, default),
                 },
                 Value::Stuck(head, elims) => {
                     let mut elims = elims.clone(); // FIXME: clone?
-                    elims.push(Elim::Int(range.clone(), branches.clone(), default.clone()));
+                    elims.push(Elim::Int(branches.clone(), default.clone()));
                     Arc::new(Value::Stuck(head.clone(), elims))
                 }
                 _ => Arc::new(Value::Stuck(
-                    Head::Error(head.range()),
-                    vec![Elim::Int(range.clone(), branches.clone(), default.clone())],
+                    Head::Error,
+                    vec![Elim::Int(branches.clone(), default.clone())],
                 )),
             }
         }
-        Term::FormatType(range) => Arc::new(Value::FormatType(range.clone())),
-        Term::Error(range) => Arc::new(Value::Error(range.clone())),
+
+        TermData::FormatType => Arc::new(Value::FormatType),
+
+        TermData::Error => Arc::new(Value::Error),
     }
 }
 
@@ -198,26 +152,22 @@ pub fn eval(globals: &Globals, items: &HashMap<&str, Item>, term: &Term) -> Arc<
 fn read_back_neutral(head: &Head, elims: &[Elim]) -> Term {
     elims.iter().fold(
         match head {
-            Head::Global(range, name) => Term::Global(range.clone(), name.clone()),
-            Head::Item(range, name) => Term::Item(range.clone(), name.clone()),
-            Head::Error(range) => Term::Error(range.clone()),
+            Head::Global(name) => Term::from(TermData::Global(name.clone())),
+            Head::Item(name) => Term::from(TermData::Item(name.clone())),
+            Head::Error => Term::from(TermData::Error),
         },
-        |head, elim| match elim {
-            Elim::Function(_, argument) => {
-                Term::FunctionElim(Arc::new(head), Arc::new(read_back(argument)))
-            }
-            Elim::Bool(range, if_true, if_false) => Term::BoolElim(
-                range.clone(),
-                Arc::new(head),
-                if_true.clone(),
-                if_false.clone(),
-            ),
-            Elim::Int(range, branches, default) => Term::IntElim(
-                range.clone(),
-                Arc::new(head),
-                branches.clone(),
-                default.clone(),
-            ),
+        |head, elim| {
+            Term::from(match elim {
+                Elim::Function(argument) => {
+                    TermData::FunctionElim(Arc::new(head), Arc::new(read_back(argument)))
+                }
+                Elim::Bool(if_true, if_false) => {
+                    TermData::BoolElim(Arc::new(head), if_true.clone(), if_false.clone())
+                }
+                Elim::Int(branches, default) => {
+                    TermData::IntElim(Arc::new(head), branches.clone(), default.clone())
+                }
+            })
         },
     )
 }
@@ -226,35 +176,116 @@ fn read_back_neutral(head: &Head, elims: &[Elim]) -> Term {
 pub fn read_back(value: &Value) -> Term {
     match value {
         Value::Stuck(head, elims) => read_back_neutral(head, elims),
-        Value::TypeType(range) => Term::TypeType(range.clone()),
-        Value::FunctionType(param_type, body_type) => Term::FunctionType(
+        Value::TypeType => Term::from(TermData::TypeType),
+        Value::FunctionType(param_type, body_type) => Term::from(TermData::FunctionType(
             Arc::new(read_back(param_type)),
             Arc::new(read_back(body_type)),
-        ),
-        Value::Constant(range, constant) => Term::Constant(range.clone(), constant.clone()),
-        Value::FormatType(range) => Term::FormatType(range.clone()),
-        Value::Error(range) => Term::Error(range.clone()),
+        )),
+        Value::Constant(constant) => Term::from(TermData::Constant(constant.clone())),
+        Value::FormatType => Term::from(TermData::FormatType),
+        Value::Error => Term::from(TermData::Error),
     }
+}
+
+/// Check that one [`Head`] is equal to another [`Head`].
+fn is_equal_head(head0: &Head, head1: &Head) -> bool {
+    match (head0, head1) {
+        (Head::Global(name0), Head::Global(name1)) if name0 == name1 => true,
+        (Head::Item(name0), Head::Item(name1)) if name0 == name1 => true,
+
+        // Errors are always treated as equal
+        (Head::Error, _) | (_, Head::Error) => true,
+        // Anything else is not equal!
+        (_, _) => false,
+    }
+}
+
+/// Check that one elimination spine is equal to another elimination spine.
+fn is_equal_spine(
+    globals: &Globals,
+    items: &HashMap<&str, Item>,
+    spine0: &[Elim],
+    spine1: &[Elim],
+) -> bool {
+    if spine0.len() != spine1.len() {
+        return false;
+    }
+
+    for (elim0, elim1) in Iterator::zip(spine0.iter(), spine1.iter()) {
+        match (elim0, elim1) {
+            (Elim::Function(input0), Elim::Function(input1))
+                if is_equal(globals, items, input0, input1) => {}
+            (Elim::Bool(if_true0, if_false0), Elim::Bool(if_true1, if_false1)) => {
+                let if_true0 = eval(globals, items, if_true0);
+                let if_true1 = eval(globals, items, if_true1);
+                if !is_equal(globals, items, &if_true0, &if_true1) {
+                    return false;
+                }
+
+                let if_false0 = eval(globals, items, if_false0);
+                let if_false1 = eval(globals, items, if_false1);
+                if !is_equal(globals, items, &if_false0, &if_false1) {
+                    return false;
+                }
+            }
+            (Elim::Int(branches0, default0), Elim::Int(branches1, default1)) => {
+                if branches0.len() != branches1.len() {
+                    return false;
+                }
+
+                if !Iterator::zip(branches0.iter(), branches1.iter()).all(
+                    |((int0, body0), (int1, body1))| {
+                        int0 == int1 && {
+                            let body0 = eval(globals, items, body0);
+                            let body1 = eval(globals, items, body1);
+                            is_equal(globals, items, &body0, &body1)
+                        }
+                    },
+                ) {
+                    return false;
+                }
+
+                let default0 = eval(globals, items, default0);
+                let default1 = eval(globals, items, default1);
+                if !is_equal(globals, items, &default0, &default1) {
+                    return false;
+                }
+            }
+
+            (_, _) => return false,
+        }
+    }
+
+    true
 }
 
 /// Check that one  [`Value`] is [computationally equal] to another  [`Value`].
 ///
 /// [`Value`]: crate::lang::core::semantics::Value
 /// [computationally equal]: https://ncatlab.org/nlab/show/equality#computational_equality
-pub fn is_equal(value0: &Value, value1: &Value) -> bool {
+pub fn is_equal(
+    globals: &Globals,
+    items: &HashMap<&str, Item>,
+    value0: &Value,
+    value1: &Value,
+) -> bool {
     match (value0, value1) {
-        (Value::Stuck(head0, elims0), Value::Stuck(head1, elims1)) => {
-            read_back_neutral(head0, elims0) == read_back_neutral(head1, elims1)
+        (Value::Stuck(head0, spine0), Value::Stuck(head1, spine1)) => {
+            is_equal_head(head0, head1) && is_equal_spine(globals, items, spine0, spine1)
         }
-        (Value::TypeType(_), Value::TypeType(_)) => true,
+        (Value::TypeType, Value::TypeType) => true,
         (
             Value::FunctionType(param_type0, body_type0),
             Value::FunctionType(param_type1, body_type1),
-        ) => is_equal(param_type1, param_type0) && is_equal(body_type0, body_type1),
-        (Value::Constant(_, constant0), Value::Constant(_, constant1)) => constant0 == constant1,
-        (Value::FormatType(_), Value::FormatType(_)) => true,
+        ) => {
+            is_equal(globals, items, param_type1, param_type0)
+                && is_equal(globals, items, body_type0, body_type1)
+        }
+        (Value::Constant(constant0), Value::Constant(constant1)) => constant0 == constant1,
+        (Value::FormatType, Value::FormatType) => true,
+
         // Errors are always treated as equal
-        (Value::Error(_), _) | (_, Value::Error(_)) => true,
+        (Value::Error, _) | (_, Value::Error) => true,
         // Anything else is not equal!
         (_, _) => false,
     }

--- a/fathom/src/lang/core/semantics.rs
+++ b/fathom/src/lang/core/semantics.rs
@@ -98,13 +98,11 @@ impl Elim {
     }
 }
 
-/// Evaluate a term into a semantic value.
-pub fn eval(
-    globals: &Globals,
-    items: &HashMap<&str, Item>,
-    // TODO: locals: &Locals<Arc<Value>>,
-    term: &Term,
-) -> Arc<Value> {
+/// Evaluate a [`core::Term`] into a [`Value`].
+///
+/// [`Value`]: crate::lang::core::semantics::Value
+/// [`core::Term`]: crate::lang::core::Term
+pub fn eval(globals: &Globals, items: &HashMap<&str, Item>, term: &Term) -> Arc<Value> {
     match term {
         Term::Global(range, name) => match globals.get(name) {
             None => Arc::new(Value::Error(range.clone())),
@@ -239,9 +237,12 @@ pub fn read_back(value: &Value) -> Term {
     }
 }
 
-/// Check that two values are equal.
-pub fn equal(val1: &Value, val2: &Value) -> bool {
-    match (val1, val2) {
+/// Check that one  [`Value`] is [computationally equal] to another  [`Value`].
+///
+/// [`Value`]: crate::lang::core::semantics::Value
+/// [computationally equal]: https://ncatlab.org/nlab/show/equality#computational_equality
+pub fn is_equal(value0: &Value, value1: &Value) -> bool {
+    match (value0, value1) {
         (Value::Stuck(head0, elims0), Value::Stuck(head1, elims1)) => {
             read_back_neutral(head0, elims0) == read_back_neutral(head1, elims1)
         }
@@ -249,7 +250,7 @@ pub fn equal(val1: &Value, val2: &Value) -> bool {
         (
             Value::FunctionType(param_type0, body_type0),
             Value::FunctionType(param_type1, body_type1),
-        ) => equal(param_type1, param_type0) && equal(body_type0, body_type1),
+        ) => is_equal(param_type1, param_type0) && is_equal(body_type0, body_type1),
         (Value::Constant(_, constant0), Value::Constant(_, constant1)) => constant0 == constant1,
         (Value::FormatType(_), Value::FormatType(_)) => true,
         // Errors are always treated as equal

--- a/fathom/src/lang/core/typing.rs
+++ b/fathom/src/lang/core/typing.rs
@@ -27,7 +27,7 @@ pub struct Context<'me> {
     items: HashMap<&'me str, Item>,
     /// List of types currently bound in this context. These could either
     /// refer to items or local bindings.
-    tys: Vec<(&'me str, Arc<Value>)>,
+    types: Vec<(&'me str, Arc<Value>)>,
 }
 
 impl<'me> Context<'me> {
@@ -37,14 +37,14 @@ impl<'me> Context<'me> {
             globals,
             file_id,
             items: HashMap::new(),
-            tys: Vec::new(),
+            types: Vec::new(),
         }
     }
 
     /// Lookup the type of a binding corresponding to `name` in the context,
     /// returning `None` if `name` was not yet bound.
-    pub fn lookup_ty(&self, name: &str) -> Option<&Arc<Value>> {
-        Some(&self.tys.iter().rev().find(|(n, _)| *n == name)?.1)
+    pub fn lookup_type(&self, name: &str) -> Option<&Arc<Value>> {
+        Some(&self.types.iter().rev().find(|(n, _)| *n == name)?.1)
     }
 
     /// Validate that the items are well-formed.
@@ -54,12 +54,12 @@ impl<'me> Context<'me> {
 
             match item {
                 Item::Alias(alias) => {
-                    let ty = self.synth_ty(&alias.term, report);
+                    let r#type = self.synth_type(&alias.term, report);
 
                     // FIXME: Avoid shadowing builtin definitions
                     match self.items.entry(&alias.name) {
                         Entry::Vacant(entry) => {
-                            self.tys.push((*entry.key(), ty));
+                            self.types.push((*entry.key(), r#type));
                             entry.insert(item.clone());
                         }
                         Entry::Occupied(entry) => report(diagnostics::item_redefinition(
@@ -71,21 +71,21 @@ impl<'me> Context<'me> {
                         )),
                     }
                 }
-                Item::Struct(struct_ty) => {
-                    self.is_fields(&struct_ty.fields, report);
+                Item::Struct(struct_type) => {
+                    self.is_fields(&struct_type.fields, report);
 
                     // FIXME: Avoid shadowing builtin definitions
-                    match self.items.entry(&struct_ty.name) {
+                    match self.items.entry(&struct_type.name) {
                         Entry::Vacant(entry) => {
-                            let ty = Arc::new(Value::FormatType(0..0));
-                            self.tys.push((*entry.key(), ty));
+                            let r#type = Arc::new(Value::FormatType(0..0));
+                            self.types.push((*entry.key(), r#type));
                             entry.insert(item.clone());
                         }
                         Entry::Occupied(entry) => report(diagnostics::item_redefinition(
                             Severity::Bug,
                             self.file_id,
-                            &struct_ty.name,
-                            struct_ty.range.clone(),
+                            &struct_type.name,
+                            struct_type.range.clone(),
                             entry.get().range(),
                         )),
                     }
@@ -103,8 +103,8 @@ impl<'me> Context<'me> {
         for field in fields {
             use std::collections::hash_map::Entry;
 
-            let format_ty = Arc::new(Value::FormatType(0..0));
-            self.check_ty(&field.term, &format_ty, report);
+            let format_type = Arc::new(Value::FormatType(0..0));
+            self.check_type(&field.term, &format_type, report);
 
             match seen_field_names.entry(field.name.clone()) {
                 Entry::Vacant(entry) => {
@@ -122,12 +122,12 @@ impl<'me> Context<'me> {
     }
 
     /// Validate that that a term is a well-formed type.
-    pub fn is_ty(&self, term: &Term, report: &mut dyn FnMut(Diagnostic<usize>)) -> bool {
+    pub fn is_type(&self, term: &Term, report: &mut dyn FnMut(Diagnostic<usize>)) -> bool {
         match term {
             Term::FormatType(_) | Term::TypeType(_) => true,
             term => {
-                let ty = self.synth_ty(term, report);
-                match ty.as_ref() {
+                let r#type = self.synth_type(term, report);
+                match r#type.as_ref() {
                     Value::FormatType(_) | Value::TypeType(_) => true,
                     Value::Error(_) => false,
                     _ => {
@@ -135,7 +135,7 @@ impl<'me> Context<'me> {
                             Severity::Bug,
                             self.file_id,
                             term.range(),
-                            &ty,
+                            &r#type,
                         ));
                         false
                     }
@@ -145,38 +145,38 @@ impl<'me> Context<'me> {
     }
 
     /// Validate that a term is an element of the given type.
-    pub fn check_ty(
+    pub fn check_type(
         &self,
         term: &Term,
-        expected_ty: &Arc<Value>,
+        expected_type: &Arc<Value>,
         report: &mut dyn FnMut(Diagnostic<usize>),
     ) {
-        match (term, expected_ty.as_ref()) {
+        match (term, expected_type.as_ref()) {
             (Term::Error(_), _) | (_, Value::Error(_)) => {}
             (Term::BoolElim(_, term, if_true, if_false), _) => {
-                let bool_ty = Arc::new(Value::global(0..0, "Bool"));
-                self.check_ty(term, &bool_ty, report);
-                self.check_ty(if_true, expected_ty, report);
-                self.check_ty(if_false, expected_ty, report);
+                let bool_type = Arc::new(Value::global(0..0, "Bool"));
+                self.check_type(term, &bool_type, report);
+                self.check_type(if_true, expected_type, report);
+                self.check_type(if_false, expected_type, report);
             }
             (Term::IntElim(_, head, branches, default), _) => {
-                let int_ty = Arc::new(Value::global(0..0, "Int"));
-                self.check_ty(head, &int_ty, report);
+                let int_type = Arc::new(Value::global(0..0, "Int"));
+                self.check_type(head, &int_type, report);
                 for term in branches.values() {
-                    self.check_ty(term, expected_ty, report);
+                    self.check_type(term, expected_type, report);
                 }
-                self.check_ty(default, expected_ty, report);
+                self.check_type(default, expected_type, report);
             }
-            (term, expected_ty) => {
-                let synth_ty = self.synth_ty(term, report);
+            (term, expected_type) => {
+                let synth_type = self.synth_type(term, report);
 
-                if !semantics::equal(&synth_ty, expected_ty) {
+                if !semantics::equal(&synth_type, expected_type) {
                     report(diagnostics::type_mismatch(
                         Severity::Bug,
                         self.file_id,
                         term.range(),
-                        expected_ty,
-                        &synth_ty,
+                        expected_type,
+                        &synth_type,
                     ));
                 }
             }
@@ -184,7 +184,7 @@ impl<'me> Context<'me> {
     }
 
     /// Synthesize the type of a term.
-    pub fn synth_ty(&self, term: &Term, report: &mut dyn FnMut(Diagnostic<usize>)) -> Arc<Value> {
+    pub fn synth_type(&self, term: &Term, report: &mut dyn FnMut(Diagnostic<usize>)) -> Arc<Value> {
         match term {
             Term::Global(range, name) => match self.globals.get(name) {
                 Some((r#type, _)) => semantics::eval(self.globals, &self.items, r#type),
@@ -197,8 +197,8 @@ impl<'me> Context<'me> {
                     Arc::new(Value::Error(0..0))
                 }
             },
-            Term::Item(range, name) => match self.lookup_ty(name) {
-                Some(ty) => ty.clone(),
+            Term::Item(range, name) => match self.lookup_type(name) {
+                Some(r#type) => r#type.clone(),
                 None => {
                     report(diagnostics::bug::item_name_not_found(
                         self.file_id,
@@ -208,11 +208,11 @@ impl<'me> Context<'me> {
                     Arc::new(Value::Error(0..0))
                 }
             },
-            Term::Ann(term, ty) => {
-                self.is_ty(ty, report);
-                let ty = semantics::eval(self.globals, &self.items, ty);
-                self.check_ty(term, &ty, report);
-                ty
+            Term::Ann(term, r#type) => {
+                self.is_type(r#type, report);
+                let r#type = semantics::eval(self.globals, &self.items, r#type);
+                self.check_type(term, &r#type, report);
+                r#type
             }
             Term::FormatType(range) | Term::TypeType(range) => {
                 report(diagnostics::term_has_no_type(
@@ -224,26 +224,26 @@ impl<'me> Context<'me> {
             }
             Term::FunctionType(param_type, body_type) => Arc::new(
                 match (
-                    self.is_ty(param_type, report),
-                    self.is_ty(body_type, report),
+                    self.is_type(param_type, report),
+                    self.is_type(body_type, report),
                 ) {
                     (true, true) => Value::TypeType(0..0),
                     (_, _) => Value::Error(0..0),
                 },
             ),
             Term::FunctionElim(head, argument) => {
-                match self.synth_ty(head, report).as_ref() {
+                match self.synth_type(head, report).as_ref() {
                     Value::FunctionType(param_type, body_type) => {
-                        self.check_ty(argument, &param_type, report);
+                        self.check_type(argument, &param_type, report);
                         (*body_type).clone() // FIXME: Clone
                     }
                     Value::Error(_) => Arc::new(Value::Error(0..0)),
-                    head_ty => {
+                    head_type => {
                         report(diagnostics::not_a_function(
                             Severity::Bug,
                             self.file_id,
                             head.range(),
-                            head_ty,
+                            head_type,
                             argument.range(),
                         ));
                         Arc::new(Value::Error(0..0))
@@ -258,20 +258,20 @@ impl<'me> Context<'me> {
             },
             Term::BoolElim(_, head, if_true, if_false) => {
                 // TODO: Lookup globals in environment
-                let bool_ty = Arc::new(Value::global(0..0, "Bool"));
-                self.check_ty(head, &bool_ty, report);
-                let if_true_ty = self.synth_ty(if_true, report);
-                let if_false_ty = self.synth_ty(if_false, report);
+                let bool_type = Arc::new(Value::global(0..0, "Bool"));
+                self.check_type(head, &bool_type, report);
+                let if_true_type = self.synth_type(if_true, report);
+                let if_false_type = self.synth_type(if_false, report);
 
-                if semantics::equal(&if_true_ty, &if_false_ty) {
-                    if_true_ty
+                if semantics::equal(&if_true_type, &if_false_type) {
+                    if_true_type
                 } else {
                     report(diagnostics::type_mismatch(
                         Severity::Bug,
                         self.file_id,
                         if_false.range(),
-                        &if_true_ty,
-                        &if_false_ty,
+                        &if_true_type,
+                        &if_false_type,
                     ));
                     Arc::new(Value::Error(0..0))
                 }

--- a/fathom/src/lang/core/typing.rs
+++ b/fathom/src/lang/core/typing.rs
@@ -11,6 +11,11 @@ use crate::diagnostics;
 use crate::lang::core::semantics::{self, Value};
 use crate::lang::core::{Constant, Globals, Item, Module, Term, TypeField};
 
+/// Validate that a module is well-formed.
+pub fn is_module(globals: &Globals, module: &Module, report: &mut dyn FnMut(Diagnostic<usize>)) {
+    Context::new(globals, module.file_id).is_items(&module.items, report);
+}
+
 /// Contextual information to be used during validation.
 pub struct Context<'me> {
     /// The global environment.
@@ -41,266 +46,245 @@ impl<'me> Context<'me> {
     pub fn lookup_ty(&self, name: &str) -> Option<&Arc<Value>> {
         Some(&self.tys.iter().rev().find(|(n, _)| *n == name)?.1)
     }
-}
 
-/// Validate that a module is well-formed.
-pub fn wf_module(globals: &Globals, module: &Module, report: &mut dyn FnMut(Diagnostic<usize>)) {
-    wf_items(Context::new(globals, module.file_id), &module.items, report);
-}
+    /// Validate that the items are well-formed.
+    pub fn is_items(mut self, items: &'me [Item], report: &mut dyn FnMut(Diagnostic<usize>)) {
+        for item in items {
+            use std::collections::hash_map::Entry;
 
-/// Validate that the items are well-formed.
-pub fn wf_items<'items>(
-    mut context: Context<'items>,
-    items: &'items [Item],
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) {
-    for item in items {
-        use std::collections::hash_map::Entry;
+            match item {
+                Item::Alias(alias) => {
+                    let ty = self.synth_ty(&alias.term, report);
 
-        match item {
-            Item::Alias(alias) => {
-                let ty = synth_ty(&context, &alias.term, report);
-
-                // FIXME: Avoid shadowing builtin definitions
-                match context.items.entry(&alias.name) {
-                    Entry::Vacant(entry) => {
-                        context.tys.push((*entry.key(), ty));
-                        entry.insert(item.clone());
+                    // FIXME: Avoid shadowing builtin definitions
+                    match self.items.entry(&alias.name) {
+                        Entry::Vacant(entry) => {
+                            self.tys.push((*entry.key(), ty));
+                            entry.insert(item.clone());
+                        }
+                        Entry::Occupied(entry) => report(diagnostics::item_redefinition(
+                            Severity::Bug,
+                            self.file_id,
+                            &alias.name,
+                            alias.range.clone(),
+                            entry.get().range(),
+                        )),
                     }
-                    Entry::Occupied(entry) => report(diagnostics::item_redefinition(
-                        Severity::Bug,
-                        context.file_id,
-                        &alias.name,
-                        alias.range.clone(),
-                        entry.get().range(),
-                    )),
                 }
-            }
-            Item::Struct(struct_ty) => {
-                wf_struct_ty_fields(&context, &struct_ty.fields, report);
+                Item::Struct(struct_ty) => {
+                    self.is_fields(&struct_ty.fields, report);
 
-                // FIXME: Avoid shadowing builtin definitions
-                match context.items.entry(&struct_ty.name) {
-                    Entry::Vacant(entry) => {
-                        let ty = Arc::new(Value::FormatType(0..0));
-                        context.tys.push((*entry.key(), ty));
-                        entry.insert(item.clone());
+                    // FIXME: Avoid shadowing builtin definitions
+                    match self.items.entry(&struct_ty.name) {
+                        Entry::Vacant(entry) => {
+                            let ty = Arc::new(Value::FormatType(0..0));
+                            self.tys.push((*entry.key(), ty));
+                            entry.insert(item.clone());
+                        }
+                        Entry::Occupied(entry) => report(diagnostics::item_redefinition(
+                            Severity::Bug,
+                            self.file_id,
+                            &struct_ty.name,
+                            struct_ty.range.clone(),
+                            entry.get().range(),
+                        )),
                     }
-                    Entry::Occupied(entry) => report(diagnostics::item_redefinition(
-                        Severity::Bug,
-                        context.file_id,
-                        &struct_ty.name,
-                        struct_ty.range.clone(),
-                        entry.get().range(),
-                    )),
                 }
             }
         }
     }
-}
 
-/// Validate that the structure type fields are well-formed.
-pub fn wf_struct_ty_fields(
-    context: &Context<'_>,
-    fields: &[TypeField],
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) {
-    // Field names that have previously seen, along with the source range
-    // where they were introduced (for diagnostic reporting).
-    let mut seen_field_names = HashMap::new();
+    /// Validate that the structure type fields are well-formed.
+    pub fn is_fields(&self, fields: &[TypeField], report: &mut dyn FnMut(Diagnostic<usize>)) {
+        // Field names that have previously seen, along with the source range
+        // where they were introduced (for diagnostic reporting).
+        let mut seen_field_names = HashMap::new();
 
-    for field in fields {
-        use std::collections::hash_map::Entry;
+        for field in fields {
+            use std::collections::hash_map::Entry;
 
-        let format_ty = Arc::new(Value::FormatType(0..0));
-        check_ty(&context, &field.term, &format_ty, report);
+            let format_ty = Arc::new(Value::FormatType(0..0));
+            self.check_ty(&field.term, &format_ty, report);
 
-        match seen_field_names.entry(field.name.clone()) {
-            Entry::Vacant(entry) => {
-                entry.insert(field.range());
-            }
-            Entry::Occupied(entry) => report(diagnostics::field_redeclaration(
-                Severity::Bug,
-                context.file_id,
-                &field.name,
-                field.range(),
-                entry.get().clone(),
-            )),
-        }
-    }
-}
-
-/// Validate that that a term is a well-formed type.
-pub fn wf_ty(
-    context: &Context<'_>,
-    term: &Term,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> bool {
-    match term {
-        Term::FormatType(_) | Term::TypeType(_) => true,
-        term => {
-            let ty = synth_ty(context, term, report);
-            match ty.as_ref() {
-                Value::FormatType(_) | Value::TypeType(_) => true,
-                Value::Error(_) => false,
-                _ => {
-                    report(diagnostics::universe_mismatch(
-                        Severity::Bug,
-                        context.file_id,
-                        term.range(),
-                        &ty,
-                    ));
-                    false
+            match seen_field_names.entry(field.name.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(field.range());
                 }
-            }
-        }
-    }
-}
-
-/// Validate that a term is an element of the given type.
-pub fn check_ty(
-    context: &Context<'_>,
-    term: &Term,
-    expected_ty: &Arc<Value>,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) {
-    match (term, expected_ty.as_ref()) {
-        (Term::Error(_), _) | (_, Value::Error(_)) => {}
-        (Term::BoolElim(_, term, if_true, if_false), _) => {
-            let bool_ty = Arc::new(Value::global(0..0, "Bool"));
-            check_ty(context, term, &bool_ty, report);
-            check_ty(context, if_true, expected_ty, report);
-            check_ty(context, if_false, expected_ty, report);
-        }
-        (Term::IntElim(_, head, branches, default), _) => {
-            let int_ty = Arc::new(Value::global(0..0, "Int"));
-            check_ty(context, head, &int_ty, report);
-            for term in branches.values() {
-                check_ty(context, term, expected_ty, report);
-            }
-            check_ty(context, default, expected_ty, report);
-        }
-        (term, expected_ty) => {
-            let synth_ty = synth_ty(context, term, report);
-
-            if !semantics::equal(&synth_ty, expected_ty) {
-                report(diagnostics::type_mismatch(
+                Entry::Occupied(entry) => report(diagnostics::field_redeclaration(
                     Severity::Bug,
-                    context.file_id,
-                    term.range(),
-                    expected_ty,
-                    &synth_ty,
-                ));
+                    self.file_id,
+                    &field.name,
+                    field.range(),
+                    entry.get().clone(),
+                )),
             }
         }
     }
-}
 
-/// Synthesize the type of a term.
-pub fn synth_ty(
-    context: &Context<'_>,
-    term: &Term,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> Arc<Value> {
-    match term {
-        Term::Global(range, name) => match context.globals.get(name) {
-            Some((r#type, _)) => semantics::eval(context.globals, &context.items, r#type),
-            None => {
-                report(diagnostics::bug::global_name_not_found(
-                    context.file_id,
-                    &name,
-                    range.clone(),
-                ));
-                Arc::new(Value::Error(0..0))
-            }
-        },
-        Term::Item(range, name) => match context.lookup_ty(name) {
-            Some(ty) => ty.clone(),
-            None => {
-                report(diagnostics::bug::item_name_not_found(
-                    context.file_id,
-                    &name,
-                    range.clone(),
-                ));
-                Arc::new(Value::Error(0..0))
-            }
-        },
-        Term::Ann(term, ty) => {
-            wf_ty(context, ty, report);
-            let ty = semantics::eval(context.globals, &context.items, ty);
-            check_ty(context, term, &ty, report);
-            ty
-        }
-        Term::FormatType(range) | Term::TypeType(range) => {
-            report(diagnostics::term_has_no_type(
-                Severity::Bug,
-                context.file_id,
-                range.clone(),
-            ));
-            Arc::new(Value::Error(0..0))
-        }
-        Term::FunctionType(param_type, body_type) => Arc::new(
-            match (
-                wf_ty(context, param_type, report),
-                wf_ty(context, body_type, report),
-            ) {
-                (true, true) => Value::TypeType(0..0),
-                (_, _) => Value::Error(0..0),
-            },
-        ),
-        Term::FunctionElim(head, argument) => {
-            match synth_ty(context, head, report).as_ref() {
-                Value::FunctionType(param_type, body_type) => {
-                    check_ty(context, argument, &param_type, report);
-                    (*body_type).clone() // FIXME: Clone
+    /// Validate that that a term is a well-formed type.
+    pub fn is_ty(&self, term: &Term, report: &mut dyn FnMut(Diagnostic<usize>)) -> bool {
+        match term {
+            Term::FormatType(_) | Term::TypeType(_) => true,
+            term => {
+                let ty = self.synth_ty(term, report);
+                match ty.as_ref() {
+                    Value::FormatType(_) | Value::TypeType(_) => true,
+                    Value::Error(_) => false,
+                    _ => {
+                        report(diagnostics::universe_mismatch(
+                            Severity::Bug,
+                            self.file_id,
+                            term.range(),
+                            &ty,
+                        ));
+                        false
+                    }
                 }
-                Value::Error(_) => Arc::new(Value::Error(0..0)),
-                head_ty => {
-                    report(diagnostics::not_a_function(
+            }
+        }
+    }
+
+    /// Validate that a term is an element of the given type.
+    pub fn check_ty(
+        &self,
+        term: &Term,
+        expected_ty: &Arc<Value>,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) {
+        match (term, expected_ty.as_ref()) {
+            (Term::Error(_), _) | (_, Value::Error(_)) => {}
+            (Term::BoolElim(_, term, if_true, if_false), _) => {
+                let bool_ty = Arc::new(Value::global(0..0, "Bool"));
+                self.check_ty(term, &bool_ty, report);
+                self.check_ty(if_true, expected_ty, report);
+                self.check_ty(if_false, expected_ty, report);
+            }
+            (Term::IntElim(_, head, branches, default), _) => {
+                let int_ty = Arc::new(Value::global(0..0, "Int"));
+                self.check_ty(head, &int_ty, report);
+                for term in branches.values() {
+                    self.check_ty(term, expected_ty, report);
+                }
+                self.check_ty(default, expected_ty, report);
+            }
+            (term, expected_ty) => {
+                let synth_ty = self.synth_ty(term, report);
+
+                if !semantics::equal(&synth_ty, expected_ty) {
+                    report(diagnostics::type_mismatch(
                         Severity::Bug,
-                        context.file_id,
-                        head.range(),
-                        head_ty,
-                        argument.range(),
+                        self.file_id,
+                        term.range(),
+                        expected_ty,
+                        &synth_ty,
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Synthesize the type of a term.
+    pub fn synth_ty(&self, term: &Term, report: &mut dyn FnMut(Diagnostic<usize>)) -> Arc<Value> {
+        match term {
+            Term::Global(range, name) => match self.globals.get(name) {
+                Some((r#type, _)) => semantics::eval(self.globals, &self.items, r#type),
+                None => {
+                    report(diagnostics::bug::global_name_not_found(
+                        self.file_id,
+                        &name,
+                        range.clone(),
+                    ));
+                    Arc::new(Value::Error(0..0))
+                }
+            },
+            Term::Item(range, name) => match self.lookup_ty(name) {
+                Some(ty) => ty.clone(),
+                None => {
+                    report(diagnostics::bug::item_name_not_found(
+                        self.file_id,
+                        &name,
+                        range.clone(),
+                    ));
+                    Arc::new(Value::Error(0..0))
+                }
+            },
+            Term::Ann(term, ty) => {
+                self.is_ty(ty, report);
+                let ty = semantics::eval(self.globals, &self.items, ty);
+                self.check_ty(term, &ty, report);
+                ty
+            }
+            Term::FormatType(range) | Term::TypeType(range) => {
+                report(diagnostics::term_has_no_type(
+                    Severity::Bug,
+                    self.file_id,
+                    range.clone(),
+                ));
+                Arc::new(Value::Error(0..0))
+            }
+            Term::FunctionType(param_type, body_type) => Arc::new(
+                match (
+                    self.is_ty(param_type, report),
+                    self.is_ty(body_type, report),
+                ) {
+                    (true, true) => Value::TypeType(0..0),
+                    (_, _) => Value::Error(0..0),
+                },
+            ),
+            Term::FunctionElim(head, argument) => {
+                match self.synth_ty(head, report).as_ref() {
+                    Value::FunctionType(param_type, body_type) => {
+                        self.check_ty(argument, &param_type, report);
+                        (*body_type).clone() // FIXME: Clone
+                    }
+                    Value::Error(_) => Arc::new(Value::Error(0..0)),
+                    head_ty => {
+                        report(diagnostics::not_a_function(
+                            Severity::Bug,
+                            self.file_id,
+                            head.range(),
+                            head_ty,
+                            argument.range(),
+                        ));
+                        Arc::new(Value::Error(0..0))
+                    }
+                }
+            }
+            Term::Constant(_, constant) => match constant {
+                // TODO: Lookup globals in environment
+                Constant::Int(_) => Arc::new(Value::global(0..0, "Int")),
+                Constant::F32(_) => Arc::new(Value::global(0..0, "F32")),
+                Constant::F64(_) => Arc::new(Value::global(0..0, "F64")),
+            },
+            Term::BoolElim(_, head, if_true, if_false) => {
+                // TODO: Lookup globals in environment
+                let bool_ty = Arc::new(Value::global(0..0, "Bool"));
+                self.check_ty(head, &bool_ty, report);
+                let if_true_ty = self.synth_ty(if_true, report);
+                let if_false_ty = self.synth_ty(if_false, report);
+
+                if semantics::equal(&if_true_ty, &if_false_ty) {
+                    if_true_ty
+                } else {
+                    report(diagnostics::type_mismatch(
+                        Severity::Bug,
+                        self.file_id,
+                        if_false.range(),
+                        &if_true_ty,
+                        &if_false_ty,
                     ));
                     Arc::new(Value::Error(0..0))
                 }
             }
-        }
-        Term::Constant(_, constant) => match constant {
-            // TODO: Lookup globals in environment
-            Constant::Int(_) => Arc::new(Value::global(0..0, "Int")),
-            Constant::F32(_) => Arc::new(Value::global(0..0, "F32")),
-            Constant::F64(_) => Arc::new(Value::global(0..0, "F64")),
-        },
-        Term::BoolElim(_, head, if_true, if_false) => {
-            // TODO: Lookup globals in environment
-            let bool_ty = Arc::new(Value::global(0..0, "Bool"));
-            check_ty(context, head, &bool_ty, report);
-            let if_true_ty = synth_ty(context, if_true, report);
-            let if_false_ty = synth_ty(context, if_false, report);
-
-            if semantics::equal(&if_true_ty, &if_false_ty) {
-                if_true_ty
-            } else {
-                report(diagnostics::type_mismatch(
+            Term::IntElim(range, _, _, _) => {
+                report(diagnostics::ambiguous_match_expression(
                     Severity::Bug,
-                    context.file_id,
-                    if_false.range(),
-                    &if_true_ty,
-                    &if_false_ty,
+                    self.file_id,
+                    range.clone(),
                 ));
                 Arc::new(Value::Error(0..0))
             }
+            Term::Error(_) => Arc::new(Value::Error(0..0)),
         }
-        Term::IntElim(range, _, _, _) => {
-            report(diagnostics::ambiguous_match_expression(
-                Severity::Bug,
-                context.file_id,
-                range.clone(),
-            ));
-            Arc::new(Value::Error(0..0))
-        }
-        Term::Error(_) => Arc::new(Value::Error(0..0)),
     }
 }

--- a/fathom/src/lang/surface.rs
+++ b/fathom/src/lang/surface.rs
@@ -70,7 +70,8 @@ pub struct Alias {
     /// Name of this definition.
     pub name: (Range<usize>, String),
     /// Optional type annotation
-    pub ty: Option<Term>,
+    // FIXME: can't use `r#type` in LALRPOP grammars
+    pub type_: Option<Term>,
     /// Fields in the struct.
     pub term: Term,
 }
@@ -142,7 +143,7 @@ pub enum Term {
 impl Term {
     pub fn range(&self) -> Range<usize> {
         match self {
-            Term::Ann(term, ty) => term.range().start..ty.range().end,
+            Term::Ann(term, r#type) => term.range().start..r#type.range().end,
             Term::Name(range, _)
             | Term::TypeType(range)
             | Term::NumberLiteral(range, _)
@@ -150,7 +151,9 @@ impl Term {
             | Term::Match(range, _, _)
             | Term::FormatType(range)
             | Term::Error(range) => range.clone(),
-            Term::FunctionType(param_ty, body_ty) => param_ty.range().start..body_ty.range().end,
+            Term::FunctionType(param_type, body_type) => {
+                param_type.range().start..body_type.range().end
+            }
             Term::FunctionElim(head, arguments) => match arguments.last() {
                 Some(argument) => head.range().start..argument.range().end,
                 None => head.range(),

--- a/fathom/src/lang/surface.rs
+++ b/fathom/src/lang/surface.rs
@@ -1,10 +1,10 @@
 //! The surface syntax for Fathom.
 
 use codespan_reporting::diagnostic::Diagnostic;
-use std::ops::Range;
 use std::sync::Arc;
 
 use crate::diagnostics;
+use crate::lang::Ranged;
 use crate::lexer::SpannedToken;
 use crate::literal;
 
@@ -43,9 +43,12 @@ impl Module {
     }
 }
 
+/// Items in the surface language.
+pub type Item = Ranged<ItemData>;
+
 /// Items in a module.
 #[derive(Debug, Clone)]
-pub enum Item {
+pub enum ItemData {
     /// Alias definitions.
     ///
     /// ```text
@@ -63,12 +66,10 @@ pub enum Item {
 /// Alias definition.
 #[derive(Debug, Clone)]
 pub struct Alias {
-    /// The full source range of this definition.
-    pub range: Range<usize>,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// Name of this definition.
-    pub name: (Range<usize>, String),
+    pub name: Ranged<String>,
     /// Optional type annotation
     // FIXME: can't use `r#type` in LALRPOP grammars
     pub type_: Option<Term>,
@@ -79,12 +80,10 @@ pub struct Alias {
 /// A struct type definition.
 #[derive(Debug, Clone)]
 pub struct StructType {
-    /// The full source range of this definition.
-    pub range: Range<usize>,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// Name of this definition.
-    pub name: (Range<usize>, String),
+    pub name: Ranged<String>,
     /// Fields in the struct.
     pub fields: Vec<TypeField>,
 }
@@ -93,71 +92,48 @@ pub struct StructType {
 #[derive(Debug, Clone)]
 pub struct TypeField {
     pub doc: Arc<[String]>,
-    pub name: (Range<usize>, String),
+    pub name: Ranged<String>,
     pub term: Term,
 }
 
-/// Patterns.
+/// Patterns in the surface language.
+pub type Pattern = Ranged<PatternData>;
+
+/// Pattern data.
 #[derive(Debug, Clone)]
-pub enum Pattern {
+pub enum PatternData {
     /// Named patterns.
-    Name(Range<usize>, String),
+    Name(String),
     /// Numeric literals.
-    NumberLiteral(Range<usize>, literal::Number),
+    NumberLiteral(literal::Number),
 }
 
-impl Pattern {
-    pub fn range(&self) -> Range<usize> {
-        match self {
-            Pattern::Name(range, _) | Pattern::NumberLiteral(range, _) => range.clone(),
-        }
-    }
-}
+/// Terms in the surface language.
+pub type Term = Ranged<TermData>;
 
-/// Terms.
+/// Term data.
 #[derive(Debug, Clone)]
-pub enum Term {
+pub enum TermData {
     /// Annotated terms.
     Ann(Box<Term>, Box<Term>),
     /// Names.
-    Name(Range<usize>, String),
+    Name(String),
     /// Type of types.
-    TypeType(Range<usize>),
+    TypeType,
     /// Function types.
     FunctionType(Box<Term>, Box<Term>),
     /// Function eliminations (function application).
     FunctionElim(Box<Term>, Vec<Term>),
     /// Numeric literals.
-    NumberLiteral(Range<usize>, literal::Number),
+    NumberLiteral(literal::Number),
     /// If-else expressions.
-    If(Range<usize>, Box<Term>, Box<Term>, Box<Term>),
+    If(Box<Term>, Box<Term>, Box<Term>),
     /// Match expressions.
-    Match(Range<usize>, Box<Term>, Vec<(Pattern, Term)>),
+    Match(Box<Term>, Vec<(Pattern, Term)>),
+
     /// Type of format types.
-    FormatType(Range<usize>),
+    FormatType,
 
     /// Error sentinel terms.
-    Error(Range<usize>),
-}
-
-impl Term {
-    pub fn range(&self) -> Range<usize> {
-        match self {
-            Term::Ann(term, r#type) => term.range().start..r#type.range().end,
-            Term::Name(range, _)
-            | Term::TypeType(range)
-            | Term::NumberLiteral(range, _)
-            | Term::If(range, _, _, _)
-            | Term::Match(range, _, _)
-            | Term::FormatType(range)
-            | Term::Error(range) => range.clone(),
-            Term::FunctionType(param_type, body_type) => {
-                param_type.range().start..body_type.range().end
-            }
-            Term::FunctionElim(head, arguments) => match arguments.last() {
-                Some(argument) => head.range().start..argument.range().end,
-                None => head.range(),
-            },
-        }
-    }
+    Error,
 }

--- a/fathom/src/lang/surface/grammar.lalrpop
+++ b/fathom/src/lang/surface/grammar.lalrpop
@@ -1,8 +1,8 @@
 use codespan_reporting::diagnostic::Diagnostic;
-use std::ops::Range;
 use std::sync::Arc;
 
-use crate::lang::surface::{Alias, Item, Module, Pattern, StructType, Term, TypeField};
+use crate::lang::Ranged;
+use crate::lang::surface::{Alias, ItemData, Module, Pattern, PatternData, StructType, Term, TermData, TypeField};
 use crate::lexer::Token;
 use crate::literal;
 
@@ -50,87 +50,85 @@ extern {
 }
 
 pub Module: Module = {
-    <doc: "inner doc comment"*>
-    <items: Item*> => {
+    <doc: "inner doc comment"*> <items: Ranged<ItemData>*> => {
         let doc = Arc::from(doc);
 
         Module { file_id, doc, items }
     },
 };
 
-Item: Item = {
+ItemData: ItemData = {
     <doc: "doc comment"*>
-    <start: @L> <name: Identifier> <type_: (":" <Term>)?> "=" <term: Term> ";" <end: @R> => {
-        let range = start..end;
+    <name: Ranged<"identifier">> <type_: (":" <Term>)?> "=" <term: Term> ";" => {
         let doc = Arc::from(doc);
 
-        Item::Alias(Alias { range, doc, name, type_, term })
+        ItemData::Alias(Alias { doc, name, type_, term })
     },
     <doc: "doc comment"*>
-    <start: @L> "struct" <name: Identifier> "{"
+    "struct" <name: Ranged<"identifier">> "{"
         <mut fields: (<Field> ",")*>
         <last: Field?>
-    "}" <end: @R> => {
-        let range = start..end;
+    "}" => {
         let doc = Arc::from(doc);
         fields.extend(last);
 
-        Item::Struct(StructType { range, doc, name, fields })
+        ItemData::Struct(StructType { doc, name, fields })
     },
 };
 
 Field: TypeField = {
     <docs: "doc comment"*>
-    <name: Identifier> ":" <term: Term> => {
+    <name: Ranged<"identifier">> ":" <term: Term> => {
         TypeField { doc: Arc::from(docs), name, term }
     },
 };
 
-Pattern: Pattern = {
-    <name: Identifier> => Pattern::Name(name.0, name.1),
-    <start: @L> <literal: "numeric literal"> <end: @R> => {
-        Pattern::NumberLiteral(start..end, literal)
-    },
+#[inline] Pattern: Pattern = Ranged<PatternData>;
+
+PatternData: PatternData = {
+    <name: "identifier"> => PatternData::Name(name),
+    <literal: "numeric literal"> => PatternData::NumberLiteral(literal),
 };
 
-Term: Term = {
-    ArrowTerm,
-    <term: ArrowTerm> ":" <ty: Term> => Term::Ann(Box::new(term), Box::new(ty)),
+#[inline] Term: Term = Ranged<TermData>;
+#[inline] ArrowTerm: Term = Ranged<ArrowTermData>;
+#[inline] AppTerm: Term = Ranged<AppTermData>;
+#[inline] AtomicTerm: Term = Ranged<AtomicTermData>;
+
+TermData: TermData = {
+    ArrowTermData,
+    <term: ArrowTerm> ":" <ty: Term> => TermData::Ann(Box::new(term), Box::new(ty)),
 };
 
-ArrowTerm: Term = {
-    AppTerm,
+ArrowTermData: TermData = {
+    AppTermData,
     <param_type: AppTerm> "->" <body_type: ArrowTerm> => {
-        Term::FunctionType(Box::new(param_type), Box::new(body_type))
+        TermData::FunctionType(Box::new(param_type), Box::new(body_type))
     },
 };
 
-AppTerm: Term = {
-    AtomicTerm,
+AppTermData: TermData = {
+    AtomicTermData,
     <head: AtomicTerm> <arguments: AtomicTerm+> => {
-        Term::FunctionElim(Box::new(head), arguments)
+        TermData::FunctionElim(Box::new(head), arguments)
     },
 };
 
-AtomicTerm: Term = {
-    "(" <term: Term> ")" => term,
-    <name: Identifier> => Term::Name(name.0, name.1),
-    <start: @L> "Type" <end: @R> => Term::TypeType(start..end),
-    <start: @L> <literal: "numeric literal"> <end: @R> => {
-        Term::NumberLiteral(start..end, literal)
+AtomicTermData: TermData = {
+    "(" <term: TermData> ")" => term,
+    <name: "identifier"> => TermData::Name(name),
+    "Type" => TermData::TypeType,
+    <literal: "numeric literal"> => TermData::NumberLiteral(literal),
+    "if" <head: Term> "{" <if_true: Term> "}" "else" "{" <if_false: Term> "}" => {
+        TermData::If(Box::new(head), Box::new(if_true), Box::new(if_false))
     },
-    <start: @L> "if" <head: Term> "{" <if_true: Term> "}" "else" "{" <if_false: Term> "}" <end: @R> => {
-        Term::If(start..end, Box::new(head), Box::new(if_true), Box::new(if_false))
-    },
-    <start: @L> "match" <head: Term> "{" <mut branches: (<Pattern> "=>" <Term> ",")*> <last: (<Pattern> "=>" <Term>)?>"}" <end: @R> => {
+    "match" <head: Term> "{" <mut branches: (<Pattern> "=>" <Term> ",")*> <last: (<Pattern> "=>" <Term>)?>"}" => {
         branches.extend(last);
-        Term::Match(start..end, Box::new(head), branches)
+        TermData::Match(Box::new(head), branches)
     },
-    <start: @L> "Format" <end: @R> => Term::FormatType(start..end),
+    "Format" => TermData::FormatType,
 };
 
-Identifier: (Range<usize>, String) = {
-    <start: @L> <name: "identifier"> <end: @R> => {
-        (start..end, name)
-    },
+#[inline] Ranged<T>: Ranged<T> = {
+    <start: @L> <data: T> <end: @R> => Ranged::new(start..end, data),
 };

--- a/fathom/src/lang/surface/grammar.lalrpop
+++ b/fathom/src/lang/surface/grammar.lalrpop
@@ -60,11 +60,11 @@ pub Module: Module = {
 
 Item: Item = {
     <doc: "doc comment"*>
-    <start: @L> <name: Identifier> <ty: (":" <Term>)?> "=" <term: Term> ";" <end: @R> => {
+    <start: @L> <name: Identifier> <type_: (":" <Term>)?> "=" <term: Term> ";" <end: @R> => {
         let range = start..end;
         let doc = Arc::from(doc);
 
-        Item::Alias(Alias { range, doc, name, ty, term })
+        Item::Alias(Alias { range, doc, name, type_, term })
     },
     <doc: "doc comment"*>
     <start: @L> "struct" <name: Identifier> "{"

--- a/fathom/src/lib.rs
+++ b/fathom/src/lib.rs
@@ -1,8 +1,9 @@
 #![warn(rust_2018_idioms)]
 
+pub mod lang;
+pub mod pass;
+
 pub mod diagnostics;
 mod ieee754;
-pub mod lang;
 pub mod lexer;
 pub mod literal;
-pub mod pass;

--- a/fathom/src/pass/core_to_pretty.rs
+++ b/fathom/src/pass/core_to_pretty.rs
@@ -38,7 +38,7 @@ where
 {
     match item {
         Item::Alias(alias) => from_alias(alloc, alias),
-        Item::Struct(struct_ty) => from_struct_ty(alloc, struct_ty),
+        Item::Struct(struct_type) => from_struct_type(alloc, struct_type),
     }
 }
 
@@ -69,12 +69,12 @@ where
         )
 }
 
-pub fn from_struct_ty<'a, D>(alloc: &'a D, struct_ty: &'a StructType) -> DocBuilder<'a, D>
+pub fn from_struct_type<'a, D>(alloc: &'a D, struct_type: &'a StructType) -> DocBuilder<'a, D>
 where
     D: DocAllocator<'a>,
     D::Doc: Clone,
 {
-    let docs = alloc.concat(struct_ty.doc.iter().map(|line| {
+    let docs = alloc.concat(struct_type.doc.iter().map(|line| {
         (alloc.nil())
             .append(format!("///{}", line))
             .append(alloc.hardline())
@@ -83,17 +83,17 @@ where
     let struct_prefix = (alloc.nil())
         .append("struct")
         .append(alloc.space())
-        .append(alloc.as_string(&struct_ty.name))
+        .append(alloc.as_string(&struct_type.name))
         .append(alloc.space());
 
-    let struct_ty = if struct_ty.fields.is_empty() {
+    let struct_type = if struct_type.fields.is_empty() {
         (alloc.nil()).append(struct_prefix).append("{}").group()
     } else {
         (alloc.nil())
             .append(struct_prefix)
             .append("{")
             .group()
-            .append(alloc.concat(struct_ty.fields.iter().map(|field| {
+            .append(alloc.concat(struct_type.fields.iter().map(|field| {
                 (alloc.nil())
                     .append(alloc.hardline())
                     .append(from_ty_field(alloc, field))
@@ -104,7 +104,7 @@ where
             .append("}")
     };
 
-    (alloc.nil()).append(docs).append(struct_ty)
+    (alloc.nil()).append(docs).append(struct_type)
 }
 
 pub fn from_ty_field<'a, D>(alloc: &'a D, ty_field: &'a TypeField) -> DocBuilder<'a, D>
@@ -190,7 +190,7 @@ where
             .append("item")
             .append(alloc.space())
             .append(alloc.as_string(name)),
-        Term::Ann(term, ty) => paren(
+        Term::Ann(term, r#type) => paren(
             alloc,
             prec > Prec::Term,
             (alloc.nil())
@@ -200,7 +200,7 @@ where
                 .group()
                 .append(
                     (alloc.space())
-                        .append(from_term_prec(alloc, ty, Prec::Term))
+                        .append(from_term_prec(alloc, r#type, Prec::Term))
                         .group()
                         .nest(4),
                 ),

--- a/fathom/src/pass/core_to_surface.rs
+++ b/fathom/src/pass/core_to_surface.rs
@@ -22,8 +22,8 @@ pub fn from_module(module: &core::Module) -> surface::Module {
 pub fn from_item(item: &core::Item) -> surface::Item {
     match item {
         core::Item::Alias(alias) => {
-            let (term, ty) = match alias.term.as_ref() {
-                core::Term::Ann(term, ty) => (from_term(term), Some(from_term(ty))),
+            let (term, r#type) = match alias.term.as_ref() {
+                core::Term::Ann(term, r#type) => (from_term(term), Some(from_term(r#type))),
                 term => (from_term(term), None),
             };
 
@@ -31,23 +31,23 @@ pub fn from_item(item: &core::Item) -> surface::Item {
                 range: alias.range.clone(),
                 doc: alias.doc.clone(),
                 name: (0..0, alias.name.to_string()),
-                ty,
+                type_: r#type,
                 term,
             })
         }
-        core::Item::Struct(struct_ty) => surface::Item::Struct(surface::StructType {
-            range: struct_ty.range.clone(),
-            doc: struct_ty.doc.clone(),
-            name: (0..0, struct_ty.name.to_string()),
-            fields: struct_ty
+        core::Item::Struct(struct_type) => surface::Item::Struct(surface::StructType {
+            range: struct_type.range.clone(),
+            doc: struct_type.doc.clone(),
+            name: (0..0, struct_type.name.to_string()),
+            fields: struct_type
                 .fields
                 .iter()
-                .map(|ty_field| {
+                .map(|type_field| {
                     surface::TypeField {
-                        doc: ty_field.doc.clone(),
-                        // TODO: use `ty_field.start`
-                        name: (0..0, ty_field.name.to_string()),
-                        term: from_term(&ty_field.term),
+                        doc: type_field.doc.clone(),
+                        // TODO: use `type_field.start`
+                        name: (0..0, type_field.name.to_string()),
+                        term: from_term(&type_field.term),
                     }
                 })
                 .collect(),
@@ -59,13 +59,14 @@ pub fn from_term(term: &core::Term) -> surface::Term {
     match term {
         core::Term::Global(range, name) => surface::Term::Name(range.clone(), name.to_string()),
         core::Term::Item(range, name) => surface::Term::Name(range.clone(), name.to_string()),
-        core::Term::Ann(term, ty) => {
-            surface::Term::Ann(Box::new(from_term(term)), Box::new(from_term(ty)))
+        core::Term::Ann(term, r#type) => {
+            surface::Term::Ann(Box::new(from_term(term)), Box::new(from_term(r#type)))
         }
         core::Term::TypeType(range) => surface::Term::TypeType(range.clone()),
-        core::Term::FunctionType(param_ty, body_ty) => {
-            surface::Term::FunctionType(Box::new(from_term(param_ty)), Box::new(from_term(body_ty)))
-        }
+        core::Term::FunctionType(param_type, body_type) => surface::Term::FunctionType(
+            Box::new(from_term(param_type)),
+            Box::new(from_term(body_type)),
+        ),
         core::Term::FunctionElim(head, argument) => surface::Term::FunctionElim(
             Box::new(from_term(head)),
             vec![from_term(argument)], // TODO: flatten arguments

--- a/fathom/src/pass/core_to_surface.rs
+++ b/fathom/src/pass/core_to_surface.rs
@@ -4,12 +4,13 @@
 //! The naming of this pass is not entirely standard, but was one of the better
 //! ones to emerge from [this twitter discussion](https://twitter.com/brendanzab/status/1173798146356342784).
 
-use crate::lang::{core, surface, Ranged};
+use crate::lang::core::{Constant, Item, ItemData, Module, Term, TermData};
+use crate::lang::{surface, Ranged};
 use crate::literal;
 
 // TODO: name/keyword avoidance!
 
-pub fn from_module(module: &core::Module) -> surface::Module {
+pub fn from_module(module: &Module) -> surface::Module {
     surface::Module {
         file_id: module.file_id,
         doc: module.doc.clone(),
@@ -17,11 +18,11 @@ pub fn from_module(module: &core::Module) -> surface::Module {
     }
 }
 
-pub fn from_item(item: &core::Item) -> surface::Item {
+pub fn from_item(item: &Item) -> surface::Item {
     let item_data = match &item.data {
-        core::ItemData::Alias(alias) => {
+        ItemData::Alias(alias) => {
             let (term, r#type) = match &alias.term.data {
-                core::TermData::Ann(term, r#type) => (from_term(term), Some(from_term(r#type))),
+                TermData::Ann(term, r#type) => (from_term(term), Some(from_term(r#type))),
                 _ => (from_term(&alias.term), None),
             };
 
@@ -32,7 +33,7 @@ pub fn from_item(item: &core::Item) -> surface::Item {
                 term,
             })
         }
-        core::ItemData::Struct(struct_type) => surface::ItemData::Struct(surface::StructType {
+        ItemData::Struct(struct_type) => surface::ItemData::Struct(surface::StructType {
             doc: struct_type.doc.clone(),
             name: Ranged::from(struct_type.name.clone()),
             fields: struct_type
@@ -50,48 +51,46 @@ pub fn from_item(item: &core::Item) -> surface::Item {
     surface::Item::from(item_data)
 }
 
-pub fn from_term(term: &core::Term) -> surface::Term {
+pub fn from_term(term: &Term) -> surface::Term {
     let term_data = match &term.data {
-        core::TermData::Global(name) => surface::TermData::Name(name.to_string()),
-        core::TermData::Item(name) => surface::TermData::Name(name.to_string()),
-        core::TermData::Ann(term, r#type) => {
+        TermData::Global(name) => surface::TermData::Name(name.to_string()),
+        TermData::Item(name) => surface::TermData::Name(name.to_string()),
+        TermData::Ann(term, r#type) => {
             surface::TermData::Ann(Box::new(from_term(term)), Box::new(from_term(r#type)))
         }
-        core::TermData::TypeType => surface::TermData::TypeType,
-        core::TermData::FunctionType(param_type, body_type) => surface::TermData::FunctionType(
+        TermData::TypeType => surface::TermData::TypeType,
+        TermData::FunctionType(param_type, body_type) => surface::TermData::FunctionType(
             Box::new(from_term(param_type)),
             Box::new(from_term(body_type)),
         ),
-        core::TermData::FunctionElim(head, argument) => surface::TermData::FunctionElim(
+        TermData::FunctionElim(head, argument) => surface::TermData::FunctionElim(
             Box::new(from_term(head)),
             vec![from_term(argument)], // TODO: flatten arguments
         ),
-        core::TermData::Constant(constant) => match constant {
-            core::Constant::Int(value) => {
+        TermData::Constant(constant) => match constant {
+            Constant::Int(value) => {
                 surface::TermData::NumberLiteral(literal::Number::from_signed(term.range(), value))
             }
-            core::Constant::F32(value) => {
+            Constant::F32(value) => {
                 surface::TermData::NumberLiteral(literal::Number::from_signed(term.range(), value))
             }
-            core::Constant::F64(value) => {
+            Constant::F64(value) => {
                 surface::TermData::NumberLiteral(literal::Number::from_signed(term.range(), value))
             }
         },
-        core::TermData::BoolElim(head, if_true, if_false) => surface::TermData::If(
+        TermData::BoolElim(head, if_true, if_false) => surface::TermData::If(
             Box::new(from_term(head)),
             Box::new(from_term(if_true)),
             Box::new(from_term(if_false)),
         ),
-        core::TermData::IntElim(head, branches, default) => surface::TermData::Match(
+        TermData::IntElim(head, branches, default) => surface::TermData::Match(
             Box::new(from_term(head)),
             branches
                 .iter()
                 .map(|(value, term)| {
                     let value = literal::Number::from_signed(0..0, value);
-                    (
-                        surface::Pattern::from(surface::PatternData::NumberLiteral(value)),
-                        from_term(term),
-                    )
+                    let pattern_data = surface::PatternData::NumberLiteral(value);
+                    (surface::Pattern::from(pattern_data), from_term(term))
                 })
                 .chain(std::iter::once((
                     surface::Pattern::from(surface::PatternData::Name("_".to_owned())),
@@ -99,9 +98,9 @@ pub fn from_term(term: &core::Term) -> surface::Term {
                 )))
                 .collect(),
         ),
-        core::TermData::FormatType => surface::TermData::FormatType,
+        TermData::FormatType => surface::TermData::FormatType,
 
-        core::TermData::Error => surface::TermData::Error,
+        TermData::Error => surface::TermData::Error,
     };
 
     surface::Term::from(term_data)

--- a/fathom/src/pass/core_to_surface.rs
+++ b/fathom/src/pass/core_to_surface.rs
@@ -4,9 +4,7 @@
 //! The naming of this pass is not entirely standard, but was one of the better
 //! ones to emerge from [this twitter discussion](https://twitter.com/brendanzab/status/1173798146356342784).
 
-use std::ops::Range;
-
-use crate::lang::{core, surface};
+use crate::lang::{core, surface, Ranged};
 use crate::literal;
 
 // TODO: name/keyword avoidance!
@@ -20,97 +18,91 @@ pub fn from_module(module: &core::Module) -> surface::Module {
 }
 
 pub fn from_item(item: &core::Item) -> surface::Item {
-    match item {
-        core::Item::Alias(alias) => {
-            let (term, r#type) = match alias.term.as_ref() {
-                core::Term::Ann(term, r#type) => (from_term(term), Some(from_term(r#type))),
-                term => (from_term(term), None),
+    let item_data = match &item.data {
+        core::ItemData::Alias(alias) => {
+            let (term, r#type) = match &alias.term.data {
+                core::TermData::Ann(term, r#type) => (from_term(term), Some(from_term(r#type))),
+                _ => (from_term(&alias.term), None),
             };
 
-            surface::Item::Alias(surface::Alias {
-                range: alias.range.clone(),
+            surface::ItemData::Alias(surface::Alias {
                 doc: alias.doc.clone(),
-                name: (0..0, alias.name.to_string()),
+                name: Ranged::from(alias.name.clone()),
                 type_: r#type,
                 term,
             })
         }
-        core::Item::Struct(struct_type) => surface::Item::Struct(surface::StructType {
-            range: struct_type.range.clone(),
+        core::ItemData::Struct(struct_type) => surface::ItemData::Struct(surface::StructType {
             doc: struct_type.doc.clone(),
-            name: (0..0, struct_type.name.to_string()),
+            name: Ranged::from(struct_type.name.clone()),
             fields: struct_type
                 .fields
                 .iter()
-                .map(|type_field| {
-                    surface::TypeField {
-                        doc: type_field.doc.clone(),
-                        // TODO: use `type_field.start`
-                        name: (0..0, type_field.name.to_string()),
-                        term: from_term(&type_field.term),
-                    }
+                .map(|type_field| surface::TypeField {
+                    doc: type_field.doc.clone(),
+                    name: Ranged::from(type_field.name.clone()),
+                    term: from_term(&type_field.term),
                 })
                 .collect(),
         }),
-    }
+    };
+
+    surface::Item::from(item_data)
 }
 
 pub fn from_term(term: &core::Term) -> surface::Term {
-    match term {
-        core::Term::Global(range, name) => surface::Term::Name(range.clone(), name.to_string()),
-        core::Term::Item(range, name) => surface::Term::Name(range.clone(), name.to_string()),
-        core::Term::Ann(term, r#type) => {
-            surface::Term::Ann(Box::new(from_term(term)), Box::new(from_term(r#type)))
+    let term_data = match &term.data {
+        core::TermData::Global(name) => surface::TermData::Name(name.to_string()),
+        core::TermData::Item(name) => surface::TermData::Name(name.to_string()),
+        core::TermData::Ann(term, r#type) => {
+            surface::TermData::Ann(Box::new(from_term(term)), Box::new(from_term(r#type)))
         }
-        core::Term::TypeType(range) => surface::Term::TypeType(range.clone()),
-        core::Term::FunctionType(param_type, body_type) => surface::Term::FunctionType(
+        core::TermData::TypeType => surface::TermData::TypeType,
+        core::TermData::FunctionType(param_type, body_type) => surface::TermData::FunctionType(
             Box::new(from_term(param_type)),
             Box::new(from_term(body_type)),
         ),
-        core::Term::FunctionElim(head, argument) => surface::Term::FunctionElim(
+        core::TermData::FunctionElim(head, argument) => surface::TermData::FunctionElim(
             Box::new(from_term(head)),
             vec![from_term(argument)], // TODO: flatten arguments
         ),
-        core::Term::Constant(range, constant) => from_constant(range.clone(), constant),
-        core::Term::BoolElim(range, head, if_true, if_false) => surface::Term::If(
-            range.clone(),
+        core::TermData::Constant(constant) => match constant {
+            core::Constant::Int(value) => {
+                surface::TermData::NumberLiteral(literal::Number::from_signed(term.range(), value))
+            }
+            core::Constant::F32(value) => {
+                surface::TermData::NumberLiteral(literal::Number::from_signed(term.range(), value))
+            }
+            core::Constant::F64(value) => {
+                surface::TermData::NumberLiteral(literal::Number::from_signed(term.range(), value))
+            }
+        },
+        core::TermData::BoolElim(head, if_true, if_false) => surface::TermData::If(
             Box::new(from_term(head)),
             Box::new(from_term(if_true)),
             Box::new(from_term(if_false)),
         ),
-        core::Term::IntElim(range, head, branches, default) => surface::Term::Match(
-            range.clone(),
+        core::TermData::IntElim(head, branches, default) => surface::TermData::Match(
             Box::new(from_term(head)),
             branches
                 .iter()
                 .map(|(value, term)| {
                     let value = literal::Number::from_signed(0..0, value);
                     (
-                        surface::Pattern::NumberLiteral(0..0, value),
+                        surface::Pattern::from(surface::PatternData::NumberLiteral(value)),
                         from_term(term),
                     )
                 })
                 .chain(std::iter::once((
-                    surface::Pattern::Name(0..0, "_".to_owned()),
+                    surface::Pattern::from(surface::PatternData::Name("_".to_owned())),
                     from_term(default),
                 )))
                 .collect(),
         ),
-        core::Term::FormatType(range) => surface::Term::FormatType(range.clone()),
-        core::Term::Error(range) => surface::Term::Error(range.clone()),
-    }
-}
+        core::TermData::FormatType => surface::TermData::FormatType,
 
-pub fn from_constant(range: Range<usize>, constant: &core::Constant) -> surface::Term {
-    match constant {
-        core::Constant::Int(value) => {
-            surface::Term::NumberLiteral(range.clone(), literal::Number::from_signed(range, value))
-        }
-        core::Constant::F32(value) => {
-            surface::Term::NumberLiteral(range.clone(), literal::Number::from_signed(range, value))
-        }
-        core::Constant::F64(value) => {
-            surface::Term::NumberLiteral(range.clone(), literal::Number::from_signed(range, value))
-        }
-    }
+        core::TermData::Error => surface::TermData::Error,
+    };
+
+    surface::Term::from(term_data)
 }

--- a/fathom/src/pass/surface_to_core.rs
+++ b/fathom/src/pass/surface_to_core.rs
@@ -313,17 +313,12 @@ impl<'me> Context<'me> {
                         // TODO: Lookup globals in environment
                         match name.as_str() {
                             "Bool" => {
-                                let (if_true, if_false) = self.from_bool_branches(
-                                    surface_branches,
-                                    expected_type,
-                                    report,
-                                );
-                                core::Term::BoolElim(
+                                report(diagnostics::bug::not_yet_implemented(
+                                    self.file_id,
                                     range.clone(),
-                                    Arc::new(head),
-                                    if_true,
-                                    if_false,
-                                )
+                                    "boolean patterns",
+                                ));
+                                core::Term::Error(range.clone())
                             }
                             "Int" => {
                                 let (branches, default) = self.from_int_branches(
@@ -520,16 +515,6 @@ impl<'me> Context<'me> {
                 Arc::new(Value::Error(0..0)),
             ),
         }
-    }
-
-    #[allow(unused_variables)]
-    fn from_bool_branches(
-        &self,
-        surface_branches: &[(surface::Pattern, surface::Term)],
-        expected_type: &Value,
-        report: &mut dyn FnMut(Diagnostic<usize>),
-    ) -> (Arc<core::Term>, Arc<core::Term>) {
-        unimplemented!("boolean eliminators")
     }
 
     fn from_int_branches(

--- a/fathom/src/pass/surface_to_core.rs
+++ b/fathom/src/pass/surface_to_core.rs
@@ -246,7 +246,7 @@ impl<'me> Context<'me> {
                 };
                 match expected_type.as_ref() {
                     // TODO: Lookup globals in environment
-                    Value::Neutral(Head::Global(_, name), elims) if elims.is_empty() => {
+                    Value::Stuck(Head::Global(_, name), elims) if elims.is_empty() => {
                         match name.as_str() {
                             "Int" => match literal.parse_big_int(self.file_id, report) {
                                 Some(value) => core::Term::Constant(range.clone(), Int(value)),
@@ -292,7 +292,7 @@ impl<'me> Context<'me> {
                 };
 
                 match head_type.as_ref() {
-                    Value::Neutral(Head::Global(_, name), elims) if elims.is_empty() => {
+                    Value::Stuck(Head::Global(_, name), elims) if elims.is_empty() => {
                         // TODO: Lookup globals in environment
                         match name.as_str() {
                             "Bool" => {

--- a/fathom/src/pass/surface_to_core.rs
+++ b/fathom/src/pass/surface_to_core.rs
@@ -19,6 +19,21 @@ use crate::diagnostics;
 use crate::lang::core::semantics::{self, Head, Value};
 use crate::lang::{core, surface};
 
+/// Translate a surface module into a core module, while validating that it is
+/// well-formed.
+pub fn from_module(
+    globals: &core::Globals,
+    surface_module: &surface::Module,
+    report: &mut dyn FnMut(Diagnostic<usize>),
+) -> core::Module {
+    core::Module {
+        file_id: surface_module.file_id,
+        doc: surface_module.doc.clone(),
+        items: Context::new(globals, surface_module.file_id)
+            .from_items(&surface_module.items, report),
+    }
+}
+
 /// Contextual information to be used during elaboration.
 pub struct Context<'me> {
     /// The global environment.
@@ -49,515 +64,502 @@ impl<'me> Context<'me> {
     pub fn lookup_ty(&self, name: &str) -> Option<&Arc<Value>> {
         Some(&self.tys.iter().rev().find(|(n, _)| *n == name)?.1)
     }
-}
 
-/// Translate a surface module into a core module, while validating that it is
-/// well-formed.
-pub fn from_module(
-    globals: &core::Globals,
-    surface_module: &surface::Module,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> core::Module {
-    let item_context = Context::new(globals, surface_module.file_id);
-    core::Module {
-        file_id: surface_module.file_id,
-        doc: surface_module.doc.clone(),
-        items: from_items(item_context, &surface_module.items, report),
-    }
-}
+    /// Translate surface items into core items, while validating that they are
+    /// well-formed.
+    pub fn from_items(
+        mut self,
+        surface_items: &'me [surface::Item],
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> Vec<core::Item> {
+        let mut core_items = Vec::new();
 
-/// Translate surface items into core items, while validating that they are
-/// well-formed.
-pub fn from_items<'items>(
-    mut context: Context<'items>,
-    surface_items: &'items [surface::Item],
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> Vec<core::Item> {
-    let mut core_items = Vec::new();
+        for item in surface_items.iter() {
+            use std::collections::hash_map::Entry;
 
-    for item in surface_items.iter() {
-        use std::collections::hash_map::Entry;
+            match item {
+                surface::Item::Alias(alias) => {
+                    let (core_term, ty) = match &alias.ty {
+                        Some(surface_ty) => {
+                            let core_ty = self.from_term_to_ty(surface_ty, report);
+                            let ty = semantics::eval(self.globals, &self.items, &core_ty);
+                            let core_term = self.from_term_check_ty(&alias.term, &ty, report);
+                            (core::Term::Ann(Arc::new(core_term), Arc::new(core_ty)), ty)
+                        }
+                        None => self.from_term_synth_ty(&alias.term, report),
+                    };
 
-        match item {
-            surface::Item::Alias(alias) => {
-                let (core_term, ty) = match &alias.ty {
-                    Some(surface_ty) => {
-                        let core_ty = from_term_to_ty(&context, surface_ty, report);
-                        let ty = semantics::eval(context.globals, &context.items, &core_ty);
-                        let core_term = from_term_check_ty(&context, &alias.term, &ty, report);
-                        (core::Term::Ann(Arc::new(core_term), Arc::new(core_ty)), ty)
+                    // FIXME: Avoid shadowing builtin definitions
+                    match self.items.entry(&alias.name.1) {
+                        Entry::Vacant(entry) => {
+                            let item = core::Alias {
+                                range: alias.range.clone(),
+                                doc: alias.doc.clone(),
+                                name: entry.key().to_string(),
+                                term: Arc::new(core_term),
+                            };
+
+                            let core_item = core::Item::Alias(item);
+                            core_items.push(core_item.clone());
+                            self.tys.push((*entry.key(), ty));
+                            entry.insert(core_item);
+                        }
+                        Entry::Occupied(entry) => report(diagnostics::item_redefinition(
+                            Severity::Error,
+                            self.file_id,
+                            entry.key(),
+                            alias.range.clone(),
+                            entry.get().range(),
+                        )),
                     }
-                    None => from_term_synth_ty(&context, &alias.term, report),
+                }
+                surface::Item::Struct(struct_ty) => {
+                    let core_fields = self.from_struct_ty_fields(&struct_ty.fields, report);
+
+                    // FIXME: Avoid shadowing builtin definitions
+                    match self.items.entry(&struct_ty.name.1) {
+                        Entry::Vacant(entry) => {
+                            let item = core::StructType {
+                                range: struct_ty.range.clone(),
+                                doc: struct_ty.doc.clone(),
+                                name: entry.key().to_string(),
+                                fields: core_fields,
+                            };
+
+                            let core_item = core::Item::Struct(item);
+                            core_items.push(core_item.clone());
+                            let ty = Arc::new(Value::FormatType(0..0));
+                            self.tys.push((*entry.key(), ty));
+                            entry.insert(core_item);
+                        }
+                        Entry::Occupied(entry) => report(diagnostics::item_redefinition(
+                            Severity::Error,
+                            self.file_id,
+                            entry.key(),
+                            struct_ty.range.clone(),
+                            entry.get().range(),
+                        )),
+                    }
+                }
+            }
+        }
+
+        core_items
+    }
+
+    /// Translate surface structure type fields into core structure type fields in
+    /// the core syntax, while validating that they are well-formed.
+    pub fn from_struct_ty_fields(
+        &self,
+        surface_fields: &[surface::TypeField],
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> Vec<core::TypeField> {
+        // Field names that have previously seen, along with the source
+        // range where they were introduced (for diagnostic reporting).
+        let mut seen_field_names = HashMap::new();
+        // Fields that have been elaborated into the core syntax.
+        let mut core_fields = Vec::with_capacity(surface_fields.len());
+
+        for field in surface_fields {
+            use std::collections::hash_map::Entry;
+
+            let field_range = field.name.0.start..field.term.range().end;
+            let format_ty = Arc::new(Value::FormatType(0..0));
+            let ty = self.from_term_check_ty(&field.term, &format_ty, report);
+
+            match seen_field_names.entry(field.name.1.clone()) {
+                Entry::Vacant(entry) => {
+                    core_fields.push(core::TypeField {
+                        doc: field.doc.clone(),
+                        start: field_range.start,
+                        name: entry.key().clone(),
+                        term: Arc::new(ty),
+                    });
+
+                    entry.insert(field_range);
+                }
+                Entry::Occupied(entry) => report(diagnostics::field_redeclaration(
+                    Severity::Error,
+                    self.file_id,
+                    entry.key(),
+                    field_range,
+                    entry.get().clone(),
+                )),
+            }
+        }
+
+        core_fields
+    }
+
+    /// Validate that a surface term is a type, and translate it into the core syntax.
+    pub fn from_term_to_ty(
+        &self,
+        surface_term: &surface::Term,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> core::Term {
+        match surface_term {
+            surface::Term::FormatType(range) => core::Term::FormatType(range.clone()),
+            surface::Term::TypeType(range) => core::Term::TypeType(range.clone()),
+            surface_term => {
+                let (core_term, ty) = self.from_term_synth_ty(surface_term, report);
+                match ty.as_ref() {
+                    Value::FormatType(_) | Value::TypeType(_) | Value::Error(_) => core_term,
+                    _ => {
+                        let range = surface_term.range();
+                        report(diagnostics::universe_mismatch(
+                            Severity::Error,
+                            self.file_id,
+                            range.clone(),
+                            &ty,
+                        ));
+                        core::Term::Error(range)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Check that a surface term is an element of a type, and translate it into the
+    /// core syntax.
+    pub fn from_term_check_ty(
+        &self,
+        surface_term: &surface::Term,
+        expected_ty: &Arc<Value>,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> core::Term {
+        match (surface_term, expected_ty.as_ref()) {
+            (surface::Term::Error(range), _) => core::Term::Error(range.clone()),
+            (surface_term, Value::Error(_)) => core::Term::Error(surface_term.range()),
+            (surface::Term::NumberLiteral(range, literal), _) => {
+                use crate::lang::core::Constant::{Int, F32, F64};
+
+                let error = |report: &mut dyn FnMut(Diagnostic<usize>)| {
+                    report(diagnostics::error::numeric_literal_not_supported(
+                        self.file_id,
+                        range.clone(),
+                        expected_ty,
+                    ));
+                    core::Term::Error(surface_term.range())
+                };
+                match expected_ty.as_ref() {
+                    // TODO: Lookup globals in environment
+                    Value::Neutral(Head::Global(_, name), elims) if elims.is_empty() => {
+                        match name.as_str() {
+                            "Int" => match literal.parse_big_int(self.file_id, report) {
+                                Some(value) => core::Term::Constant(range.clone(), Int(value)),
+                                None => core::Term::Error(range.clone()),
+                            },
+                            "F32" => match literal.parse_float(self.file_id, report) {
+                                Some(value) => core::Term::Constant(range.clone(), F32(value)),
+                                None => core::Term::Error(range.clone()),
+                            },
+                            "F64" => match literal.parse_float(self.file_id, report) {
+                                Some(value) => core::Term::Constant(range.clone(), F64(value)),
+                                None => core::Term::Error(range.clone()),
+                            },
+                            _ => error(report),
+                        }
+                    }
+                    _ => error(report),
+                }
+            }
+            (surface::Term::If(range, surface_head, surface_if_true, surface_if_false), _) => {
+                // TODO: Lookup globals in environment
+                let bool_ty = Arc::new(Value::global(0..0, "Bool"));
+                let head = self.from_term_check_ty(surface_head, &bool_ty, report);
+                let if_true = self.from_term_check_ty(surface_if_true, expected_ty, report);
+                let if_false = self.from_term_check_ty(surface_if_false, expected_ty, report);
+
+                core::Term::BoolElim(
+                    range.clone(),
+                    Arc::new(head),
+                    Arc::new(if_true),
+                    Arc::new(if_false),
+                )
+            }
+            (surface::Term::Match(range, surface_head, surface_branches), _) => {
+                let (head, head_ty) = self.from_term_synth_ty(surface_head, report);
+                let error = |report: &mut dyn FnMut(Diagnostic<usize>)| {
+                    report(diagnostics::error::unsupported_pattern_ty(
+                        self.file_id,
+                        surface_head.range(),
+                        &head_ty,
+                    ));
+                    core::Term::Error(range.clone())
                 };
 
-                // FIXME: Avoid shadowing builtin definitions
-                match context.items.entry(&alias.name.1) {
-                    Entry::Vacant(entry) => {
-                        let item = core::Alias {
-                            range: alias.range.clone(),
-                            doc: alias.doc.clone(),
-                            name: entry.key().to_string(),
-                            term: Arc::new(core_term),
-                        };
-
-                        let core_item = core::Item::Alias(item);
-                        core_items.push(core_item.clone());
-                        context.tys.push((*entry.key(), ty));
-                        entry.insert(core_item);
+                match head_ty.as_ref() {
+                    Value::Neutral(Head::Global(_, name), elims) if elims.is_empty() => {
+                        // TODO: Lookup globals in environment
+                        match name.as_str() {
+                            "Bool" => {
+                                let (if_true, if_false) =
+                                    self.from_bool_branches(surface_branches, expected_ty, report);
+                                core::Term::BoolElim(
+                                    range.clone(),
+                                    Arc::new(head),
+                                    if_true,
+                                    if_false,
+                                )
+                            }
+                            "Int" => {
+                                let (branches, default) = self.from_int_branches(
+                                    surface_head.range(),
+                                    surface_branches,
+                                    expected_ty,
+                                    report,
+                                );
+                                core::Term::IntElim(
+                                    range.clone(),
+                                    Arc::new(head),
+                                    branches,
+                                    default,
+                                )
+                            }
+                            _ => error(report),
+                        }
                     }
-                    Entry::Occupied(entry) => report(diagnostics::item_redefinition(
-                        Severity::Error,
-                        context.file_id,
-                        entry.key(),
-                        alias.range.clone(),
-                        entry.get().range(),
-                    )),
+                    Value::Error(_) => core::Term::Error(range.clone()),
+                    _ => error(report),
                 }
             }
-            surface::Item::Struct(struct_ty) => {
-                let core_fields = from_struct_ty_fields(&context, &struct_ty.fields, report);
+            (surface_term, expected_ty) => {
+                let (core_term, synth_ty) = self.from_term_synth_ty(surface_term, report);
 
-                // FIXME: Avoid shadowing builtin definitions
-                match context.items.entry(&struct_ty.name.1) {
-                    Entry::Vacant(entry) => {
-                        let item = core::StructType {
-                            range: struct_ty.range.clone(),
-                            doc: struct_ty.doc.clone(),
-                            name: entry.key().to_string(),
-                            fields: core_fields,
-                        };
-
-                        let core_item = core::Item::Struct(item);
-                        core_items.push(core_item.clone());
-                        let ty = Arc::new(Value::FormatType(0..0));
-                        context.tys.push((*entry.key(), ty));
-                        entry.insert(core_item);
-                    }
-                    Entry::Occupied(entry) => report(diagnostics::item_redefinition(
+                if semantics::equal(&synth_ty, expected_ty) {
+                    core_term
+                } else {
+                    report(diagnostics::type_mismatch(
                         Severity::Error,
-                        context.file_id,
-                        entry.key(),
-                        struct_ty.range.clone(),
-                        entry.get().range(),
-                    )),
-                }
-            }
-        }
-    }
-
-    core_items
-}
-
-/// Translate surface structure type fields into core structure type fields in
-/// the core syntax, while validating that they are well-formed.
-pub fn from_struct_ty_fields(
-    context: &Context<'_>,
-    surface_fields: &[surface::TypeField],
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> Vec<core::TypeField> {
-    // Field names that have previously seen, along with the source
-    // range where they were introduced (for diagnostic reporting).
-    let mut seen_field_names = HashMap::new();
-    // Fields that have been elaborated into the core syntax.
-    let mut core_fields = Vec::with_capacity(surface_fields.len());
-
-    for field in surface_fields {
-        use std::collections::hash_map::Entry;
-
-        let field_range = field.name.0.start..field.term.range().end;
-        let format_ty = Arc::new(Value::FormatType(0..0));
-        let ty = from_term_check_ty(&context, &field.term, &format_ty, report);
-
-        match seen_field_names.entry(field.name.1.clone()) {
-            Entry::Vacant(entry) => {
-                core_fields.push(core::TypeField {
-                    doc: field.doc.clone(),
-                    start: field_range.start,
-                    name: entry.key().clone(),
-                    term: Arc::new(ty),
-                });
-
-                entry.insert(field_range);
-            }
-            Entry::Occupied(entry) => report(diagnostics::field_redeclaration(
-                Severity::Error,
-                context.file_id,
-                entry.key(),
-                field_range,
-                entry.get().clone(),
-            )),
-        }
-    }
-
-    core_fields
-}
-
-/// Validate that a surface term is a type, and translate it into the core syntax.
-pub fn from_term_to_ty(
-    context: &Context<'_>,
-    surface_term: &surface::Term,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> core::Term {
-    match surface_term {
-        surface::Term::FormatType(range) => core::Term::FormatType(range.clone()),
-        surface::Term::TypeType(range) => core::Term::TypeType(range.clone()),
-        surface_term => {
-            let (core_term, ty) = from_term_synth_ty(context, surface_term, report);
-            match ty.as_ref() {
-                Value::FormatType(_) | Value::TypeType(_) | Value::Error(_) => core_term,
-                _ => {
-                    let range = surface_term.range();
-                    report(diagnostics::universe_mismatch(
-                        Severity::Error,
-                        context.file_id,
-                        range.clone(),
-                        &ty,
+                        self.file_id,
+                        surface_term.range(),
+                        expected_ty,
+                        &synth_ty,
                     ));
-                    core::Term::Error(range)
+                    core::Term::Error(surface_term.range())
                 }
             }
         }
     }
-}
 
-/// Check that a surface term is an element of a type, and translate it into the
-/// core syntax.
-pub fn from_term_check_ty(
-    context: &Context<'_>,
-    surface_term: &surface::Term,
-    expected_ty: &Arc<Value>,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> core::Term {
-    match (surface_term, expected_ty.as_ref()) {
-        (surface::Term::Error(range), _) => core::Term::Error(range.clone()),
-        (surface_term, Value::Error(_)) => core::Term::Error(surface_term.range()),
-        (surface::Term::NumberLiteral(range, literal), _) => {
-            let error = |report: &mut dyn FnMut(Diagnostic<usize>)| {
-                report(diagnostics::error::numeric_literal_not_supported(
-                    context.file_id,
+    /// Synthesize the type of a surface term, and elaborate it into the core syntax.
+    pub fn from_term_synth_ty(
+        &self,
+        surface_term: &surface::Term,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> (core::Term, Arc<Value>) {
+        match surface_term {
+            surface::Term::Ann(surface_term, surface_ty) => {
+                let core_ty = self.from_term_to_ty(surface_ty, report);
+                let ty = semantics::eval(self.globals, &self.items, &core_ty);
+                let core_term = self.from_term_check_ty(surface_term, &ty, report);
+                (core::Term::Ann(Arc::new(core_term), Arc::new(core_ty)), ty)
+            }
+            surface::Term::Name(range, name) => {
+                if let Some((ty, _)) = self.globals.get(name) {
+                    return (
+                        core::Term::Global(range.clone(), name.to_owned()),
+                        semantics::eval(self.globals, &self.items, ty),
+                    );
+                }
+                if let Some(ty) = self.lookup_ty(name) {
+                    return (core::Term::Item(range.clone(), name.to_owned()), ty.clone());
+                }
+
+                report(diagnostics::error::var_name_not_found(
+                    self.file_id,
+                    name.as_str(),
                     range.clone(),
-                    expected_ty,
                 ));
-                core::Term::Error(surface_term.range())
-            };
-            match expected_ty.as_ref() {
-                // TODO: Lookup globals in environment
-                Value::Neutral(Head::Global(_, name), elims) if elims.is_empty() => {
-                    match name.as_str() {
-                        "Int" => match literal.parse_big_int(context.file_id, report) {
-                            Some(value) => {
-                                core::Term::Constant(range.clone(), core::Constant::Int(value))
-                            }
-                            None => core::Term::Error(range.clone()),
-                        },
-                        "F32" => match literal.parse_float(context.file_id, report) {
-                            Some(value) => {
-                                core::Term::Constant(range.clone(), core::Constant::F32(value))
-                            }
-                            None => core::Term::Error(range.clone()),
-                        },
-                        "F64" => match literal.parse_float(context.file_id, report) {
-                            Some(value) => {
-                                core::Term::Constant(range.clone(), core::Constant::F64(value))
-                            }
-                            None => core::Term::Error(range.clone()),
-                        },
-                        _ => error(report),
-                    }
-                }
-                _ => error(report),
-            }
-        }
-        (surface::Term::If(range, surface_head, surface_if_true, surface_if_false), _) => {
-            // TODO: Lookup globals in environment
-            let bool_ty = Arc::new(Value::global(0..0, "Bool"));
-            let head = from_term_check_ty(context, surface_head, &bool_ty, report);
-            let if_true = from_term_check_ty(context, surface_if_true, expected_ty, report);
-            let if_false = from_term_check_ty(context, surface_if_false, expected_ty, report);
-
-            core::Term::BoolElim(
-                range.clone(),
-                Arc::new(head),
-                Arc::new(if_true),
-                Arc::new(if_false),
-            )
-        }
-        (surface::Term::Match(range, surface_head, surface_branches), _) => {
-            let (head, head_ty) = from_term_synth_ty(context, surface_head, report);
-            let error = |report: &mut dyn FnMut(Diagnostic<usize>)| {
-                report(diagnostics::error::unsupported_pattern_ty(
-                    context.file_id,
-                    surface_head.range(),
-                    &head_ty,
-                ));
-                core::Term::Error(range.clone())
-            };
-
-            match head_ty.as_ref() {
-                Value::Neutral(Head::Global(_, name), elims) if elims.is_empty() => {
-                    // TODO: Lookup globals in environment
-                    match name.as_str() {
-                        "Bool" => {
-                            let (if_true, if_false) =
-                                from_bool_branches(context, surface_branches, expected_ty, report);
-                            core::Term::BoolElim(range.clone(), Arc::new(head), if_true, if_false)
-                        }
-                        "Int" => {
-                            let (branches, default) = from_int_branches(
-                                context,
-                                surface_head.range(),
-                                surface_branches,
-                                expected_ty,
-                                report,
-                            );
-                            core::Term::IntElim(range.clone(), Arc::new(head), branches, default)
-                        }
-                        _ => error(report),
-                    }
-                }
-                Value::Error(_) => core::Term::Error(range.clone()),
-                _ => error(report),
-            }
-        }
-        (surface_term, expected_ty) => {
-            let (core_term, synth_ty) = from_term_synth_ty(context, surface_term, report);
-
-            if semantics::equal(&synth_ty, expected_ty) {
-                core_term
-            } else {
-                report(diagnostics::type_mismatch(
-                    Severity::Error,
-                    context.file_id,
-                    surface_term.range(),
-                    expected_ty,
-                    &synth_ty,
-                ));
-                core::Term::Error(surface_term.range())
-            }
-        }
-    }
-}
-
-/// Synthesize the type of a surface term, and elaborate it into the core syntax.
-pub fn from_term_synth_ty(
-    context: &Context<'_>,
-    surface_term: &surface::Term,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> (core::Term, Arc<Value>) {
-    match surface_term {
-        surface::Term::Ann(surface_term, surface_ty) => {
-            let core_ty = from_term_to_ty(context, surface_ty, report);
-            let ty = semantics::eval(context.globals, &context.items, &core_ty);
-            let core_term = from_term_check_ty(context, surface_term, &ty, report);
-            (core::Term::Ann(Arc::new(core_term), Arc::new(core_ty)), ty)
-        }
-        surface::Term::Name(range, name) => {
-            if let Some((ty, _)) = context.globals.get(name) {
-                return (
-                    core::Term::Global(range.clone(), name.to_owned()),
-                    semantics::eval(context.globals, &context.items, ty),
-                );
-            }
-            if let Some(ty) = context.lookup_ty(name) {
-                return (core::Term::Item(range.clone(), name.to_owned()), ty.clone());
-            }
-
-            report(diagnostics::error::var_name_not_found(
-                context.file_id,
-                name.as_str(),
-                range.clone(),
-            ));
-            (
-                core::Term::Error(range.clone()),
-                Arc::new(Value::Error(0..0)),
-            )
-        }
-        surface::Term::TypeType(range) | surface::Term::FormatType(range) => {
-            report(diagnostics::term_has_no_type(
-                Severity::Error,
-                context.file_id,
-                range.clone(),
-            ));
-            (
-                core::Term::Error(range.clone()),
-                Arc::new(Value::Error(0..0)),
-            )
-        }
-        surface::Term::FunctionType(param_ty, body_ty) => {
-            let core_param_ty = from_term_to_ty(context, param_ty, report);
-            let core_body_ty = from_term_to_ty(context, body_ty, report);
-
-            match (&core_param_ty, &core_body_ty) {
-                (core::Term::Error(_), _) | (_, core::Term::Error(_)) => (
-                    core::Term::Error(surface_term.range()),
-                    Arc::new(Value::Error(0..0)),
-                ),
-                (_, _) => (
-                    core::Term::FunctionType(Arc::new(core_param_ty), Arc::new(core_body_ty)),
-                    Arc::new(Value::TypeType(0..0)),
-                ),
-            }
-        }
-        surface::Term::FunctionElim(head, arguments) => {
-            let range = surface_term.range();
-            let (mut core_head, mut head_type) = from_term_synth_ty(context, head, report);
-
-            for argument in arguments {
-                match head_type.as_ref() {
-                    Value::FunctionType(param_type, body_type) => {
-                        core_head = core::Term::FunctionElim(
-                            Arc::new(core_head),
-                            Arc::new(from_term_check_ty(context, argument, &param_type, report)),
-                        );
-                        head_type = body_type.clone();
-                    }
-                    Value::Error(_) => {
-                        return (core::Term::Error(range), Arc::new(Value::Error(0..0)));
-                    }
-                    head_ty => {
-                        report(diagnostics::not_a_function(
-                            Severity::Error,
-                            context.file_id,
-                            head.range(),
-                            head_ty,
-                            argument.range(),
-                        ));
-                        return (core::Term::Error(range), Arc::new(Value::Error(0..0)));
-                    }
-                }
-            }
-
-            (core_head, head_type)
-        }
-        surface::Term::NumberLiteral(range, _) => {
-            report(diagnostics::error::ambiguous_numeric_literal(
-                context.file_id,
-                range.clone(),
-            ));
-
-            (
-                core::Term::Error(range.clone()),
-                Arc::new(Value::Error(0..0)),
-            )
-        }
-        surface::Term::If(range, surface_head, surface_if_true, surface_if_false) => {
-            // TODO: Lookup globals in environment
-            let bool_ty = Arc::new(Value::global(0..0, "Bool"));
-            let head = from_term_check_ty(context, surface_head, &bool_ty, report);
-            let (if_true, if_true_ty) = from_term_synth_ty(context, surface_if_true, report);
-            let (if_false, if_false_ty) = from_term_synth_ty(context, surface_if_false, report);
-
-            if semantics::equal(&if_true_ty, &if_false_ty) {
                 (
-                    core::Term::BoolElim(
-                        range.clone(),
-                        Arc::new(head),
-                        Arc::new(if_true),
-                        Arc::new(if_false),
-                    ),
-                    if_true_ty,
+                    core::Term::Error(range.clone()),
+                    Arc::new(Value::Error(0..0)),
                 )
-            } else {
-                report(diagnostics::type_mismatch(
+            }
+            surface::Term::TypeType(range) | surface::Term::FormatType(range) => {
+                report(diagnostics::term_has_no_type(
                     Severity::Error,
-                    context.file_id,
-                    surface_if_false.range(),
-                    &if_true_ty,
-                    &if_false_ty,
+                    self.file_id,
+                    range.clone(),
+                ));
+                (
+                    core::Term::Error(range.clone()),
+                    Arc::new(Value::Error(0..0)),
+                )
+            }
+            surface::Term::FunctionType(param_ty, body_ty) => {
+                let core_param_ty = self.from_term_to_ty(param_ty, report);
+                let core_body_ty = self.from_term_to_ty(body_ty, report);
+
+                match (&core_param_ty, &core_body_ty) {
+                    (core::Term::Error(_), _) | (_, core::Term::Error(_)) => (
+                        core::Term::Error(surface_term.range()),
+                        Arc::new(Value::Error(0..0)),
+                    ),
+                    (_, _) => (
+                        core::Term::FunctionType(Arc::new(core_param_ty), Arc::new(core_body_ty)),
+                        Arc::new(Value::TypeType(0..0)),
+                    ),
+                }
+            }
+            surface::Term::FunctionElim(head, arguments) => {
+                let range = surface_term.range();
+                let (mut core_head, mut head_type) = self.from_term_synth_ty(head, report);
+
+                for argument in arguments {
+                    match head_type.as_ref() {
+                        Value::FunctionType(param_type, body_type) => {
+                            core_head = core::Term::FunctionElim(
+                                Arc::new(core_head),
+                                Arc::new(self.from_term_check_ty(argument, &param_type, report)),
+                            );
+                            head_type = body_type.clone();
+                        }
+                        Value::Error(_) => {
+                            return (core::Term::Error(range), Arc::new(Value::Error(0..0)));
+                        }
+                        head_ty => {
+                            report(diagnostics::not_a_function(
+                                Severity::Error,
+                                self.file_id,
+                                head.range(),
+                                head_ty,
+                                argument.range(),
+                            ));
+                            return (core::Term::Error(range), Arc::new(Value::Error(0..0)));
+                        }
+                    }
+                }
+
+                (core_head, head_type)
+            }
+            surface::Term::NumberLiteral(range, _) => {
+                report(diagnostics::error::ambiguous_numeric_literal(
+                    self.file_id,
+                    range.clone(),
+                ));
+
+                (
+                    core::Term::Error(range.clone()),
+                    Arc::new(Value::Error(0..0)),
+                )
+            }
+            surface::Term::If(range, surface_head, surface_if_true, surface_if_false) => {
+                // TODO: Lookup globals in environment
+                let bool_ty = Arc::new(Value::global(0..0, "Bool"));
+                let head = self.from_term_check_ty(surface_head, &bool_ty, report);
+                let (if_true, if_true_ty) = self.from_term_synth_ty(surface_if_true, report);
+                let (if_false, if_false_ty) = self.from_term_synth_ty(surface_if_false, report);
+
+                if semantics::equal(&if_true_ty, &if_false_ty) {
+                    (
+                        core::Term::BoolElim(
+                            range.clone(),
+                            Arc::new(head),
+                            Arc::new(if_true),
+                            Arc::new(if_false),
+                        ),
+                        if_true_ty,
+                    )
+                } else {
+                    report(diagnostics::type_mismatch(
+                        Severity::Error,
+                        self.file_id,
+                        surface_if_false.range(),
+                        &if_true_ty,
+                        &if_false_ty,
+                    ));
+                    (
+                        core::Term::Error(range.clone()),
+                        Arc::new(Value::Error(range.clone())),
+                    )
+                }
+            }
+            surface::Term::Match(range, _, _) => {
+                report(diagnostics::ambiguous_match_expression(
+                    Severity::Error,
+                    self.file_id,
+                    range.clone(),
                 ));
                 (
                     core::Term::Error(range.clone()),
                     Arc::new(Value::Error(range.clone())),
                 )
             }
-        }
-        surface::Term::Match(range, _, _) => {
-            report(diagnostics::ambiguous_match_expression(
-                Severity::Error,
-                context.file_id,
-                range.clone(),
-            ));
-            (
+            surface::Term::Error(range) => (
                 core::Term::Error(range.clone()),
-                Arc::new(Value::Error(range.clone())),
-            )
+                Arc::new(Value::Error(0..0)),
+            ),
         }
-        surface::Term::Error(range) => (
-            core::Term::Error(range.clone()),
-            Arc::new(Value::Error(0..0)),
-        ),
     }
-}
 
-#[allow(unused_variables)]
-fn from_bool_branches(
-    context: &Context<'_>,
-    surface_branches: &[(surface::Pattern, surface::Term)],
-    expected_ty: &Value,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> (Arc<core::Term>, Arc<core::Term>) {
-    unimplemented!("boolean eliminators")
-}
+    #[allow(unused_variables)]
+    fn from_bool_branches(
+        &self,
+        surface_branches: &[(surface::Pattern, surface::Term)],
+        expected_ty: &Value,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> (Arc<core::Term>, Arc<core::Term>) {
+        unimplemented!("boolean eliminators")
+    }
 
-fn from_int_branches(
-    context: &Context<'_>,
-    range: Range<usize>,
-    surface_branches: &[(surface::Pattern, surface::Term)],
-    expected_ty: &Arc<Value>,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> (BTreeMap<BigInt, Arc<core::Term>>, Arc<core::Term>) {
-    use std::collections::btree_map::Entry;
+    fn from_int_branches(
+        &self,
+        range: Range<usize>,
+        surface_branches: &[(surface::Pattern, surface::Term)],
+        expected_ty: &Arc<Value>,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> (BTreeMap<BigInt, Arc<core::Term>>, Arc<core::Term>) {
+        use std::collections::btree_map::Entry;
 
-    let mut branches = BTreeMap::new();
-    let mut default = None;
+        let mut branches = BTreeMap::new();
+        let mut default = None;
 
-    for (pattern, surface_term) in surface_branches {
-        match pattern {
-            surface::Pattern::NumberLiteral(range, literal) => {
-                let core_term = from_term_check_ty(context, surface_term, expected_ty, report);
-                if let Some(value) = literal.parse_big_int(context.file_id, report) {
+        for (pattern, surface_term) in surface_branches {
+            match pattern {
+                surface::Pattern::NumberLiteral(range, literal) => {
+                    let core_term = self.from_term_check_ty(surface_term, expected_ty, report);
+                    if let Some(value) = literal.parse_big_int(self.file_id, report) {
+                        match &default {
+                            None => match branches.entry(value) {
+                                Entry::Occupied(_) => {
+                                    report(diagnostics::warning::unreachable_pattern(
+                                        self.file_id,
+                                        range.clone(),
+                                    ))
+                                }
+                                Entry::Vacant(entry) => {
+                                    entry.insert(Arc::new(core_term));
+                                }
+                            },
+                            Some(_) => report(diagnostics::warning::unreachable_pattern(
+                                self.file_id,
+                                range.clone(),
+                            )),
+                        }
+                    }
+                }
+                surface::Pattern::Name(range, _name) => {
+                    // TODO: check if name is bound
+                    // - if so compare for equality
+                    // - otherwise bind local variable
+                    let core_term = self.from_term_check_ty(surface_term, expected_ty, report);
                     match &default {
-                        None => match branches.entry(value) {
-                            Entry::Occupied(_) => {
-                                report(diagnostics::warning::unreachable_pattern(
-                                    context.file_id,
-                                    range.clone(),
-                                ))
-                            }
-                            Entry::Vacant(entry) => {
-                                entry.insert(Arc::new(core_term));
-                            }
-                        },
+                        None => default = Some(Arc::new(core_term)),
                         Some(_) => report(diagnostics::warning::unreachable_pattern(
-                            context.file_id,
+                            self.file_id,
                             range.clone(),
                         )),
                     }
                 }
             }
-            surface::Pattern::Name(range, _name) => {
-                // TODO: check if name is bound
-                // - if so compare for equality
-                // - otherwise bind local variable
-                let core_term = from_term_check_ty(context, surface_term, expected_ty, report);
-                match &default {
-                    None => default = Some(Arc::new(core_term)),
-                    Some(_) => report(diagnostics::warning::unreachable_pattern(
-                        context.file_id,
-                        range.clone(),
-                    )),
-                }
-            }
         }
+
+        let default = default.unwrap_or_else(|| {
+            report(diagnostics::error::no_default_pattern(self.file_id, range));
+            Arc::new(core::Term::Error(0..0))
+        });
+
+        (branches, default)
     }
-
-    let default = default.unwrap_or_else(|| {
-        report(diagnostics::error::no_default_pattern(
-            context.file_id,
-            range,
-        ));
-        Arc::new(core::Term::Error(0..0))
-    });
-
-    (branches, default)
 }

--- a/fathom/src/pass/surface_to_doc.rs
+++ b/fathom/src/pass/surface_to_doc.rs
@@ -11,7 +11,6 @@ use crate::pass::surface_to_pretty::Prec;
 #[allow(clippy::write_literal)]
 pub fn from_module(writer: &mut impl Write, module: &Module) -> io::Result<()> {
     let mut context = Context {
-        _file_id: module.file_id,
         items: HashMap::new(),
     };
 
@@ -75,7 +74,6 @@ pub fn from_module(writer: &mut impl Write, module: &Module) -> io::Result<()> {
 }
 
 struct Context {
-    _file_id: usize,
     items: HashMap<String, ItemMeta>,
 }
 

--- a/fathom/src/pass/surface_to_doc.rs
+++ b/fathom/src/pass/surface_to_doc.rs
@@ -13,7 +13,7 @@ pub fn from_module(
     module: &surface::Module,
     report: &mut dyn FnMut(Diagnostic<usize>),
 ) -> io::Result<()> {
-    let mut context = ModuleContext {
+    let mut context = Context {
         _file_id: module.file_id,
         items: HashMap::new(),
     };
@@ -58,9 +58,9 @@ pub fn from_module(
 
     for item in &module.items {
         let (name, item) = match item {
-            surface::Item::Alias(alias) => from_alias(&context, writer, alias, report)?,
+            surface::Item::Alias(alias) => context.from_alias(writer, alias, report)?,
             surface::Item::Struct(struct_ty) => {
-                from_struct_ty(&context, writer, struct_ty, report)?
+                context.from_struct_ty(writer, struct_ty, report)?
             }
         };
 
@@ -79,7 +79,7 @@ pub fn from_module(
     Ok(())
 }
 
-struct ModuleContext {
+struct Context {
     _file_id: usize,
     items: HashMap<String, Item>,
 }
@@ -88,205 +88,204 @@ struct Item {
     id: String,
 }
 
-fn from_alias(
-    context: &ModuleContext,
-    writer: &mut impl Write,
-    alias: &surface::Alias,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> io::Result<(String, Item)> {
-    let (_, name) = &alias.name;
-    let id = format!("items[{}]", name);
+impl Context {
+    fn from_alias(
+        &self,
+        writer: &mut impl Write,
+        alias: &surface::Alias,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> io::Result<(String, Item)> {
+        let (_, name) = &alias.name;
+        let id = format!("items[{}]", name);
 
-    writeln!(
-        writer,
-        r##"        <dt id="{id}" class="item alias">"##,
-        id = id,
-    )?;
-    match &alias.ty {
-        None => writeln!(
+        writeln!(
             writer,
-            r##"          <a href="#{id}">{name}</a>"##,
+            r##"        <dt id="{id}" class="item alias">"##,
             id = id,
-            name = name,
-        )?,
-        Some(ty) => writeln!(
+        )?;
+        match &alias.ty {
+            None => writeln!(
+                writer,
+                r##"          <a href="#{id}">{name}</a>"##,
+                id = id,
+                name = name,
+            )?,
+            Some(ty) => writeln!(
+                writer,
+                r##"          <a href="#{id}">{name}</a> : {ty}"##,
+                id = id,
+                name = name,
+                ty = self.from_term_prec(ty, Prec::Term, report),
+            )?,
+        }
+        write!(
             writer,
-            r##"          <a href="#{id}">{name}</a> : {ty}"##,
-            id = id,
-            name = name,
-            ty = from_term_prec(context, ty, Prec::Term, report),
-        )?,
-    }
-    write!(
-        writer,
-        r##"        </dt>
+            r##"        </dt>
         <dd class="item alias">
 "##
-    )?;
+        )?;
 
-    if !alias.doc.is_empty() {
-        writeln!(writer, r##"          <section class="doc">"##)?;
-        from_doc_lines(writer, "            ", &alias.doc)?;
-        writeln!(writer, r##"          </section>"##)?;
-    }
+        if !alias.doc.is_empty() {
+            writeln!(writer, r##"          <section class="doc">"##)?;
+            from_doc_lines(writer, "            ", &alias.doc)?;
+            writeln!(writer, r##"          </section>"##)?;
+        }
 
-    let term = from_term_prec(context, &alias.term, Prec::Term, report);
+        let term = self.from_term_prec(&alias.term, Prec::Term, report);
 
-    write!(
-        writer,
-        r##"          <section class="term">
+        write!(
+            writer,
+            r##"          <section class="term">
             {}
           </section>
         </dd>
 "##,
-        term
-    )?;
+            term
+        )?;
 
-    Ok((name.clone(), Item { id }))
-}
+        Ok((name.clone(), Item { id }))
+    }
 
-fn from_struct_ty(
-    context: &ModuleContext,
-    writer: &mut impl Write,
-    struct_ty: &surface::StructType,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> io::Result<(String, Item)> {
-    let (_, name) = &struct_ty.name;
-    let id = format!("items[{}]", name);
+    fn from_struct_ty(
+        &self,
+        writer: &mut impl Write,
+        struct_ty: &surface::StructType,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> io::Result<(String, Item)> {
+        let (_, name) = &struct_ty.name;
+        let id = format!("items[{}]", name);
 
-    write!(
-        writer,
-        r##"        <dt id="{id}" class="item struct">
+        write!(
+            writer,
+            r##"        <dt id="{id}" class="item struct">
           struct <a href="#{id}">{name}</a>
         </dt>
         <dd class="item struct">
 "##,
-        id = id,
-        name = name
-    )?;
+            id = id,
+            name = name
+        )?;
 
-    if !struct_ty.doc.is_empty() {
-        writeln!(writer, r##"          <section class="doc">"##)?;
-        from_doc_lines(writer, "            ", &struct_ty.doc)?;
-        writeln!(writer, r##"          </section>"##)?;
-    }
+        if !struct_ty.doc.is_empty() {
+            writeln!(writer, r##"          <section class="doc">"##)?;
+            from_doc_lines(writer, "            ", &struct_ty.doc)?;
+            writeln!(writer, r##"          </section>"##)?;
+        }
 
-    if !struct_ty.fields.is_empty() {
-        writeln!(writer, r##"          <dl class="fields">"##)?;
-        for field in &struct_ty.fields {
-            let (_, field_name) = &field.name;
-            let field_id = format!("{}.fields[{}]", id, field_name);
-            let ty = from_term_prec(context, &field.term, Prec::Term, report);
+        if !struct_ty.fields.is_empty() {
+            writeln!(writer, r##"          <dl class="fields">"##)?;
+            for field in &struct_ty.fields {
+                let (_, field_name) = &field.name;
+                let field_id = format!("{}.fields[{}]", id, field_name);
+                let ty = self.from_term_prec(&field.term, Prec::Term, report);
 
-            write!(
-                writer,
-                r##"            <dt id="{id}" class="field">
+                write!(
+                    writer,
+                    r##"            <dt id="{id}" class="field">
               <a href="#{id}">{name}</a> : {ty}
             </dt>
             <dd class="field">
               <section class="doc">
 "##,
-                id = field_id,
-                name = field_name,
-                ty = ty,
-            )?;
-            from_doc_lines(writer, "                ", &field.doc)?;
-            write!(
-                writer,
-                r##"              </section>
+                    id = field_id,
+                    name = field_name,
+                    ty = ty,
+                )?;
+                from_doc_lines(writer, "                ", &field.doc)?;
+                write!(
+                    writer,
+                    r##"              </section>
             </dd>
 "##
-            )?;
+                )?;
+            }
+            writeln!(writer, r##"          </dl>"##)?;
         }
-        writeln!(writer, r##"          </dl>"##)?;
+
+        writeln!(writer, r##"        </dd>"##)?;
+
+        Ok((name.clone(), Item { id }))
     }
 
-    writeln!(writer, r##"        </dd>"##)?;
+    fn from_term_prec<'term>(
+        &self,
+        term: &'term surface::Term,
+        prec: Prec,
+        report: &mut dyn FnMut(Diagnostic<usize>),
+    ) -> Cow<'term, str> {
+        use itertools::Itertools;
 
-    Ok((name.clone(), Item { id }))
-}
+        match term {
+            surface::Term::Name(_, name) => {
+                let id = match self.items.get(name) {
+                    Some(item) => item.id.as_str(),
+                    None => "",
+                };
 
-fn from_term_prec<'term>(
-    context: &ModuleContext,
-    term: &'term surface::Term,
-    prec: Prec,
-    report: &mut dyn FnMut(Diagnostic<usize>),
-) -> Cow<'term, str> {
-    use itertools::Itertools;
-
-    match term {
-        surface::Term::Name(_, name) => {
-            let id = match context.items.get(name) {
-                Some(item) => item.id.as_str(),
-                None => "",
-            };
-
-            format!(r##"<var><a href="#{}">{}</a></var>"##, id, name).into()
+                format!(r##"<var><a href="#{}">{}</a></var>"##, id, name).into()
+            }
+            surface::Term::TypeType(_) => "Type".into(),
+            surface::Term::Ann(term, ty) => format!(
+                "{lparen}{term} : {ty}{rparen}",
+                lparen = if prec > Prec::Term { "(" } else { "" },
+                rparen = if prec > Prec::Term { ")" } else { "" },
+                term = self.from_term_prec(term, Prec::Arrow, report),
+                ty = self.from_term_prec(ty, Prec::Term, report),
+            )
+            .into(),
+            surface::Term::FunctionType(param_type, body_type) => format!(
+                "{lparen}{param_type} &rarr; {body_type}{rparen}",
+                lparen = if prec > Prec::Arrow { "(" } else { "" },
+                rparen = if prec > Prec::Arrow { ")" } else { "" },
+                param_type = self.from_term_prec(param_type, Prec::App, report),
+                body_type = self.from_term_prec(body_type, Prec::Arrow, report),
+            )
+            .into(),
+            surface::Term::FunctionElim(head, arguments) => format!(
+                // TODO: multiline formatting!
+                "{lparen}{head} {arguments}{rparen}",
+                lparen = if prec > Prec::App { "(" } else { "" },
+                rparen = if prec > Prec::App { ")" } else { "" },
+                head = self.from_term_prec(head, Prec::Atomic, report),
+                arguments = arguments
+                    .iter()
+                    .map(|argument| self.from_term_prec(argument, Prec::Atomic, report))
+                    .format(" "),
+            )
+            .into(),
+            surface::Term::NumberLiteral(_, literal) => format!("{}", literal).into(),
+            surface::Term::If(_, head, if_true, if_false) => format!(
+                // TODO: multiline formatting!
+                "if {head} {{ {if_true} }} else {{ {if_false} }}",
+                head = self.from_term_prec(head, Prec::Term, report),
+                if_true = self.from_term_prec(if_true, Prec::Term, report),
+                if_false = self.from_term_prec(if_false, Prec::Term, report),
+            )
+            .into(),
+            surface::Term::Match(_, head, branches) => format!(
+                // TODO: multiline formatting!
+                "match {head} {{ {branches} }}",
+                head = self.from_term_prec(head, Prec::Term, report),
+                branches = branches
+                    .iter()
+                    .map(|(pattern, term)| format!(
+                        "{pattern} &rArr; {term}",
+                        pattern = self.from_pattern(pattern),
+                        term = self.from_term_prec(term, Prec::Term, report),
+                    ))
+                    .format(", "),
+            )
+            .into(),
+            surface::Term::FormatType(_) => "Format".into(),
+            surface::Term::Error(_) => r##"<strong>(invalid data description)</strong>"##.into(),
         }
-        surface::Term::TypeType(_) => "Type".into(),
-        surface::Term::Ann(term, ty) => format!(
-            "{lparen}{term} : {ty}{rparen}",
-            lparen = if prec > Prec::Term { "(" } else { "" },
-            rparen = if prec > Prec::Term { ")" } else { "" },
-            term = from_term_prec(context, term, Prec::Arrow, report),
-            ty = from_term_prec(context, ty, Prec::Term, report),
-        )
-        .into(),
-        surface::Term::FunctionType(param_type, body_type) => format!(
-            "{lparen}{param_type} &rarr; {body_type}{rparen}",
-            lparen = if prec > Prec::Arrow { "(" } else { "" },
-            rparen = if prec > Prec::Arrow { ")" } else { "" },
-            param_type = from_term_prec(context, param_type, Prec::App, report),
-            body_type = from_term_prec(context, body_type, Prec::Arrow, report),
-        )
-        .into(),
-        surface::Term::FunctionElim(head, arguments) => format!(
-            // TODO: multiline formatting!
-            "{lparen}{head} {arguments}{rparen}",
-            lparen = if prec > Prec::App { "(" } else { "" },
-            rparen = if prec > Prec::App { ")" } else { "" },
-            head = from_term_prec(context, head, Prec::Atomic, report),
-            arguments = arguments
-                .iter()
-                .map(|argument| from_term_prec(context, argument, Prec::Atomic, report))
-                .format(" "),
-        )
-        .into(),
-        surface::Term::NumberLiteral(_, literal) => format!("{}", literal).into(),
-        surface::Term::If(_, head, if_true, if_false) => format!(
-            // TODO: multiline formatting!
-            "if {head} {{ {if_true} }} else {{ {if_false} }}",
-            head = from_term_prec(context, head, Prec::Term, report),
-            if_true = from_term_prec(context, if_true, Prec::Term, report),
-            if_false = from_term_prec(context, if_false, Prec::Term, report),
-        )
-        .into(),
-        surface::Term::Match(_, head, branches) => format!(
-            // TODO: multiline formatting!
-            "match {head} {{ {branches} }}",
-            head = from_term_prec(context, head, Prec::Term, report),
-            branches = branches
-                .iter()
-                .map(|(pattern, term)| format!(
-                    "{pattern} &rArr; {term}",
-                    pattern = from_pattern(context, pattern),
-                    term = from_term_prec(context, term, Prec::Term, report),
-                ))
-                .format(", "),
-        )
-        .into(),
-        surface::Term::FormatType(_) => "Format".into(),
-        surface::Term::Error(_) => r##"<strong>(invalid data description)</strong>"##.into(),
     }
-}
 
-fn from_pattern<'term>(
-    _context: &ModuleContext,
-    pattern: &'term surface::Pattern,
-) -> Cow<'term, str> {
-    match pattern {
-        surface::Pattern::Name(_, name) => format!(r##"<a href="#">{}</a>"##, name).into(), // TODO: add local binding
-        surface::Pattern::NumberLiteral(_, literal) => format!("{}", literal).into(),
+    fn from_pattern<'term>(&self, pattern: &'term surface::Pattern) -> Cow<'term, str> {
+        match pattern {
+            surface::Pattern::Name(_, name) => format!(r##"<a href="#">{}</a>"##, name).into(), // TODO: add local binding
+            surface::Pattern::NumberLiteral(_, literal) => format!("{}", literal).into(),
+        }
     }
 }
 

--- a/fathom/src/pass/surface_to_pretty.rs
+++ b/fathom/src/pass/surface_to_pretty.rs
@@ -41,7 +41,7 @@ where
 {
     match item {
         Item::Alias(alias) => from_alias(alloc, alias),
-        Item::Struct(struct_ty) => from_struct_ty(alloc, struct_ty),
+        Item::Struct(struct_type) => from_struct_type(alloc, struct_type),
     }
 }
 
@@ -62,11 +62,11 @@ where
         .append(alloc.space())
         .append("=")
         .group()
-        .append(match &alias.ty {
+        .append(match &alias.type_ {
             None => alloc.nil(),
-            Some(ty) => (alloc.nil())
+            Some(r#type) => (alloc.nil())
                 .append(alloc.space())
-                .append(from_term_prec(alloc, ty, Prec::Term))
+                .append(from_term_prec(alloc, r#type, Prec::Term))
                 .group()
                 .nest(4),
         })
@@ -80,12 +80,12 @@ where
         )
 }
 
-pub fn from_struct_ty<'a, D>(alloc: &'a D, struct_ty: &'a StructType) -> DocBuilder<'a, D>
+pub fn from_struct_type<'a, D>(alloc: &'a D, struct_type: &'a StructType) -> DocBuilder<'a, D>
 where
     D: DocAllocator<'a>,
     D::Doc: Clone,
 {
-    let docs = alloc.concat(struct_ty.doc.iter().map(|line| {
+    let docs = alloc.concat(struct_type.doc.iter().map(|line| {
         (alloc.nil())
             .append(format!("///{}", line))
             .append(alloc.hardline())
@@ -94,17 +94,17 @@ where
     let struct_prefix = (alloc.nil())
         .append("struct")
         .append(alloc.space())
-        .append(&struct_ty.name.1)
+        .append(&struct_type.name.1)
         .append(alloc.space());
 
-    let struct_ty = if struct_ty.fields.is_empty() {
+    let struct_type = if struct_type.fields.is_empty() {
         (alloc.nil()).append(struct_prefix).append("{}").group()
     } else {
         (alloc.nil())
             .append(struct_prefix)
             .append("{")
             .group()
-            .append(alloc.concat(struct_ty.fields.iter().map(|field| {
+            .append(alloc.concat(struct_type.fields.iter().map(|field| {
                 (alloc.nil())
                     .append(alloc.hardline())
                     .append(from_ty_field(alloc, field))
@@ -115,7 +115,7 @@ where
             .append("}")
     };
 
-    (alloc.nil()).append(docs).append(struct_ty)
+    (alloc.nil()).append(docs).append(struct_type)
 }
 
 pub fn from_ty_field<'a, D>(alloc: &'a D, ty_field: &'a TypeField) -> DocBuilder<'a, D>
@@ -171,7 +171,7 @@ where
     D::Doc: Clone,
 {
     match term {
-        Term::Ann(term, ty) => paren(
+        Term::Ann(term, r#type) => paren(
             alloc,
             prec > Prec::Term,
             (alloc.nil())
@@ -181,7 +181,7 @@ where
                 .group()
                 .append(
                     (alloc.space())
-                        .append(from_term_prec(alloc, ty, Prec::Term))
+                        .append(from_term_prec(alloc, r#type, Prec::Term))
                         .group()
                         .nest(4),
                 ),

--- a/fathom/src/pass/surface_to_pretty.rs
+++ b/fathom/src/pass/surface_to_pretty.rs
@@ -2,7 +2,9 @@
 
 use pretty::{DocAllocator, DocBuilder};
 
-use crate::lang::surface::{Alias, Item, Module, Pattern, StructType, Term, TypeField};
+use crate::lang::surface::{
+    Alias, Item, ItemData, Module, Pattern, PatternData, StructType, Term, TermData, TypeField,
+};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Prec {
@@ -39,9 +41,9 @@ where
     D: DocAllocator<'a>,
     D::Doc: Clone,
 {
-    match item {
-        Item::Alias(alias) => from_alias(alloc, alias),
-        Item::Struct(struct_type) => from_struct_type(alloc, struct_type),
+    match &item.data {
+        ItemData::Alias(alias) => from_alias(alloc, alias),
+        ItemData::Struct(struct_type) => from_struct_type(alloc, struct_type),
     }
 }
 
@@ -58,7 +60,7 @@ where
 
     (alloc.nil())
         .append(docs)
-        .append(&alias.name.1)
+        .append(&alias.name.data)
         .append(alloc.space())
         .append("=")
         .group()
@@ -94,7 +96,7 @@ where
     let struct_prefix = (alloc.nil())
         .append("struct")
         .append(alloc.space())
-        .append(&struct_type.name.1)
+        .append(&struct_type.name.data)
         .append(alloc.space());
 
     let struct_type = if struct_type.fields.is_empty() {
@@ -133,7 +135,7 @@ where
         .append(docs)
         .append(
             (alloc.nil())
-                .append(&ty_field.name.1)
+                .append(&ty_field.name.data)
                 .append(alloc.space())
                 .append(":")
                 .group(),
@@ -151,9 +153,9 @@ where
     D: DocAllocator<'a>,
     D::Doc: Clone,
 {
-    match pattern {
-        Pattern::Name(_, name) => alloc.text(name),
-        Pattern::NumberLiteral(_, literal) => alloc.as_string(literal),
+    match &pattern.data {
+        PatternData::Name(name) => alloc.text(name),
+        PatternData::NumberLiteral(literal) => alloc.as_string(literal),
     }
 }
 
@@ -170,8 +172,8 @@ where
     D: DocAllocator<'a>,
     D::Doc: Clone,
 {
-    match term {
-        Term::Ann(term, r#type) => paren(
+    match &term.data {
+        TermData::Ann(term, r#type) => paren(
             alloc,
             prec > Prec::Term,
             (alloc.nil())
@@ -186,9 +188,9 @@ where
                         .nest(4),
                 ),
         ),
-        Term::Name(_, name) => alloc.text(name),
-        Term::TypeType(_) => alloc.text("Type"),
-        Term::FunctionType(param_type, body_type) => paren(
+        TermData::Name(name) => alloc.text(name),
+        TermData::TypeType => alloc.text("Type"),
+        TermData::FunctionType(param_type, body_type) => paren(
             alloc,
             prec > Prec::App,
             (alloc.nil())
@@ -198,7 +200,7 @@ where
                 .append(alloc.space())
                 .append(from_term_prec(alloc, body_type, Prec::Arrow)),
         ),
-        Term::FunctionElim(head, arguments) => paren(
+        TermData::FunctionElim(head, arguments) => paren(
             alloc,
             prec > Prec::App,
             from_term_prec(alloc, head, Prec::Atomic).append(
@@ -210,8 +212,8 @@ where
                     .nest(4),
             ),
         ),
-        Term::NumberLiteral(_, literal) => alloc.as_string(literal),
-        Term::If(_, head, if_true, if_false) => (alloc.nil())
+        TermData::NumberLiteral(literal) => alloc.as_string(literal),
+        TermData::If(head, if_true, if_false) => (alloc.nil())
             .append("if")
             .append(alloc.space())
             .append(from_term_prec(alloc, head, Prec::Term))
@@ -244,7 +246,7 @@ where
             )
             .append(alloc.space())
             .append("}"),
-        Term::Match(_, head, branches) => (alloc.nil())
+        TermData::Match(head, branches) => (alloc.nil())
             .append("match")
             .append(alloc.space())
             .append(from_term_prec(alloc, head, Prec::Term))
@@ -271,8 +273,9 @@ where
             })))
             .append(alloc.hardline())
             .append("}"),
-        Term::FormatType(_) => alloc.text("Format"),
-        Term::Error(_) => alloc.text("!"),
+        TermData::FormatType => alloc.text("Format"),
+
+        TermData::Error => alloc.text("!"),
     }
 }
 

--- a/tests/input/alias/pass_format_array.rs
+++ b/tests/input/alias/pass_format_array.rs
@@ -16,7 +16,7 @@ fn eof_inner() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"SimpleFormatArray") {
+    match read_context.read_item(&FIXTURE, &"SimpleFormatArray") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -39,8 +39,9 @@ fn valid_test() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let simple_array =
-        binary::read::from_module_item(&mut read_context, &FIXTURE, &"SimpleFormatArray").unwrap();
+    let simple_array = read_context
+        .read_item(&FIXTURE, &"SimpleFormatArray")
+        .unwrap();
     assert_eq!(
         simple_array,
         binary::Term::Seq(vec![
@@ -70,7 +71,7 @@ fn invalid_test_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"SimpleFormatArray") {
+    match read_context.read_item(&FIXTURE, &"SimpleFormatArray") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -94,8 +95,9 @@ fn valid_test_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let simple_array =
-        binary::read::from_module_item(&mut read_context, &FIXTURE, &"SimpleFormatArray").unwrap();
+    let simple_array = read_context
+        .read_item(&FIXTURE, &"SimpleFormatArray")
+        .unwrap();
     assert_eq!(
         simple_array,
         binary::Term::Seq(vec![

--- a/tests/input/alias/pass_if_else_format_type.rs
+++ b/tests/input/alias/pass_if_else_format_type.rs
@@ -16,7 +16,7 @@ fn eof_inner() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test") {
+    match read_context.read_item(&FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -34,7 +34,7 @@ fn valid_test() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(23.64e10));
 
     // TODO: Check remaining
@@ -50,7 +50,7 @@ fn valid_test_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(781.453298));
 
     // TODO: Check remaining

--- a/tests/input/alias/pass_if_else_format_type_item.rs
+++ b/tests/input/alias/pass_if_else_format_type_item.rs
@@ -16,7 +16,7 @@ fn eof_inner() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test") {
+    match read_context.read_item(&FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -34,7 +34,7 @@ fn valid_test() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(23.64e10));
 
     // TODO: Check remaining
@@ -50,7 +50,7 @@ fn valid_test_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(781.453298));
 
     // TODO: Check remaining

--- a/tests/input/alias/pass_match_int_format_type.rs
+++ b/tests/input/alias/pass_match_int_format_type.rs
@@ -16,7 +16,7 @@ fn eof_inner() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test") {
+    match read_context.read_item(&FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -34,7 +34,7 @@ fn valid_test() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(23.64e10));
 
     // TODO: Check remaining
@@ -50,7 +50,7 @@ fn valid_test_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(781.453298));
 
     // TODO: Check remaining

--- a/tests/input/alias/pass_match_int_format_type_item.rs
+++ b/tests/input/alias/pass_match_int_format_type_item.rs
@@ -16,7 +16,7 @@ fn eof_inner() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test") {
+    match read_context.read_item(&FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -34,7 +34,7 @@ fn valid_test() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(23.64e10));
 
     // TODO: Check remaining
@@ -50,7 +50,7 @@ fn valid_test_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let test = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
+    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
     assert_eq!(test, binary::Term::F64(781.453298));
 
     // TODO: Check remaining

--- a/tests/input/alias/pass_simple.rs
+++ b/tests/input/alias/pass_simple.rs
@@ -13,7 +13,7 @@ fn eof_inner() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Byte") {
+    match read_context.read_item(&FIXTURE, &"Byte") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -31,7 +31,7 @@ fn valid_singleton() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let byte = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Byte").unwrap();
+    let byte = read_context.read_item(&FIXTURE, &"Byte").unwrap();
 
     assert_eq!(byte, binary::Term::int(31));
 
@@ -48,7 +48,7 @@ fn valid_singleton_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    let byte = binary::read::from_module_item(&mut read_context, &FIXTURE, &"Byte").unwrap();
+    let byte = read_context.read_item(&FIXTURE, &"Byte").unwrap();
 
     assert_eq!(byte, binary::Term::int(255));
 

--- a/tests/input/struct/pass_empty.rs
+++ b/tests/input/struct/pass_empty.rs
@@ -15,7 +15,7 @@ fn valid_empty() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, "Empty").unwrap() {
+    match read_context.read_item(&FIXTURE, "Empty").unwrap() {
         binary::Term::Struct(fields) => {
             assert_eq!(fields, BTreeMap::from_iter(vec![]));
         }
@@ -34,7 +34,7 @@ fn valid_empty_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, "Empty").unwrap() {
+    match read_context.read_item(&FIXTURE, "Empty").unwrap() {
         binary::Term::Struct(fields) => {
             assert_eq!(fields, BTreeMap::from_iter(vec![]));
         }

--- a/tests/input/struct/pass_pair.rs
+++ b/tests/input/struct/pass_pair.rs
@@ -15,7 +15,7 @@ fn eof_first() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Pair") {
+    match read_context.read_item(&FIXTURE, &"Pair") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,7 +33,7 @@ fn eof_second() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Pair") {
+    match read_context.read_item(&FIXTURE, &"Pair") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -52,7 +52,7 @@ fn valid_pair() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Pair").unwrap() {
+    match read_context.read_item(&FIXTURE, &"Pair").unwrap() {
         binary::Term::Struct(fields) => {
             assert_eq!(
                 fields,
@@ -79,7 +79,7 @@ fn valid_pair_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Pair").unwrap() {
+    match read_context.read_item(&FIXTURE, &"Pair").unwrap() {
         binary::Term::Struct(fields) => {
             assert_eq!(
                 fields,

--- a/tests/input/struct/pass_singleton.rs
+++ b/tests/input/struct/pass_singleton.rs
@@ -15,7 +15,7 @@ fn eof_inner() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Byte") {
+    match read_context.read_item(&FIXTURE, &"Byte") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,7 +33,7 @@ fn valid_singleton() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Byte").unwrap() {
+    match read_context.read_item(&FIXTURE, &"Byte").unwrap() {
         binary::Term::Struct(fields) => {
             assert_eq!(
                 fields,
@@ -56,7 +56,7 @@ fn valid_singleton_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match binary::read::from_module_item(&mut read_context, &FIXTURE, &"Byte").unwrap() {
+    match read_context.read_item(&FIXTURE, &"Byte").unwrap() {
         binary::Term::Struct(fields) => {
             assert_eq!(
                 fields,


### PR DESCRIPTION
Over the past few months I've learned even more about implementing languages thanks to my ongoing work on [pikelet's 'next' branch](https://github.com/pikelet-lang/pikelet/tree/next). Having them side-by-side makes it clear that Fathom needs a bit of TLC. Hoping to do this before @toothbrush and I get too stuck into collaborating, which might make changing this stuff a bit more challenging.