### PR TITLE
Tree wrangling cleanups

### DIFF
--- a/fathom/src/lang.rs
+++ b/fathom/src/lang.rs
@@ -1,27 +1,46 @@
 //! Intermediate languages of the Fathom compiler.
 
-use std::ops::Range;
-
 pub mod surface;
 //       🠃
 pub mod core;
 //       🠃
 //      ...
 
+/// A range of source code.
+///
+/// This is added to simplify working with ranges, because [`std::ops::Range`]
+/// does not implement [`std::ops::Copy`].
+#[derive(Debug, Copy, Clone)]
+pub struct Range {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Into<std::ops::Range<usize>> for Range {
+    fn into(self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+}
+
+impl From<std::ops::Range<usize>> for Range {
+    fn from(src: std::ops::Range<usize>) -> Range {
+        Range {
+            start: src.start,
+            end: src.end,
+        }
+    }
+}
+
 /// Data that covers some range of source code.
 #[derive(Debug, Clone)]
 pub struct Ranged<Data> {
-    pub range: Range<usize>,
+    pub range: Range,
     pub data: Data,
 }
 
 impl<Data> Ranged<Data> {
-    pub fn new(range: Range<usize>, data: Data) -> Ranged<Data> {
+    pub fn new(range: Range, data: Data) -> Ranged<Data> {
         Ranged { range, data }
-    }
-
-    pub fn range(&self) -> Range<usize> {
-        self.range.clone()
     }
 }
 
@@ -37,6 +56,6 @@ impl<Data> From<Data> for Ranged<Data> {
     fn from(data: Data) -> Ranged<Data> {
         // TODO: Use a better marker for data that does not originate from to a
         // specific source location.
-        Ranged::new(0..0, data)
+        Ranged::new(Range::from(0..0), data)
     }
 }

--- a/fathom/src/lang/core/grammar.lalrpop
+++ b/fathom/src/lang/core/grammar.lalrpop
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::lang::Ranged;
+use crate::lang::{Range, Ranged};
 use crate::lang::core::{
     Constant, FieldDeclaration, FieldDefinition, ItemData, Module, Primitive, Sort, StructType,
     StructFormat, Term, TermData,
@@ -147,26 +147,26 @@ AtomicTermData: TermData = {
         let branches = branches
             .into_iter()
             .filter_map(|(start, literal, end, term)| Some((
-                literal::State::new(file_id, start..end, literal, messages).number_to_big_int()?,
+                literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_big_int()?,
                 Arc::new(term),
             ))).collect();
 
         TermData::IntElim(Arc::new(head), branches, Arc::new(default))
     },
     "int" <start: @L> <literal: "numeric literal"> <end: @R> => {
-        match literal::State::new(file_id, start..end, literal, messages).number_to_big_int() {
+        match literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_big_int() {
             Some(value) => TermData::Primitive(Primitive::Int(value)),
             None => TermData::Error,
         }
     },
     "f32" <start: @L> <literal: "numeric literal"> <end: @R> => {
-        match literal::State::new(file_id, start..end, literal, messages).number_to_float() {
+        match literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_float() {
             Some(value) => TermData::Primitive(Primitive::F32(value)),
             None => TermData::Error,
         }
     },
     "f64" <start: @L> <literal: "numeric literal"> <end: @R> => {
-        match literal::State::new(file_id, start..end, literal, messages).number_to_float() {
+        match literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_float() {
             Some(value) => TermData::Primitive(Primitive::F64(value)),
             None => TermData::Error,
         }
@@ -199,5 +199,5 @@ Name: String = {
 
 #[inline]
 Ranged<T>: Ranged<T> = {
-    <start: @L> <data: T> <end: @R> => Ranged::new(start..end, data),
+    <start: @L> <data: T> <end: @R> => Ranged::new(Range::from(start..end), data),
 };

--- a/fathom/src/lang/core/lexer.rs
+++ b/fathom/src/lang/core/lexer.rs
@@ -1,6 +1,7 @@
 use logos::Logos;
 use std::fmt;
 
+use crate::lang::Range;
 use crate::reporting::LexerMessage;
 
 /// Tokens in the core language.
@@ -132,7 +133,10 @@ pub fn tokens<'source>(
     Token::lexer(source)
         .spanned()
         .map(move |(token, range)| match token {
-            Token::Error => Err(LexerMessage::InvalidToken { file_id, range }),
+            Token::Error => Err(LexerMessage::InvalidToken {
+                file_id,
+                range: Range::from(range),
+            }),
             token => Ok((range.start, token, range.end)),
         })
 }

--- a/fathom/src/lang/core/typing.rs
+++ b/fathom/src/lang/core/typing.rs
@@ -4,13 +4,13 @@
 //! debugging purposes.
 
 use std::collections::HashMap;
-use std::ops::Range;
 use std::sync::Arc;
 
 use crate::lang::core::semantics::{self, Elim, Head, Value};
 use crate::lang::core::{
     Globals, Item, ItemData, Module, Primitive, Sort, StructType, Term, TermData,
 };
+use crate::lang::Range;
 use crate::reporting::{CoreTypingMessage, Message};
 
 /// Returns the sorts of sorts.
@@ -76,10 +76,10 @@ impl<'me> Context<'me> {
     fn force_item<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range<usize>, &'context ItemData, &'value [Elim])> {
+    ) -> Option<(Range, &'context ItemData, &'value [Elim])> {
         match value {
             Value::Stuck(Head::Item(name), elims) => match self.items.get(name) {
-                Some(item) => Some((item.range(), &item.data, elims)),
+                Some(item) => Some((item.range, &item.data, elims)),
                 None => panic!("could not find an item called `{}` in the context", name),
             },
             _ => None,
@@ -91,10 +91,10 @@ impl<'me> Context<'me> {
     fn force_struct_type<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range<usize>, &'context StructType, &'value [Elim])> {
+    ) -> Option<(Range, &'context StructType, &'value [Elim])> {
         match self.force_item(value) {
-            Some((ref range, ItemData::StructType(struct_type), elims)) => {
-                Some((range.clone(), struct_type, elims))
+            Some((range, ItemData::StructType(struct_type), elims)) => {
+                Some((range, struct_type, elims))
             }
             Some(_) | None => None,
         }
@@ -149,7 +149,7 @@ impl<'me> Context<'me> {
                             self.push_message(CoreTypingMessage::FieldRedeclaration {
                                 file_id,
                                 field_name: field.label.data.clone(),
-                                record_range: item.range(),
+                                record_range: item.range,
                             });
                         }
                     }
@@ -170,7 +170,7 @@ impl<'me> Context<'me> {
                             self.push_message(CoreTypingMessage::FieldRedeclaration {
                                 file_id,
                                 field_name: field.label.data.clone(),
-                                record_range: item.range(),
+                                record_range: item.range,
                             });
                         }
                     }
@@ -185,11 +185,11 @@ impl<'me> Context<'me> {
                     entry.insert(item.clone());
                 }
                 Entry::Occupied(entry) => {
-                    let original_range = entry.get().range();
+                    let original_range = entry.get().range;
                     self.push_message(CoreTypingMessage::ItemRedefinition {
                         file_id,
                         name: item_name,
-                        found_range: item.range(),
+                        found_range: item.range,
                         original_range,
                     });
                 }
@@ -208,7 +208,7 @@ impl<'me> Context<'me> {
             r#type => {
                 self.push_message(CoreTypingMessage::UniverseMismatch {
                     file_id,
-                    term_range: term.range(),
+                    term_range: term.range,
                     found_type: self.read_back(&r#type),
                 });
                 None
@@ -231,7 +231,7 @@ impl<'me> Context<'me> {
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
                             file_id,
-                            range: term.range(),
+                            range: term.range,
                             feature_name: "struct parameters",
                         });
                         return;
@@ -240,7 +240,7 @@ impl<'me> Context<'me> {
                         let expected_type = self.read_back(expected_type);
                         self.push_message(CoreTypingMessage::UnexpectedStructTerm {
                             file_id,
-                            term_range: term.range(),
+                            term_range: term.range,
                             expected_type,
                         });
                         return;
@@ -288,14 +288,14 @@ impl<'me> Context<'me> {
                 if !missing_labels.is_empty() {
                     self.push_message(CoreTypingMessage::MissingStructFields {
                         file_id,
-                        term_range: term.range(),
+                        term_range: term.range,
                         missing_labels,
                     });
                 }
                 if !unexpected_labels.is_empty() {
                     self.push_message(CoreTypingMessage::UnexpectedStructFields {
                         file_id,
-                        term_range: term.range(),
+                        term_range: term.range,
                         unexpected_labels,
                     });
                 }
@@ -320,7 +320,7 @@ impl<'me> Context<'me> {
                 found_type if self.is_equal(&found_type, expected_type) => {}
                 found_type => self.push_message(CoreTypingMessage::TypeMismatch {
                     file_id,
-                    term_range: term.range(),
+                    term_range: term.range,
                     expected_type: self.read_back(expected_type),
                     found_type: self.read_back(&found_type),
                 }),
@@ -337,7 +337,7 @@ impl<'me> Context<'me> {
                     self.push_message(CoreTypingMessage::GlobalNameNotFound {
                         file_id,
                         name: name.clone(),
-                        name_range: term.range(),
+                        name_range: term.range,
                     });
                     Arc::new(Value::Error)
                 }
@@ -348,7 +348,7 @@ impl<'me> Context<'me> {
                     self.push_message(CoreTypingMessage::ItemNameNotFound {
                         file_id,
                         name: name.clone(),
-                        name_range: term.range(),
+                        name_range: term.range,
                     });
                     Arc::new(Value::Error)
                 }
@@ -367,7 +367,7 @@ impl<'me> Context<'me> {
                 None => {
                     self.push_message(CoreTypingMessage::TermHasNoType {
                         file_id,
-                        term_range: term.range(),
+                        term_range: term.range,
                     });
                     Arc::new(Value::Error)
                 }
@@ -394,9 +394,9 @@ impl<'me> Context<'me> {
                     head_type => {
                         self.push_message(CoreTypingMessage::NotAFunction {
                             file_id,
-                            head_range: head.range(),
+                            head_range: head.range,
                             head_type: self.read_back(head_type),
-                            argument_range: argument.range(),
+                            argument_range: argument.range,
                         });
                         Arc::new(Value::Error)
                     }
@@ -406,7 +406,7 @@ impl<'me> Context<'me> {
             TermData::StructTerm(_) => {
                 self.push_message(CoreTypingMessage::AmbiguousStructTerm {
                     file_id,
-                    term_range: term.range(),
+                    term_range: term.range,
                 });
                 Arc::new(Value::Error)
             }
@@ -425,7 +425,7 @@ impl<'me> Context<'me> {
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
                             file_id,
-                            range: term.range.clone(),
+                            range: term.range,
                             feature_name: "struct parameters",
                         });
                         return Arc::new(Value::Error);
@@ -441,7 +441,7 @@ impl<'me> Context<'me> {
                         let head_type = self.read_back(&head_type);
                         self.push_message(CoreTypingMessage::FieldNotFound {
                             file_id,
-                            head_range: head.range(),
+                            head_range: head.range,
                             head_type,
                             label: label.clone(),
                         });
@@ -468,7 +468,7 @@ impl<'me> Context<'me> {
                 } else {
                     self.push_message(CoreTypingMessage::TypeMismatch {
                         file_id,
-                        term_range: if_false.range(),
+                        term_range: if_false.range,
                         expected_type: self.read_back(&if_true_type),
                         found_type: self.read_back(&if_false_type),
                     });
@@ -478,7 +478,7 @@ impl<'me> Context<'me> {
             TermData::IntElim(_, _, _) => {
                 self.push_message(CoreTypingMessage::AmbiguousIntElim {
                     file_id,
-                    term_range: term.range(),
+                    term_range: term.range,
                 });
                 Arc::new(Value::Error)
             }

--- a/fathom/src/lang/surface/grammar.lalrpop
+++ b/fathom/src/lang/surface/grammar.lalrpop
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::lang::Ranged;
+use crate::lang::{Range, Ranged};
 use crate::lang::surface::{
     Constant, FieldDeclaration, FieldDefinition, ItemData, Module, Pattern, PatternData, StructType,
     Term, TermData,
@@ -168,5 +168,5 @@ Name: String = {
 
 #[inline]
 Ranged<T>: Ranged<T> = {
-    <start: @L> <data: T> <end: @R> => Ranged::new(start..end, data),
+    <start: @L> <data: T> <end: @R> => Ranged::new(Range::from(start..end), data),
 };

--- a/fathom/src/lang/surface/lexer.rs
+++ b/fathom/src/lang/surface/lexer.rs
@@ -1,6 +1,7 @@
 use logos::Logos;
 use std::fmt;
 
+use crate::lang::Range;
 use crate::reporting::LexerMessage;
 
 /// Tokens in the surface language.
@@ -141,7 +142,10 @@ pub fn tokens<'source>(
     Token::lexer(source)
         .spanned()
         .map(move |(token, range)| match token {
-            Token::Error => Err(LexerMessage::InvalidToken { file_id, range }),
+            Token::Error => Err(LexerMessage::InvalidToken {
+                file_id,
+                range: Range::from(range),
+            }),
             token => Ok((range.start, token, range.end)),
         })
 }

--- a/fathom/src/literal.rs
+++ b/fathom/src/literal.rs
@@ -5,8 +5,8 @@
 use logos::Logos;
 use num_bigint::BigInt;
 use num_traits::Float;
-use std::ops::Range;
 
+use crate::lang::Range;
 use crate::reporting::LiteralParseMessage::*;
 use crate::reporting::Message;
 
@@ -101,7 +101,7 @@ enum Digit10 {
 /// Literal parser state.
 pub struct State<'source, 'messages> {
     file_id: usize,
-    range: Range<usize>,
+    range: Range,
     source: &'source str,
     messages: &'messages mut Vec<Message>,
 }
@@ -109,7 +109,7 @@ pub struct State<'source, 'messages> {
 impl<'source, 'messages> State<'source, 'messages> {
     pub fn new(
         file_id: usize,
-        range: Range<usize>,
+        range: Range,
         source: &'source str,
         messages: &'messages mut Vec<Message>,
     ) -> State<'source, 'messages> {
@@ -127,18 +127,13 @@ impl<'source, 'messages> State<'source, 'messages> {
         None
     }
 
-    /// The range of the entire literal.
-    fn range(&self) -> Range<usize> {
-        self.range.clone()
-    }
-
     /// Get the file-relative range of the current token.
-    fn token_range<Token>(&self, lexer: &logos::Lexer<'source, Token>) -> Range<usize>
+    fn token_range<Token>(&self, lexer: &logos::Lexer<'source, Token>) -> Range
     where
         Token: Logos<'source>,
     {
         let span = lexer.span();
-        (self.range.start + span.start)..(self.range.start + span.end)
+        Range::from((self.range.start + span.start)..(self.range.start + span.end))
     }
 
     /// Expect another token to be present in the lexer, reporting an error if not.
@@ -325,7 +320,7 @@ impl<'source, 'messages> State<'source, 'messages> {
 
             Some(float)
         } else {
-            self.report(UnsupportedFloatLiteralBase(file_id, self.range(), base))
+            self.report(UnsupportedFloatLiteralBase(file_id, self.range, base))
         }
     }
 

--- a/fathom/src/pass/surface_to_core.rs
+++ b/fathom/src/pass/surface_to_core.rs
@@ -11,12 +11,12 @@
 use num_bigint::BigInt;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::ops::Range;
 use std::sync::Arc;
 
 use crate::lang::core::semantics::{self, Elim, Head, Value};
 use crate::lang::core::{self, Sort};
 use crate::lang::surface::{ItemData, Module, Pattern, PatternData, StructType, Term, TermData};
+use crate::lang::Range;
 use crate::literal;
 use crate::pass::core_to_surface;
 use crate::reporting::{Message, SurfaceToCoreMessage};
@@ -66,10 +66,10 @@ impl<'me> Context<'me> {
     fn force_item<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range<usize>, &'context core::ItemData, &'value [Elim])> {
+    ) -> Option<(Range, &'context core::ItemData, &'value [Elim])> {
         match value {
             Value::Stuck(Head::Item(name), elims) => match self.items.get(name) {
-                Some(item) => Some((item.range(), &item.data, elims)),
+                Some(item) => Some((item.range, &item.data, elims)),
                 None => panic!("could not find an item called `{}` in the context", name),
             },
             _ => None,
@@ -81,10 +81,10 @@ impl<'me> Context<'me> {
     fn force_struct_type<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range<usize>, &'context core::StructType, &'value [Elim])> {
+    ) -> Option<(Range, &'context core::StructType, &'value [Elim])> {
         match self.force_item(value) {
-            Some((ref range, core::ItemData::StructType(struct_type), elims)) => {
-                Some((range.clone(), struct_type, elims))
+            Some((range, core::ItemData::StructType(struct_type), elims)) => {
+                Some((range, struct_type, elims))
             }
             Some(_) | None => None,
         }
@@ -156,7 +156,7 @@ impl<'me> Context<'me> {
                             let (core_type, _) = self.is_type(file_id, surface_type);
                             match &core_type.data {
                                 core::TermData::Error => (
-                                    core::Term::new(constant.term.range(), core::TermData::Error),
+                                    core::Term::new(constant.term.range, core::TermData::Error),
                                     Arc::new(Value::Error),
                                 ),
                                 _ => {
@@ -166,7 +166,7 @@ impl<'me> Context<'me> {
                                         Arc::new(core_type),
                                     );
 
-                                    (core::Term::new(constant.term.range(), term_data), r#type)
+                                    (core::Term::new(constant.term.range, term_data), r#type)
                                 }
                             }
                         }
@@ -186,7 +186,7 @@ impl<'me> Context<'me> {
                         self.push_message(SurfaceToCoreMessage::MissingStructAnnotation {
                             file_id,
                             name: struct_type.name.data.clone(),
-                            name_range: struct_type.name.range(),
+                            name_range: struct_type.name.range,
                         });
                         continue;
                     }
@@ -203,7 +203,7 @@ impl<'me> Context<'me> {
                                     file_id,
                                     name: struct_type.name.data.clone(),
                                     ann_type,
-                                    ann_range: core_type.range(),
+                                    ann_range: core_type.range,
                                 });
                                 continue;
                             }
@@ -217,17 +217,17 @@ impl<'me> Context<'me> {
             // FIXME: Avoid shadowing builtin definitions
             match self.items.entry(name.data.clone()) {
                 Entry::Vacant(entry) => {
-                    let core_item = core::Item::new(item.range(), item_data);
+                    let core_item = core::Item::new(item.range, item_data);
                     core_items.push(core_item.clone());
                     self.types.push((entry.key().clone(), r#type));
                     entry.insert(core_item);
                 }
                 Entry::Occupied(entry) => {
-                    let original_range = entry.get().range();
+                    let original_range = entry.get().range;
                     self.push_message(SurfaceToCoreMessage::ItemRedefinition {
                         file_id,
                         name: name.data.clone(),
-                        found_range: item.range.clone(),
+                        found_range: item.range,
                         original_range,
                     });
                 }
@@ -254,7 +254,7 @@ impl<'me> Context<'me> {
         let mut core_fields = Vec::with_capacity(struct_type.fields.len());
 
         for field in &struct_type.fields {
-            let field_range = field.label.range().start..field.term.range().end;
+            let field_range = Range::from(field.label.range.start..field.term.range.end);
             let format_type = Arc::new(Value::Sort(Sort::Type));
             let r#type = self.check_type(file_id, &field.term, &format_type);
 
@@ -273,7 +273,7 @@ impl<'me> Context<'me> {
                         file_id,
                         name: entry.key().clone(),
                         found_range: field_range,
-                        original_range: entry.get().clone(),
+                        original_range: *entry.get(),
                     });
                 }
             }
@@ -296,7 +296,7 @@ impl<'me> Context<'me> {
         let mut core_fields = Vec::with_capacity(struct_type.fields.len());
 
         for field in &struct_type.fields {
-            let field_range = field.label.range().start..field.term.range().end;
+            let field_range = Range::from(field.label.range.start..field.term.range.end);
             let format_type = Arc::new(Value::FormatType);
             let r#type = self.check_type(file_id, &field.term, &format_type);
 
@@ -315,7 +315,7 @@ impl<'me> Context<'me> {
                         file_id,
                         name: entry.key().clone(),
                         found_range: field_range,
-                        original_range: entry.get().clone(),
+                        original_range: *entry.get(),
                     });
                 }
             }
@@ -334,7 +334,7 @@ impl<'me> Context<'me> {
         file_id: usize,
         surface_term: &Term,
     ) -> (core::Term, Option<core::Sort>) {
-        let range = surface_term.range();
+        let range = surface_term.range;
 
         let (core_term, core_type) = self.synth_type(file_id, surface_term);
         match core_type.as_ref() {
@@ -344,7 +344,7 @@ impl<'me> Context<'me> {
                 let found_type = self.read_back_to_surface(core_type);
                 self.push_message(SurfaceToCoreMessage::UniverseMismatch {
                     file_id,
-                    term_range: range.clone(),
+                    term_range: range,
                     found_type,
                 });
                 (core::Term::new(range, core::TermData::Error), None)
@@ -360,7 +360,7 @@ impl<'me> Context<'me> {
         surface_term: &Term,
         expected_type: &Arc<Value>,
     ) -> core::Term {
-        let range = surface_term.range();
+        let range = surface_term.range;
 
         match (&surface_term.data, expected_type.as_ref()) {
             (TermData::Error, _) => core::Term::new(range, core::TermData::Error),
@@ -375,7 +375,7 @@ impl<'me> Context<'me> {
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
                             file_id,
-                            range: range.clone(),
+                            range: range,
                             feature_name: "struct parameters",
                         });
                         return core::Term::new(range, core::TermData::Error);
@@ -384,7 +384,7 @@ impl<'me> Context<'me> {
                         let expected_type = self.read_back_to_surface(expected_type);
                         self.push_message(SurfaceToCoreMessage::UnexpectedStructTerm {
                             file_id,
-                            term_range: range.clone(),
+                            term_range: range,
                             expected_type,
                         });
                         return core::Term::new(range, core::TermData::Error);
@@ -441,7 +441,7 @@ impl<'me> Context<'me> {
                     has_problems = true;
                     self.push_message(SurfaceToCoreMessage::MissingStructFields {
                         file_id,
-                        term_range: range.clone(),
+                        term_range: range,
                         missing_labels,
                     });
                 }
@@ -449,7 +449,7 @@ impl<'me> Context<'me> {
                     has_problems = true;
                     self.push_message(SurfaceToCoreMessage::UnexpectedStructFields {
                         file_id,
-                        term_range: range.clone(),
+                        term_range: range,
                         unexpected_labels,
                     });
                 }
@@ -461,8 +461,7 @@ impl<'me> Context<'me> {
             }
 
             (TermData::NumberLiteral(source), _) => {
-                let parse_state =
-                    literal::State::new(file_id, range.clone(), source, &mut self.messages);
+                let parse_state = literal::State::new(file_id, range, source, &mut self.messages);
                 let term_data = match expected_type.as_ref() {
                     // TODO: Lookup globals in environment
                     Value::Stuck(Head::Global(name), elims) if elims.is_empty() => {
@@ -484,7 +483,7 @@ impl<'me> Context<'me> {
                                 self.push_message(
                                     SurfaceToCoreMessage::NumericLiteralNotSupported {
                                         file_id,
-                                        literal_range: range.clone(),
+                                        literal_range: range,
                                         expected_type,
                                     },
                                 );
@@ -497,7 +496,7 @@ impl<'me> Context<'me> {
                         let expected_type = self.read_back_to_surface(expected_type);
                         self.push_message(SurfaceToCoreMessage::NumericLiteralNotSupported {
                             file_id,
-                            literal_range: range.clone(),
+                            literal_range: range,
                             expected_type,
                         });
                         core::TermData::Error
@@ -527,7 +526,7 @@ impl<'me> Context<'me> {
                             "Bool" => {
                                 self.push_message(Message::NotYetImplemented {
                                     file_id,
-                                    range: range.clone(),
+                                    range: range,
                                     feature_name: "boolean patterns",
                                 });
                                 core::TermData::Error
@@ -535,7 +534,7 @@ impl<'me> Context<'me> {
                             "Int" => {
                                 let (branches, default) = self.from_int_branches(
                                     file_id,
-                                    surface_head.range(),
+                                    surface_head.range,
                                     surface_branches,
                                     expected_type,
                                 );
@@ -545,7 +544,7 @@ impl<'me> Context<'me> {
                                 let found_type = self.read_back_to_surface(&head_type);
                                 self.push_message(SurfaceToCoreMessage::UnsupportedPatternType {
                                     file_id,
-                                    scrutinee_range: surface_head.range(),
+                                    scrutinee_range: surface_head.range,
                                     found_type,
                                 });
                                 core::TermData::Error
@@ -557,7 +556,7 @@ impl<'me> Context<'me> {
                         let found_type = self.read_back_to_surface(&head_type);
                         self.push_message(SurfaceToCoreMessage::UnsupportedPatternType {
                             file_id,
-                            scrutinee_range: surface_head.range(),
+                            scrutinee_range: surface_head.range,
                             found_type,
                         });
                         core::TermData::Error
@@ -574,7 +573,7 @@ impl<'me> Context<'me> {
                     let found_type = self.read_back_to_surface(&found_type);
                     self.push_message(SurfaceToCoreMessage::TypeMismatch {
                         file_id,
-                        term_range: range.clone(),
+                        term_range: range,
                         expected_type,
                         found_type,
                     });
@@ -586,8 +585,8 @@ impl<'me> Context<'me> {
 
     /// Synthesize the type of a surface term, and elaborate it into the core syntax.
     pub fn synth_type(&mut self, file_id: usize, surface_term: &Term) -> (core::Term, Arc<Value>) {
-        let range = surface_term.range();
-        let error_term = || core::Term::new(surface_term.range(), core::TermData::Error);
+        let range = surface_term.range;
+        let error_term = || core::Term::new(surface_term.range, core::TermData::Error);
 
         match &surface_term.data {
             TermData::Name(name) => {
@@ -603,7 +602,7 @@ impl<'me> Context<'me> {
                 self.push_message(SurfaceToCoreMessage::VarNameNotFound {
                     file_id,
                     name: name.clone(),
-                    name_range: surface_term.range(),
+                    name_range: surface_term.range,
                 });
                 (error_term(), Arc::new(Value::Error))
             }
@@ -619,7 +618,7 @@ impl<'me> Context<'me> {
                             Arc::new(core_type),
                         );
 
-                        (core::Term::new(surface_term.range(), term_data), r#type)
+                        (core::Term::new(surface_term.range, term_data), r#type)
                     }
                 }
             }
@@ -627,7 +626,7 @@ impl<'me> Context<'me> {
             TermData::KindType => {
                 self.push_message(SurfaceToCoreMessage::TermHasNoType {
                     file_id,
-                    term_range: surface_term.range(),
+                    term_range: surface_term.range,
                 });
                 (error_term(), Arc::new(Value::Error))
             }
@@ -664,7 +663,7 @@ impl<'me> Context<'me> {
                                 Arc::new(core_head),
                                 Arc::new(self.check_type(file_id, argument, &param_type)),
                             );
-                            core_head = core::Term::new(range.clone(), term_data);
+                            core_head = core::Term::new(range, term_data);
                             head_type = body_type.clone();
                         }
                         Value::Error => return (error_term(), Arc::new(Value::Error)),
@@ -672,9 +671,9 @@ impl<'me> Context<'me> {
                             let head_type = self.read_back_to_surface(head_type);
                             self.push_message(SurfaceToCoreMessage::NotAFunction {
                                 file_id,
-                                head_range: head.range(),
+                                head_range: head.range,
                                 head_type,
-                                argument_range: argument.range(),
+                                argument_range: argument.range,
                             });
                             return (error_term(), Arc::new(Value::Error));
                         }
@@ -687,7 +686,7 @@ impl<'me> Context<'me> {
             TermData::StructTerm(_) => {
                 self.push_message(SurfaceToCoreMessage::AmbiguousStructTerm {
                     file_id,
-                    term_range: surface_term.range(),
+                    term_range: surface_term.range,
                 });
                 (error_term(), Arc::new(Value::Error))
             }
@@ -706,7 +705,7 @@ impl<'me> Context<'me> {
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
                             file_id,
-                            range: range.clone(),
+                            range: range,
                             feature_name: "struct parameters",
                         });
                         return (error_term(), Arc::new(Value::Error));
@@ -722,7 +721,7 @@ impl<'me> Context<'me> {
                         let head_type = self.read_back_to_surface(&head_type);
                         self.push_message(SurfaceToCoreMessage::FieldNotFound {
                             file_id,
-                            head_range: head.range(),
+                            head_range: head.range,
                             head_type,
                             label: label.clone(),
                         });
@@ -739,7 +738,7 @@ impl<'me> Context<'me> {
             TermData::NumberLiteral(_) => {
                 self.push_message(SurfaceToCoreMessage::AmbiguousNumericLiteral {
                     file_id,
-                    literal_range: surface_term.range(),
+                    literal_range: surface_term.range,
                 });
                 (error_term(), Arc::new(Value::Error))
             }
@@ -762,7 +761,7 @@ impl<'me> Context<'me> {
                     let found_type = self.read_back_to_surface(&if_false_type);
                     self.push_message(SurfaceToCoreMessage::TypeMismatch {
                         file_id,
-                        term_range: surface_if_false.range(),
+                        term_range: surface_if_false.range,
                         expected_type,
                         found_type,
                     });
@@ -772,7 +771,7 @@ impl<'me> Context<'me> {
             TermData::Match(_, _) => {
                 self.push_message(SurfaceToCoreMessage::AmbiguousMatchExpression {
                     file_id,
-                    term_range: surface_term.range(),
+                    term_range: surface_term.range,
                 });
                 (error_term(), Arc::new(Value::Error))
             }
@@ -797,7 +796,7 @@ impl<'me> Context<'me> {
     fn from_int_branches(
         &mut self,
         file_id: usize,
-        range: Range<usize>,
+        range: Range,
         surface_branches: &[(Pattern, Term)],
         expected_type: &Arc<Value>,
     ) -> (BTreeMap<BigInt, Arc<core::Term>>, Arc<core::Term>) {
@@ -809,14 +808,14 @@ impl<'me> Context<'me> {
         for (pattern, surface_term) in surface_branches {
             let unreachable_pattern = || SurfaceToCoreMessage::UnreachablePattern {
                 file_id,
-                pattern_range: pattern.range(),
+                pattern_range: pattern.range,
             };
 
             match &pattern.data {
                 PatternData::NumberLiteral(source) => {
                     let core_term = self.check_type(file_id, surface_term, expected_type);
                     let parse_state =
-                        literal::State::new(file_id, range.clone(), source, &mut self.messages);
+                        literal::State::new(file_id, range, source, &mut self.messages);
                     match parse_state.number_to_big_int() {
                         None => {} // Skipping - an error message should have already been recorded
                         Some(value) => match &default {
@@ -846,7 +845,7 @@ impl<'me> Context<'me> {
         let default = default.unwrap_or_else(|| {
             self.push_message(SurfaceToCoreMessage::NoDefaultPattern {
                 file_id,
-                match_range: range.clone(),
+                match_range: range,
             });
             Arc::new(core::Term::new(range, core::TermData::Error))
         });


### PR DESCRIPTION
Some assorted cleanups related to wrangling ASTs.

- adds a `Range` type that can be copied
- adds `Value::{try_global, try_item}` shortcut methods to clean up some pattern matching

This is implemented on-top of #248