### PR TITLE
First cut of laying out options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     './fathom',
+    './fathom-cli',
     './fathom-runtime',
     './fathom-test',
     './fathom-test-util',

--- a/fathom-cli/Cargo.toml
+++ b/fathom-cli/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fathom-cli"
+version = "0.1.0"
+authors = ["YesLogic Pty. Ltd. <info@yeslogic.com>"]
+edition = "2018"
+publish = false # TODO: Remove this when we are ready to publish to crates.io
+
+description = "CLI interface for Fathom"
+license = "Apache-2.0"
+
+[dependencies]
+structopt = { version = "0.3" }

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -5,7 +5,7 @@ use structopt::{clap::ArgGroup, StructOpt};
 
 /// Fathom DDL interpreter to provide tools to inspect and query binary files.
 #[derive(StructOpt, Debug)]
-#[structopt(group = ArgGroup::with_name("format_choice").required(false))]
+#[structopt(group = ArgGroup::with_name("format_choice"))]
 pub struct Cli {
     /// --format=NAME is an optional argument for specifying the name
     /// of the format description in the installed catalog, for

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+use std::vec::Vec;
+use structopt::StructOpt;
+
+/// Fathom DDL interpreter to provide tools to inspect and query binary files.
+#[derive(StructOpt, Debug)]
+pub struct Cli {
+    /// The pattern to look for
+    pattern: String,
+    /// The path to the file(s) to parse
+    #[structopt(parse(from_os_str))]
+    files: Vec<PathBuf>,
+}

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -18,6 +18,27 @@ pub struct Cli {
     /// will be used to process the files.
     #[structopt(long, group = "format_choice")]
     format_file: Option<PathBuf>,
+    // Output options, optional:
+    /// Prints a brief summary of each file based on the format
+    /// description. This may include printing the type or version or
+    /// other important details about the file but may not validate
+    /// the entire file contents.
+    #[structopt(long)]
+    summary: bool,
+    /// Prints a textual representation of the complete contents of
+    /// each file as described by the format description. This will
+    /// also validate the entire file against the format description
+    /// and warn of any discrepancies.
+    #[structopt(long)]
+    dump: bool,
+    /// Print the results of applying the specified format query to
+    /// each input file.
+    #[structopt(long)]
+    query: Option<String>,
+    /// Read a query from file and print the results of applying the
+    /// format query to each input file.
+    #[structopt(long)]
+    query_file: Option<PathBuf>,
     // The (binary) input files to operate on:
     /// The path to the file(s) to parse
     #[structopt(parse(from_os_str))]

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -7,15 +7,15 @@ use structopt::{clap::ArgGroup, StructOpt};
 #[derive(StructOpt, Debug)]
 #[structopt(group = ArgGroup::with_name("format_choice"))]
 pub struct Cli {
-    /// --format=NAME is an optional argument for specifying the name
-    /// of the format description in the installed catalog, for
-    /// example "opentype", that will be used to process the files.
+    // Format choice, optional:
+    /// Optional argument for specifying the name of the format
+    /// description in the installed catalog, for example "opentype",
+    /// that will be used to process the files.
     #[structopt(long, group = "format_choice")]
     format: Option<String>,
-    /// --format-file=FILE is an optional argument for specifying the
-    /// file containing the format description, for example
-    /// "path/to/myformat.ddl", that will be used to process the
-    /// files.
+    /// Optional argument for specifying the file containing the
+    /// format description, for example "path/to/myformat.ddl", that
+    /// will be used to process the files.
     #[structopt(long, group = "format_choice")]
     format_file: Option<PathBuf>,
     // The (binary) input files to operate on:

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -5,7 +5,7 @@ use structopt::{clap::ArgGroup, StructOpt};
 
 /// Fathom DDL interpreter to provide tools to inspect and query binary files.
 #[derive(StructOpt, Debug)]
-#[structopt(group = ArgGroup::with_name("format_choice"))]
+#[structopt(group = ArgGroup::with_name("format_choice"), after_help = "If no output option is specified it defaults to --summary.")]
 pub struct Cli {
     // Format choice, optional:
     /// Optional argument for specifying the name of the format

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -5,8 +5,17 @@ use structopt::StructOpt;
 /// Fathom DDL interpreter to provide tools to inspect and query binary files.
 #[derive(StructOpt, Debug)]
 pub struct Cli {
-    /// The pattern to look for
-    pattern: String,
+    /// --format=NAME is an optional argument for specifying the name
+    /// of the format description in the installed catalog, for
+    /// example "opentype", that will be used to process the files.
+    #[structopt(long)]
+    format: String,
+    /// --format-file=FILE is an optional argument for specifying the
+    /// file containing the format description, for example
+    /// "path/to/myformat.ddl", that will be used to process the
+    /// files.
+    #[structopt(long)]
+    format_file: PathBuf,
     /// The path to the file(s) to parse
     #[structopt(parse(from_os_str))]
     files: Vec<PathBuf>,

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -11,12 +11,12 @@ pub struct Cli {
     /// Optional argument for specifying the name of the format
     /// description in the installed catalog, for example "opentype",
     /// that will be used to process the files.
-    #[structopt(long, group = "format_choice")]
+    #[structopt(long, group = "format_choice", name = "NAME")]
     format: Option<String>,
     /// Optional argument for specifying the file containing the
     /// format description, for example "path/to/myformat.ddl", that
     /// will be used to process the files.
-    #[structopt(long, group = "format_choice")]
+    #[structopt(long, group = "format_choice", name = "FORMAT-FILE")]
     format_file: Option<PathBuf>,
     // Output options, optional:
     /// Prints a brief summary of each file based on the format
@@ -33,11 +33,11 @@ pub struct Cli {
     dump: bool,
     /// Print the results of applying the specified format query to
     /// each input file.
-    #[structopt(long)]
+    #[structopt(long, name = "QUERY")]
     query: Option<String>,
     /// Read a query from file and print the results of applying the
     /// format query to each input file.
-    #[structopt(long)]
+    #[structopt(long, name = "QUERY-FILE")]
     query_file: Option<PathBuf>,
     // The (binary) input files to operate on:
     /// The path to the file(s) to parse

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -1,21 +1,23 @@
 use std::path::PathBuf;
 use std::vec::Vec;
-use structopt::StructOpt;
+
+use structopt::{clap::ArgGroup, StructOpt};
 
 /// Fathom DDL interpreter to provide tools to inspect and query binary files.
 #[derive(StructOpt, Debug)]
+#[structopt(group = ArgGroup::with_name("format_choice").required(false))]
 pub struct Cli {
     /// --format=NAME is an optional argument for specifying the name
     /// of the format description in the installed catalog, for
     /// example "opentype", that will be used to process the files.
-    #[structopt(long)]
-    format: String,
+    #[structopt(long, group = "format_choice")]
+    format: Option<String>,
     /// --format-file=FILE is an optional argument for specifying the
     /// file containing the format description, for example
     /// "path/to/myformat.ddl", that will be used to process the
     /// files.
-    #[structopt(long)]
-    format_file: PathBuf,
+    #[structopt(long, group = "format_choice")]
+    format_file: Option<PathBuf>,
     /// The path to the file(s) to parse
     #[structopt(parse(from_os_str))]
     files: Vec<PathBuf>,

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -18,6 +18,7 @@ pub struct Cli {
     /// files.
     #[structopt(long, group = "format_choice")]
     format_file: Option<PathBuf>,
+    // The (binary) input files to operate on:
     /// The path to the file(s) to parse
     #[structopt(parse(from_os_str))]
     files: Vec<PathBuf>,

--- a/fathom-cli/src/main.rs
+++ b/fathom-cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/fathom-cli/src/main.rs
+++ b/fathom-cli/src/main.rs
@@ -1,3 +1,10 @@
+use structopt::StructOpt;
+
+mod cli;
+
 fn main() {
+    let args = cli::Cli::from_args();
     println!("Hello, world!");
+
+    println!("debug: {:?}", args);
 }


### PR DESCRIPTION
I've grabbed the options as suggested in #239 by @mikeday, and put them into this simple configuration.  While the flags work pretty much as described in that issue, the output of `--help` leaves a lot to be desired and i'm not sure that [`structopt`](https://github.com/TeXitoi/structopt) actually can accommodate everything we want.

Things i'd still like to fix:

- Make it clear that `--format` and `--format-file` are mutually exclusive, instead of exploding if a user tries to specify both.
- Sensibly group the format- and output-related options in `--help`.  Currently they're just sorted alphabetically.

I don't want to waste too much time on this, i'll revisit it once this package has managed to integrate with `fathom` a little.