### PR TITLE
Github Actions disables add_path: fix!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   spec:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Check Makam Specification
     steps:
       - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
         working-directory: ./experiments/makam-spec
 
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust: ["1.42.0", "stable", "beta", "nightly"]
@@ -42,7 +42,7 @@ jobs:
           command: check
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust: ["1.42.0", "stable", "beta", "nightly"]
@@ -61,7 +61,7 @@ jobs:
           command: test
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust: ["1.42.0", "stable", "beta", "nightly"]
@@ -82,7 +82,7 @@ jobs:
           args: --all -- --check
 
 #   clippy:
-#     runs-on: ubuntu-latest
+#     runs-on: ubuntu-20.04
 #     strategy:
 #       matrix:
 #         rust: ["1.42.0", "stable", "beta", "nightly"]
@@ -103,7 +103,7 @@ jobs:
 #           args: -- -D warnings
 
   book:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Build and Test Book
     env:
       MDBOOK_VERSION: '0.4.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Test Book
     env:
-      MDBOOK_VERSION: '0.4.2'
+      MDBOOK_VERSION: '0.4.4'
       MDBOOK_LINKCHECK_VERSION: '0.7.0'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,12 +113,12 @@ jobs:
       - name: Install mdBook
         # Install prebuilt binaries where possible to improve CI performance
         run: |
-          mkdir -p $HOME/mdbook
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C $HOME/mdbook
-          echo "::add-path::${HOME}/mdbook/"
-          mkdir -p $HOME/mdbook-linkcheck
-          curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$MDBOOK_LINKCHECK_VERSION/mdbook-linkcheck-v$MDBOOK_LINKCHECK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C $HOME/mdbook-linkcheck
-          echo "::add-path::${HOME}/mdbook-linkcheck/"
+          mkdir -p "$HOME/mdbook"
+          curl -L "https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C "$HOME/mdbook"
+          echo "$HOME/mdbook/" >> $GITHUB_PATH
+          mkdir -p "$HOME/mdbook-linkcheck"
+          curl -L "https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$MDBOOK_LINKCHECK_VERSION/mdbook-linkcheck-v$MDBOOK_LINKCHECK_VERSION-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C "$HOME/mdbook-linkcheck"
+          echo "$HOME/mdbook-linkcheck/" >> $GITHUB_PATH
       - name: Install Javascript dependencies
         run: yarn install
         working-directory: book

--- a/book/book.toml
+++ b/book/book.toml
@@ -15,6 +15,7 @@ additional-js = [
 ]
 
 [output.linkcheck]
+follow-web-links = false # Avoid intermittent failures on CI from transient network errors
 exclude = [
     '\./code-of-conduct\.md', # Bypass `traverse-parent-directories` for this symlink
 ]


### PR DESCRIPTION
We should adapt now that Github has [deprecated the old way of setting environment variables](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).

Since i'm a pedant, i've also added quoting around shell arguments that could cause word-splitting.

Also killing a warning from Github Actions by explicitly setting Ubuntu version.