### PR TITLE
Rename format_elim to format_repr in makam spec

### DIFF
--- a/experiments/makam-spec/src/lang/core/base.makam
+++ b/experiments/makam-spec/src/lang/core/base.makam
@@ -63,7 +63,7 @@ format_intro_array : term -> term -> term.
 format_intro_record : list (string * term) -> term.
 format_intro_compute : term -> term -> term.
 format_intro_absorb : term -> term.
-format_elim : term -> term.
+format_repr : term -> term.     % Convert a format description into its host representation
 
 
 % Items

--- a/experiments/makam-spec/src/lang/core/semantics.makam
+++ b/experiments/makam-spec/src/lang/core/semantics.makam
@@ -95,7 +95,7 @@
     enum_elim : choice_closure -> stuck -> stuck.
     %  stage_elim : stuck -> stuck.
     %  array_elim : stuck -> value -> stuck.
-    format_elim : stuck -> stuck.
+    format_repr : stuck -> stuck.   % Convert a format description into its host representation
 
     closure : list value -> term -> closure.
     field_closure : list value -> list (string * term) -> field_closure.
@@ -112,7 +112,7 @@
     record_elim : value -> string -> value -> prop.
     %  stage_elim : value -> value -> prop.
     %  array_elim : value -> value -> stuck.
-    format_elim : value -> value -> prop.
+    format_repr : value -> value -> prop.
 
     eval Values (local Index) Value :-
         list.nth Values Index Value.
@@ -180,9 +180,9 @@
         eval Values Type Type'.
     eval Values (format_intro_absorb Type) (format_intro_absorb Type') :-
         eval Values Type Type'.
-    eval Values (format_elim Elem) Value' :-
+    eval Values (format_repr Elem) Value' :-
         eval Values Elem Value,
-        format_elim Value Value'.
+        format_repr Value Value'.
 
     % Closure operations
 
@@ -208,32 +208,32 @@
 
     % TODO: stage_elim
 
-    format_elim (stuck Neutral) (stuck (format_elim Neutral)).
-    format_elim format_intro_void (enum_type []).
-    format_elim format_intro_unit (record_type (field_closure [] [])).
-    format_elim format_intro_u8 int_type.
-    format_elim format_intro_u16le int_type.
-    format_elim format_intro_u16be int_type.
-    format_elim format_intro_u32le int_type.
-    format_elim format_intro_u32be int_type.
-    format_elim format_intro_u64le int_type.
-    format_elim format_intro_u64be int_type.
-    format_elim format_intro_s8 int_type.
-    format_elim format_intro_s16le int_type.
-    format_elim format_intro_s16be int_type.
-    format_elim format_intro_s32le int_type.
-    format_elim format_intro_s32be int_type.
-    format_elim format_intro_s64le int_type.
-    format_elim format_intro_s64be int_type.
-    format_elim (format_intro_array Elem Len) (array_type Elem' Len) :-
-        format_elim Elem Elem'.
-    format_elim
+    format_repr (stuck Neutral) (stuck (format_repr Neutral)).
+    format_repr format_intro_void (enum_type []).
+    format_repr format_intro_unit (record_type (field_closure [] [])).
+    format_repr format_intro_u8 int_type.
+    format_repr format_intro_u16le int_type.
+    format_repr format_intro_u16be int_type.
+    format_repr format_intro_u32le int_type.
+    format_repr format_intro_u32be int_type.
+    format_repr format_intro_u64le int_type.
+    format_repr format_intro_u64be int_type.
+    format_repr format_intro_s8 int_type.
+    format_repr format_intro_s16le int_type.
+    format_repr format_intro_s16be int_type.
+    format_repr format_intro_s32le int_type.
+    format_repr format_intro_s32be int_type.
+    format_repr format_intro_s64le int_type.
+    format_repr format_intro_s64be int_type.
+    format_repr (format_intro_array Elem Len) (array_type Elem' Len) :-
+        format_repr Elem Elem'.
+    format_repr
         (format_intro_record (field_closure Values TypeFields))
         (record_type (field_closure Values TypeFields'))
     :-
-        map (pfun ( Label, Elem ) ( Label, format_elim Elem ) => success) TypeFields TypeFields'.
-    format_elim (format_intro_compute Elem Type) Type.
-    format_elim (format_intro_absorb Type) (record_type (field_closure [] [])).
+        map (pfun ( Label, Elem ) ( Label, format_repr Elem ) => success) TypeFields TypeFields'.
+    format_repr (format_intro_compute Elem Type) Type.
+    format_repr (format_intro_absorb Type) (record_type (field_closure [] [])).
 
 
     % Find the type of a field in a record elimination, based on the given
@@ -274,7 +274,7 @@
         plus Length 1 Length1,
         readback Length1 OutputType' OutputType'',
         readback Length Neutral Elem.
-    readback Length (format_elim Neutral : stuck) (format_elim Elem) :-
+    readback Length (format_repr Neutral : stuck) (format_repr Elem) :-
         readback Length Neutral Elem.
 
     readback Length (stuck Neutral) Elem :-
@@ -398,7 +398,7 @@
         eval (stuck (local Length) :: Values2) OutputType2 OutputType2',
         is_equal Length OutputType1' OutputType2',
         is_equal Length Neutral1 Neutral2.
-    is_equal Length (format_elim Neutral1 : stuck) (format_elim Neutral2 : stuck) :-
+    is_equal Length (format_repr Neutral1 : stuck) (format_repr Neutral2 : stuck) :-
         is_equal Length Neutral1 Neutral2.
 
     is_equal Length (stuck Neutral1) (stuck Neutral2) :-

--- a/experiments/makam-spec/src/lang/core/typing.makam
+++ b/experiments/makam-spec/src/lang/core/typing.makam
@@ -217,7 +217,7 @@
     synth_type Context (format_intro_record (( Label, Type ) :: TypeFields)) format_type :-
         not (contains ( Label, _ ) TypeFields),
         check_type Context Type format_type,
-        context.eval Context (format_elim Type) Type',
+        context.eval Context (format_repr Type) Type',
         context.add_param Context Type' Context',
         check_type Context' (format_intro_record TypeFields) format_type.
     synth_type Context (format_intro_compute Elem Type) format_type :-
@@ -226,7 +226,7 @@
         check_type Context Elem Type'.
     synth_type Context (format_intro_absorb Type) format_type :-
         check_type Context Type format_type.
-    synth_type Context (format_elim Type) type_type :-
+    synth_type Context (format_repr Type) type_type :-
         check_type Context Type format_type.
 
 

--- a/experiments/makam-spec/src/lang/stratified.makam
+++ b/experiments/makam-spec/src/lang/stratified.makam
@@ -111,7 +111,7 @@
     format_intro_record : list (string * term1) -> term1.
     format_intro_compute : term0 -> term1 -> term1.
     format_intro_absorb : term1 -> term1.
-    format_elim : term1 -> term2.
+    format_repr : term1 -> term2.               % Convert a format description into its host representation
 
 
     % The computation language.

--- a/experiments/makam-spec/src/pass/core_to_stratified.makam
+++ b/experiments/makam-spec/src/pass/core_to_stratified.makam
@@ -168,7 +168,7 @@
         (term1 (stratified.format_intro_absorb TargetType))
     :-
         from_term Context SourceType (term1 TargetType).
-    from_term Context (core.format_elim SourceType) (term2 (stratified.format_elim TargetType)) :-
+    from_term Context (core.format_repr SourceType) (term2 (stratified.format_repr TargetType)) :-
         from_term Context SourceType (term1 TargetType).
 
 

--- a/experiments/makam-spec/src/pass/surface_to_core.makam
+++ b/experiments/makam-spec/src/pass/surface_to_core.makam
@@ -102,6 +102,10 @@
         (core.function_intro core.format_type
             (core.function_intro core.int_type
                 (core.format_intro_array (core.local 1) (core.local 0)))).
+    lookup_global "Repr"
+        (core.function_type core.format_type core.type_type)
+        (core.function_intro core.format_type
+            (core.format_repr (core.local 0))).
 
 
     % Elaboration rules
@@ -200,7 +204,7 @@
     :-
         not (contains ( Label, _ ) SourceTypeFields),
         check_type Context SourceType format_type TargetType,
-        context.eval Context (core.format_elim TargetType) TargetType',
+        context.eval Context (core.format_repr TargetType) TargetType',
         context.add_param Context ( some Label, TargetType' ) Context',
         check_type Context' (surface.record_type SourceTypeFields) format_type
             (core.format_intro_record TargetTypeFields).

--- a/experiments/makam-spec/src/pass/surface_to_core.makam
+++ b/experiments/makam-spec/src/pass/surface_to_core.makam
@@ -71,8 +71,8 @@
     % Globals
 
     lookup_global : string -> core.term -> core.term -> prop.
+
     lookup_global "Type" core.kind_type core.type_type. % NOTE: Follows from the PTS axioms
-    lookup_global "Format" core.kind_type core.format_type.
     lookup_global "Int" core.type_type core.int_type.
     lookup_global "Array"
         (core.function_type core.type_type
@@ -80,12 +80,8 @@
         (core.function_intro core.type_type
             (core.function_intro core.int_type
                 (core.array_type (core.local 1) (core.local 0)))).
-    lookup_global "FormatArray"
-        (core.function_type core.format_type
-            (core.function_type core.int_type core.format_type))
-        (core.function_intro core.format_type
-            (core.function_intro core.int_type
-                (core.format_intro_array (core.local 1) (core.local 0)))).
+
+    lookup_global "Format" core.kind_type core.format_type.
     lookup_global "U8" core.format_type core.format_intro_u8.
     lookup_global "U16Le" core.format_type core.format_intro_u16le.
     lookup_global "U16Be" core.format_type core.format_intro_u16be.
@@ -100,6 +96,12 @@
     lookup_global "S32Be" core.format_type core.format_intro_s32be.
     lookup_global "S64Le" core.format_type core.format_intro_s64le.
     lookup_global "S64Be" core.format_type core.format_intro_s64be.
+    lookup_global "FormatArray"
+        (core.function_type core.format_type
+            (core.function_type core.int_type core.format_type))
+        (core.function_intro core.format_type
+            (core.function_intro core.int_type
+                (core.format_intro_array (core.local 1) (core.local 0)))).
 
 
     % Elaboration rules

--- a/experiments/makam-spec/test/lang/core/semantics.makam
+++ b/experiments/makam-spec/test/lang/core/semantics.makam
@@ -317,36 +317,36 @@
 >> Yes:
 >> Term := format_intro_absorb format_intro_u8.
 
->> normalize [ stuck (local 0) ] (format_elim (local 0)) Term ?
+>> normalize [ stuck (local 0) ] (format_repr (local 0)) Term ?
 >> Yes:
->> Term := format_elim (local 0).
+>> Term := format_repr (local 0).
 
->> normalize (format_elim format_intro_void) Term ?
+>> normalize (format_repr format_intro_void) Term ?
 >> Yes:
 >> Term := enum_type [].
 
->> normalize (format_elim format_intro_unit) Term ?
+>> normalize (format_repr format_intro_unit) Term ?
 >> Yes:
 >> Term := record_type [].
 
->> normalize (format_elim format_intro_u8) Term ?
+>> normalize (format_repr format_intro_u8) Term ?
 >> Yes:
 >> Term := int_type.
 
->> normalize (format_elim (format_intro_array format_intro_u8 (int_intro 3))) Term ?
+>> normalize (format_repr (format_intro_array format_intro_u8 (int_intro 3))) Term ?
 >> Yes:
 >> Term := array_type int_type (int_intro 3).
 
->> normalize (format_elim (format_intro_array format_intro_u8 (int_intro 3))) Term ?
+>> normalize (format_repr (format_intro_array format_intro_u8 (int_intro 3))) Term ?
 >> Yes:
 >> Term := array_type int_type (int_intro 3).
 
->> normalize (format_elim (format_intro_record [])) Term ?
+>> normalize (format_repr (format_intro_record [])) Term ?
 >> Yes:
 >> Term := record_type [].
 
 >> normalize [ format_intro_u16be, format_intro_unit ]
-    (format_elim
+    (format_repr
         (format_intro_record
             [ ( "len", local 0 )
             , ( "data", format_intro_array (local 2) (local 0) )
@@ -360,13 +360,13 @@
         ].
 
 >> normalize [ int_type ]
-    (format_elim (format_intro_compute (int_intro 2) (local 0)))
+    (format_repr (format_intro_compute (int_intro 2) (local 0)))
     Term ?
 >> Yes:
 >> Term := int_type.
 
 >> normalize [ format_intro_u8 ]
-    (format_elim (format_intro_absorb (local 0)))
+    (format_repr (format_intro_absorb (local 0)))
     Term ?
 >> Yes:
 >> Term := record_type [].

--- a/experiments/makam-spec/test/lang/core/typing.makam
+++ b/experiments/makam-spec/test/lang/core/typing.makam
@@ -447,7 +447,7 @@
 >> Yes:
 >> Type := format_type.
 
->> synth_type (format_elim (format_intro_array format_intro_u8 (int_intro 3))) Type ?
+>> synth_type (format_repr (format_intro_array format_intro_u8 (int_intro 3))) Type ?
 >> Yes:
 >> Type := type_type.
 

--- a/experiments/makam-spec/test/pass/surface_to_core.makam
+++ b/experiments/makam-spec/test/pass/surface_to_core.makam
@@ -16,6 +16,16 @@
 >> Type := kind_type.
 >> Elem := core.type_type.
 
+>> synth_type (surface.name "Array") Type Elem ?
+>> Yes:
+>> Type :=
+    function_type type_type
+        (closure [] (core.function_type core.int_type core.type_type)).
+>> Elem :=
+    core.function_intro core.type_type
+            (core.function_intro core.int_type
+                (core.array_type (core.local 1) (core.local 0))).
+
 >> synth_type (surface.name "Format") Type Elem ?
 >> Yes:
 >> Type := kind_type.
@@ -34,16 +44,6 @@
     (surface.name "Bap")
     Type Elem ?
 >> Impossible.
-
->> synth_type (surface.name "Array") Type Elem ?
->> Yes:
->> Type :=
-    function_type type_type
-        (closure [] (core.function_type core.int_type core.type_type)).
->> Elem :=
-    core.function_intro core.type_type
-            (core.function_intro core.int_type
-                (core.array_type (core.local 1) (core.local 0))).
 
 
     % Annotated terms

--- a/experiments/makam-spec/test/pass/surface_to_core.makam
+++ b/experiments/makam-spec/test/pass/surface_to_core.makam
@@ -23,13 +23,20 @@
         (closure [] (core.function_type core.int_type core.type_type)).
 >> Elem :=
     core.function_intro core.type_type
-            (core.function_intro core.int_type
-                (core.array_type (core.local 1) (core.local 0))).
+        (core.function_intro core.int_type
+            (core.array_type (core.local 1) (core.local 0))).
 
 >> synth_type (surface.name "Format") Type Elem ?
 >> Yes:
 >> Type := kind_type.
 >> Elem := core.format_type.
+
+>> synth_type (surface.name "Repr") Type Elem ?
+>> Yes:
+>> Type := function_type format_type (closure [] core.type_type).
+>> Elem :=
+    core.function_intro core.format_type
+        (core.format_repr (core.local 0)).
 
 >> synth_type
     (context [ ( some "Boop", Level, _, format_type ) ])
@@ -294,6 +301,19 @@
                         (core.format_intro_array (core.local 1) (core.local 0))))
             core.format_intro_u32be)
         (core.int_intro 23).
+
+>> synth_type
+    (surface.function_elim (surface.name "Repr")
+        [ surface.name "U32Be"
+        ])
+    Type Elem ?
+>> Yes:
+>> Type := type_type.
+>> Elem :=
+    core.function_elim
+        (core.function_intro core.format_type
+            (core.format_repr (core.local 0)))
+        core.format_intro_u32be.
 
 
     % Records


### PR DESCRIPTION
This probably makes this a tad clearer, because you’d most likely expect `format_elim` to be doing induction over format descriptions, where as it's more a builtin function that does this induction over format descriptions internally.