### PR TITLE
Remove editor workarounds

### DIFF
--- a/fathom/src/lang/core/lexer.rs
+++ b/fathom/src/lang/core/lexer.rs
@@ -15,7 +15,7 @@ pub enum Token<'source> {
     Name(&'source str),
     #[regex(r#"'([^'\\]|\\.)*'"#)]
     CharLiteral(&'source str),
-    #[regex(r#""([^"\\]|\\.)*""#)] // workaround editor highlighting: "
+    #[regex(r#""([^"\\]|\\.)*""#)]
     StringLiteral(&'source str),
     #[regex(r"[-+]?[0-9][a-zA-Z0-9_\.]*")]
     NumericLiteral(&'source str),

--- a/fathom/src/lang/surface/lexer.rs
+++ b/fathom/src/lang/surface/lexer.rs
@@ -15,7 +15,7 @@ pub enum Token<'source> {
     Name(&'source str),
     #[regex(r#"'([^'\\]|\\.)*'"#)]
     CharLiteral(&'source str),
-    #[regex(r#""([^"\\]|\\.)*""#)] // workaround editor highlighting: "
+    #[regex(r#""([^"\\]|\\.)*""#)]
     StringLiteral(&'source str),
     #[regex(r"[-+]?[0-9][a-zA-Z0-9_\.]*")]
     NumericLiteral(&'source str),


### PR DESCRIPTION
These [were fixed](https://github.com/rust-analyzer/rust-analyzer/pull/6248) in rust-analyzer’s new TextMate grammar.