### PR TITLE
Return values from binary reader

### DIFF
--- a/fathom-test-util/src/lib.rs
+++ b/fathom-test-util/src/lib.rs
@@ -7,6 +7,17 @@ pub use fathom;
 pub use lazy_static;
 
 #[macro_export]
+macro_rules! assert_is_equal {
+    ($globals:expr, $value0:expr, $value1:expr $(,)?) => {{
+        let items = std::collections::HashMap::new();
+        // TODO: better error reporting?
+        assert!($crate::fathom::lang::core::semantics::is_equal(
+            &$globals, &items, &$value0, &$value1,
+        ));
+    }};
+}
+
+#[macro_export]
 macro_rules! core_module {
     ($IDENT:ident, $path:literal) => {
         $crate::lazy_static::lazy_static! {

--- a/fathom/src/lang/core/binary.rs
+++ b/fathom/src/lang/core/binary.rs
@@ -3,29 +3,4 @@
 //! This is only a naive implementation, and intended for getting a better idea
 //! of whether our compiled back-ends actually meet the specification.
 
-use num_bigint::BigInt;
-use std::collections::BTreeMap;
-
 pub mod read;
-
-/// Terms that can be produced as a result of reading a binary file, or used as
-/// a source from which to write binary data.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Term {
-    /// Integers.
-    Int(BigInt),
-    /// IEEE-754 single-precision floating point numbers.
-    F32(f32),
-    /// IEEE-754 double-precision floating point numbers.
-    F64(f64),
-    /// Sequences
-    Seq(Vec<Term>),
-    /// Structure values
-    Struct(BTreeMap<String, Term>),
-}
-
-impl Term {
-    pub fn int(data: impl Into<BigInt>) -> Term {
-        Term::Int(data.into())
-    }
-}

--- a/tests/input/constant/pass_format_array.rs
+++ b/tests/input/constant/pass_format_array.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use fathom_runtime::{FormatWriter, ReadError, ReadScope, U32Be, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
+use std::sync::Arc;
 
 fathom_test_util::core_module!(
     FIXTURE,
@@ -42,15 +44,16 @@ fn valid_test() {
     let simple_array = read_context
         .read_item(&FIXTURE, &"SimpleFormatArray")
         .unwrap();
-    assert_eq!(
+    fathom_test_util::assert_is_equal!(
+        globals,
         simple_array,
-        binary::Term::Seq(vec![
-            binary::Term::int(1),
-            binary::Term::int(2),
-            binary::Term::int(3),
-            binary::Term::int(4),
-            binary::Term::int(5),
-            binary::Term::int(6),
+        Value::ArrayTerm(vec![
+            Arc::new(Value::int(1)),
+            Arc::new(Value::int(2)),
+            Arc::new(Value::int(3)),
+            Arc::new(Value::int(4)),
+            Arc::new(Value::int(5)),
+            Arc::new(Value::int(6)),
         ]),
     );
 
@@ -98,15 +101,16 @@ fn valid_test_trailing() {
     let simple_array = read_context
         .read_item(&FIXTURE, &"SimpleFormatArray")
         .unwrap();
-    assert_eq!(
+    fathom_test_util::assert_is_equal!(
+        globals,
         simple_array,
-        binary::Term::Seq(vec![
-            binary::Term::int(1),
-            binary::Term::int(2),
-            binary::Term::int(3),
-            binary::Term::int(4),
-            binary::Term::int(5),
-            binary::Term::int(6),
+        Value::ArrayTerm(vec![
+            Arc::new(Value::int(1)),
+            Arc::new(Value::int(2)),
+            Arc::new(Value::int(3)),
+            Arc::new(Value::int(4)),
+            Arc::new(Value::int(5)),
+            Arc::new(Value::int(6)),
         ]),
     );
 

--- a/tests/input/constant/pass_if_else_format_type.rs
+++ b/tests/input/constant/pass_if_else_format_type.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use fathom_runtime::{F64Be, FormatWriter, ReadError, ReadScope, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 
 fathom_test_util::core_module!(
@@ -35,7 +36,7 @@ fn valid_test() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(23.64e10));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
 
     // TODO: Check remaining
 }
@@ -51,7 +52,7 @@ fn valid_test_trailing() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(781.453298));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_if_else_format_type_item.rs
+++ b/tests/input/constant/pass_if_else_format_type_item.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use fathom_runtime::{F64Be, FormatWriter, ReadError, ReadScope, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 
 fathom_test_util::core_module!(
@@ -35,7 +36,7 @@ fn valid_test() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(23.64e10));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
 
     // TODO: Check remaining
 }
@@ -51,7 +52,7 @@ fn valid_test_trailing() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(781.453298));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_match_int_format_type.rs
+++ b/tests/input/constant/pass_match_int_format_type.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use fathom_runtime::{F64Le, FormatWriter, ReadError, ReadScope, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 
 fathom_test_util::core_module!(
@@ -35,7 +36,7 @@ fn valid_test() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(23.64e10));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
 
     // TODO: Check remaining
 }
@@ -51,7 +52,7 @@ fn valid_test_trailing() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(781.453298));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_match_int_format_type_item.rs
+++ b/tests/input/constant/pass_match_int_format_type_item.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use fathom_runtime::{F64Le, FormatWriter, ReadError, ReadScope, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 
 fathom_test_util::core_module!(
@@ -35,7 +36,7 @@ fn valid_test() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(23.64e10));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
 
     // TODO: Check remaining
 }
@@ -51,7 +52,7 @@ fn valid_test_trailing() {
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
     let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    assert_eq!(test, binary::Term::F64(781.453298));
+    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_simple.rs
+++ b/tests/input/constant/pass_simple.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use fathom_runtime::{FormatWriter, ReadError, ReadScope, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 
 fathom_test_util::core_module!(FIXTURE, "../../snapshots/constant/pass_simple.core.fathom");
@@ -33,7 +34,7 @@ fn valid_singleton() {
 
     let byte = read_context.read_item(&FIXTURE, &"Byte").unwrap();
 
-    assert_eq!(byte, binary::Term::int(31));
+    fathom_test_util::assert_is_equal!(globals, byte, Value::int(31));
 
     // TODO: Check remaining
 }
@@ -50,7 +51,7 @@ fn valid_singleton_trailing() {
 
     let byte = read_context.read_item(&FIXTURE, &"Byte").unwrap();
 
-    assert_eq!(byte, binary::Term::int(255));
+    fathom_test_util::assert_is_equal!(globals, byte, Value::int(255));
 
     // TODO: Check remaining
 }

--- a/tests/input/struct/pass_empty.rs
+++ b/tests/input/struct/pass_empty.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use fathom_runtime::{FormatWriter, ReadScope, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
@@ -15,12 +16,11 @@ fn valid_empty() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match read_context.read_item(&FIXTURE, "EmptyFormat").unwrap() {
-        binary::Term::Struct(fields) => {
-            assert_eq!(fields, BTreeMap::from_iter(vec![]));
-        }
-        _ => panic!("struct expected"),
-    }
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context.read_item(&FIXTURE, "EmptyFormat").unwrap(),
+        Value::StructTerm(BTreeMap::from_iter(vec![])),
+    );
 
     // TODO: Check remaining
 }
@@ -34,12 +34,11 @@ fn valid_empty_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match read_context.read_item(&FIXTURE, "EmptyFormat").unwrap() {
-        binary::Term::Struct(fields) => {
-            assert_eq!(fields, BTreeMap::from_iter(vec![]));
-        }
-        _ => panic!("struct expected"),
-    }
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context.read_item(&FIXTURE, "EmptyFormat").unwrap(),
+        Value::StructTerm(BTreeMap::from_iter(vec![])),
+    );
 
     // TODO: Check remaining
 }

--- a/tests/input/struct/pass_pair.rs
+++ b/tests/input/struct/pass_pair.rs
@@ -1,9 +1,11 @@
 #![cfg(test)]
 
 use fathom_runtime::{FormatWriter, ReadError, ReadScope, I8, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
+use std::sync::Arc;
 
 fathom_test_util::core_module!(FIXTURE, "../../snapshots/struct/pass_pair.core.fathom");
 
@@ -52,18 +54,14 @@ fn valid_pair() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match read_context.read_item(&FIXTURE, &"PairFormat").unwrap() {
-        binary::Term::Struct(fields) => {
-            assert_eq!(
-                fields,
-                BTreeMap::from_iter(vec![
-                    ("first".to_owned(), binary::Term::int(31)),
-                    ("second".to_owned(), binary::Term::int(-30)),
-                ]),
-            );
-        }
-        _ => panic!("struct expected"),
-    }
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context.read_item(&FIXTURE, &"PairFormat").unwrap(),
+        Value::StructTerm(BTreeMap::from_iter(vec![
+            ("first".to_owned(), Arc::new(Value::int(31))),
+            ("second".to_owned(), Arc::new(Value::int(-30))),
+        ])),
+    );
 
     // TODO: Check remaining
 }
@@ -79,18 +77,14 @@ fn valid_pair_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match read_context.read_item(&FIXTURE, &"PairFormat").unwrap() {
-        binary::Term::Struct(fields) => {
-            assert_eq!(
-                fields,
-                BTreeMap::from_iter(vec![
-                    ("first".to_owned(), binary::Term::int(255)),
-                    ("second".to_owned(), binary::Term::int(-30)),
-                ]),
-            );
-        }
-        _ => panic!("struct expected"),
-    }
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context.read_item(&FIXTURE, &"PairFormat").unwrap(),
+        Value::StructTerm(BTreeMap::from_iter(vec![
+            ("first".to_owned(), Arc::new(Value::int(255))),
+            ("second".to_owned(), Arc::new(Value::int(-30))),
+        ])),
+    );
 
     // TODO: Check remaining
 }

--- a/tests/input/struct/pass_singleton.rs
+++ b/tests/input/struct/pass_singleton.rs
@@ -1,9 +1,11 @@
 #![cfg(test)]
 
 use fathom_runtime::{FormatWriter, ReadError, ReadScope, U8};
+use fathom_test_util::fathom::lang::core::semantics::Value;
 use fathom_test_util::fathom::lang::core::{self, binary};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
+use std::sync::Arc;
 
 fathom_test_util::core_module!(FIXTURE, "../../snapshots/struct/pass_singleton.core.fathom");
 
@@ -33,15 +35,14 @@ fn valid_singleton() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match read_context.read_item(&FIXTURE, &"Byte").unwrap() {
-        binary::Term::Struct(fields) => {
-            assert_eq!(
-                fields,
-                BTreeMap::from_iter(vec![("inner".to_owned(), binary::Term::int(31))]),
-            );
-        }
-        _ => panic!("struct expected"),
-    }
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context.read_item(&FIXTURE, &"Byte").unwrap(),
+        Value::StructTerm(BTreeMap::from_iter(vec![(
+            "inner".to_owned(),
+            Arc::new(Value::int(31)),
+        )])),
+    );
 
     // TODO: Check remaining
 }
@@ -56,15 +57,14 @@ fn valid_singleton_trailing() {
     let read_scope = ReadScope::new(writer.buffer());
     let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    match read_context.read_item(&FIXTURE, &"Byte").unwrap() {
-        binary::Term::Struct(fields) => {
-            assert_eq!(
-                fields,
-                BTreeMap::from_iter(vec![("inner".to_owned(), binary::Term::int(255))]),
-            );
-        }
-        _ => panic!("struct expected"),
-    }
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context.read_item(&FIXTURE, &"Byte").unwrap(),
+        Value::StructTerm(BTreeMap::from_iter(vec![(
+            "inner".to_owned(),
+            Arc::new(Value::int(255)),
+        )])),
+    );
 
     // TODO: Check remaining
 }


### PR DESCRIPTION
Thanks to the addition of array terms (#265) and struct terms (#248) we are now able to represent all format representations in the host language. This lets us remove `lang::core::binary::Term`, and return values from the interpreted binary reader instead, making it easier to implement dependent parsing in the future (see #244).