### PR TITLE
Fix a few documentation typos

### DIFF
--- a/book/src/background.md
+++ b/book/src/background.md
@@ -72,10 +72,10 @@ such as file formats, network protocols or bitstreams.
   a nice graphvis output, and a nice web-based IDE. It lacks a formal foundation however,
   and YAML can be hard to read.
 - [IPADS/DDC](https://www.cs.princeton.edu/~dpw/papers/700popl06.pdf):
-  We like the IPADS/DDC approach, but it is geard more towards log files and misses features like pointer offsets
+  We like the IPADS/DDC approach, but it is geared more towards log files and misses features like pointer offsets
   which are needed to support many binary formats.
 - [Restructure](https://github.com/devongovett/restructure):
-  A library for declaratively encode and decode binary data using a JavaScript EDSL.
+  A library for declaratively encoding and decoding binary data using a JavaScript EDSL.
   Used in [fontkit](https://github.com/devongovett/fontkit) for describing the Open Type Font specification.
   Shows promise as nice way to describe binary formats, but JS is not the most flexible host language.
 - [HarfBuzz](https://github.com/harfbuzz/harfbuzz) defines [a handy set of types and macros](https://github.com/harfbuzz/harfbuzz/blob/35218c488c3966aa6d459ec5a007a2b43208e97c/src/hb-machinery.hh)
@@ -85,5 +85,5 @@ such as file formats, network protocols or bitstreams.
 - [Nom](https://github.com/Geal/nom):
   A Rust parser combinator library geared towards describing binary formats.
   It is fast and zero copy, but we believe that the combinator approach has drawbacks to do with
-  being to tied to a single host language for specifications,
-  and a tied to a single operational semantics.
+  being too tied to a single host language for specifications,
+  and tied to a single operational semantics.

--- a/book/src/implementation/contributing.md
+++ b/book/src/implementation/contributing.md
@@ -68,11 +68,11 @@ no matter your experience with type theory and programming language research.
 
 Optionally you might be interested in some of the academic research we base our work on.
 These can be found in the [background reading][background].
-Our approach is very inspired those described in
-“The next 700 hundred data description languages” and “The power of pi”,
+Our approach is very inspired by those described in
+“The next 700 data description languages” and “The power of pi”,
 so you might want to start with those first!
 
-If are new to reading programming language papers,
+If you are new to reading programming language papers,
 Jeremy Siek's [Crash Course on Notation in Programming Language Theory][crash-couse] can be a big help.
 Also feel free to reach out to us on [Matrix](#matrix-room) for assistance!
 

--- a/book/src/reference/format-descriptions.md
+++ b/book/src/reference/format-descriptions.md
@@ -103,7 +103,7 @@ These are encoded following the [IEEE Standard for Floating-Point Arithmetic
 
 ### Array formats
 
-An fixed-length array of a single format can be described using the `FormatArray` format:
+A fixed-length array of a single format can be described using the `FormatArray` format:
 
 ```fathom
 FormatArray : Int -> Format -> Format

--- a/book/src/reference/sorts.md
+++ b/book/src/reference/sorts.md
@@ -6,7 +6,7 @@ Fathom has two sorts, `Type` and `Kind`, with a single axiom:
 Type : Kind
 ```
 
-`Kind` has no type, so is may only ever appear in type annotations.
+`Kind` has no type, so it may only ever appear in type annotations.
 For example it cannot be used in top-level definitions:
 
 ```fathom

--- a/book/src/specification/textual-representation/concrete-syntax.md
+++ b/book/src/specification/textual-representation/concrete-syntax.md
@@ -47,7 +47,7 @@ struct Point3 {
 }
 ```
 
-Structures are composite types that are have a name and a list of fields. The
+Structures are composite types that have a name and a list of fields. The
 fields within a structure must have unique names.
 
 > <sub>Grammar:</sub>


### PR DESCRIPTION
These were discovered after a quick scan-through of the docs.