### PR TITLE
API for test suite and CLI

### DIFF
--- a/examples/stl.fathom
+++ b/examples/stl.fathom
@@ -1,0 +1,28 @@
+//! Binary STL File
+//!
+//! # References
+//!
+//! - [Wikipedia](https://en.wikipedia.org/wiki/STL_(file_format)#Binary_STL)
+
+// TODO: STL variants:
+// - VisCAM
+// - SolidView
+// - Materialise Magics
+
+struct Vec3d : Format {
+    x : F32Le,
+    y : F32Le,
+    z : F32Le,
+}
+
+struct Triangle : Format {
+    normal : Vec3d,
+    vertices : FormatArray 3 Vec3d,
+    attribute_byte_count : U16Le,
+}
+
+struct Stl : Format {
+    header : FormatArray 80 U8,
+    triangle_count : U32Le,
+    triangles : FormatArray triangle_count Triangle,
+}

--- a/fathom-cli/Cargo.toml
+++ b/fathom-cli/Cargo.toml
@@ -10,4 +10,5 @@ license = "Apache-2.0"
 
 [dependencies]
 fathom = { version = "0.1.0", path = "../fathom" }
+fathom-runtime = { version = "0.1.0", path = "../fathom-runtime" }
 structopt = { version = "0.3" }

--- a/fathom-cli/Cargo.toml
+++ b/fathom-cli/Cargo.toml
@@ -9,4 +9,5 @@ description = "CLI interface for Fathom"
 license = "Apache-2.0"
 
 [dependencies]
+fathom = { version = "0.1.0", path = "../fathom" }
 structopt = { version = "0.3" }

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -7,17 +7,12 @@ use structopt::{clap::ArgGroup, StructOpt};
 #[derive(StructOpt, Debug)]
 #[structopt(group = ArgGroup::with_name("format_choice"), after_help = "If no output option is specified it defaults to --summary.")]
 pub struct Cli {
-    // Format choice, optional:
-    /// Optional argument for specifying the name of the format
-    /// description in the installed catalog, for example "opentype",
-    /// that will be used to process the files.
-    #[structopt(long, group = "format_choice", name = "NAME")]
-    pub format: Option<String>,
-    /// Optional argument for specifying the file containing the
+    // Format choice:
+    /// Argument for specifying the file containing the
     /// format description, for example "path/to/myformat.ddl", that
     /// will be used to process the files.
     #[structopt(long, group = "format_choice", name = "FORMAT-FILE")]
-    pub format_file: Option<PathBuf>,
+    pub format_file: PathBuf,
     // Output options, optional:
     /// Prints a brief summary of each file based on the format
     /// description. This may include printing the type or version or

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -12,35 +12,35 @@ pub struct Cli {
     /// description in the installed catalog, for example "opentype",
     /// that will be used to process the files.
     #[structopt(long, group = "format_choice", name = "NAME")]
-    format: Option<String>,
+    pub format: Option<String>,
     /// Optional argument for specifying the file containing the
     /// format description, for example "path/to/myformat.ddl", that
     /// will be used to process the files.
     #[structopt(long, group = "format_choice", name = "FORMAT-FILE")]
-    format_file: Option<PathBuf>,
+    pub format_file: Option<PathBuf>,
     // Output options, optional:
     /// Prints a brief summary of each file based on the format
     /// description. This may include printing the type or version or
     /// other important details about the file but may not validate
     /// the entire file contents.
     #[structopt(long)]
-    summary: bool,
+    pub summary: bool,
     /// Prints a textual representation of the complete contents of
     /// each file as described by the format description. This will
     /// also validate the entire file against the format description
     /// and warn of any discrepancies.
     #[structopt(long)]
-    dump: bool,
+    pub dump: bool,
     /// Print the results of applying the specified format query to
     /// each input file.
     #[structopt(long, name = "QUERY")]
-    query: Option<String>,
+    pub query: Option<String>,
     /// Read a query from file and print the results of applying the
     /// format query to each input file.
     #[structopt(long, name = "QUERY-FILE")]
-    query_file: Option<PathBuf>,
+    pub query_file: Option<PathBuf>,
     // The (binary) input files to operate on:
     /// The path to the file(s) to parse
     #[structopt(parse(from_os_str))]
-    files: Vec<PathBuf>,
+    pub files: Vec<PathBuf>,
 }

--- a/fathom-cli/src/cli.rs
+++ b/fathom-cli/src/cli.rs
@@ -28,11 +28,11 @@ pub struct Cli {
     pub dump: bool,
     /// Print the results of applying the specified format query to
     /// each input file.
-    #[structopt(long, name = "QUERY")]
+    #[structopt(long, name = "QUERY", required_unless_all(&["QUERY_FILE"]))]
     pub query: Option<String>,
     /// Read a query from file and print the results of applying the
     /// format query to each input file.
-    #[structopt(long, name = "QUERY-FILE")]
+    #[structopt(long, name = "QUERY-FILE", required_unless_all(&["QUERY"]))]
     pub query_file: Option<PathBuf>,
     // The (binary) input files to operate on:
     /// The path to the file(s) to parse

--- a/fathom-cli/src/main.rs
+++ b/fathom-cli/src/main.rs
@@ -1,3 +1,4 @@
+use fathom::driver;
 use structopt::StructOpt;
 
 mod cli;
@@ -7,4 +8,19 @@ fn main() {
     println!("Hello, world!");
 
     println!("debug: {:?}", args);
+
+    if args.files.len() == 0 {
+        // error, please provide an input file
+    }
+
+    if args.files.len() != 1 {
+        // note that we only will read one input file.
+    }
+
+    let file = args.files.first().unwrap();
+
+    driver::compiler::run_compiler(
+        &*file.clone().into_os_string().into_string().unwrap(),
+        &*file,
+    )
 }

--- a/fathom-cli/src/main.rs
+++ b/fathom-cli/src/main.rs
@@ -1,26 +1,46 @@
 use fathom::driver;
 use structopt::StructOpt;
 
+use fathom::lang::core;
+use fathom::lang::core::binary;
+use fathom_runtime::ReadScope;
+
 mod cli;
 
-fn main() {
+fn main() -> Result<(), String> {
     let args = cli::Cli::from_args();
-    println!("Hello, world!");
 
     println!("debug: {:?}", args);
 
     if args.files.len() == 0 {
-        // error, please provide an input file
+        return Err("Please provide a binary file to operate on.".to_string());
     }
 
-    if args.files.len() != 1 {
-        // note that we only will read one input file.
+    let root_query = match args.query {
+        Some(query) => query,
+        None => return Err("Please provide name of root item with --query.".to_string()),
+    };
+
+    let ddl_file = args.format_file;
+
+    for input_file in args.files {
+        let core_module = driver::compiler::run_compiler(
+            &ddl_file.clone().into_os_string().into_string().unwrap(),
+            &ddl_file,
+        );
+
+        let globals = core::Globals::default();
+        let input_buffer = std::fs::read(&input_file).unwrap();
+        let read_scope = ReadScope::new(&input_buffer);
+        let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+
+        match read_context.read_item(&core_module, &root_query) {
+            Ok(value) => println!("{:?}", value),
+            Err(err) => {
+                return Err(format!("{:?}", err));
+            }
+        }
     }
 
-    let file = args.files.first().unwrap();
-
-    driver::compiler::run_compiler(
-        &*file.clone().into_os_string().into_string().unwrap(),
-        &*file,
-    )
+    Ok(())
 }

--- a/fathom-test/Cargo.toml
+++ b/fathom-test/Cargo.toml
@@ -13,10 +13,10 @@ license = "Apache-2.0"
 [dev-dependencies]
 assert_fs = "1.0"
 codespan-reporting =  "0.9.4"
+difference = "2.0"
 fathom = { version = "0.1.0", path = "../fathom" }
 fathom-runtime = { version = "0.1.0", path = "../fathom-runtime" }
 fathom-test-util = { version = "0.1.0", path = "../fathom-test-util" }
-difference = "2.0"
 json = "0.12"
 lazy_static = "1.4"
 pretty = "0.10"

--- a/fathom-test/src/support/mod.rs
+++ b/fathom-test/src/support/mod.rs
@@ -93,8 +93,9 @@ impl Test {
         });
         let input_fathom_file_id = files.add(input_fathom_path.display().to_string(), source);
 
-        // Extract the directives from the source code
-
+        // Extract the directives from the source code.  Directives
+        // are the annotations on test inputs such as "// ~error:..."
+        // to express that the test case expects a particular error.
         let directives = {
             let (directives, diagnostics) = {
                 let lexer = directives::Lexer::new(&files, input_fathom_file_id);

--- a/fathom-test/src/support/mod.rs
+++ b/fathom-test/src/support/mod.rs
@@ -39,6 +39,7 @@ lazy_static::lazy_static! {
 
     static ref INPUT_DIR: PathBuf = CARGO_WORKSPACE_ROOT.join("tests").join("input");
     static ref SNAPSHOTS_DIR: PathBuf = CARGO_WORKSPACE_ROOT.join("tests").join("snapshots");
+    static ref GLOBALS: fathom::lang::core::Globals = fathom::lang::core::Globals::default();
 
 }
 

--- a/fathom-test/src/support/mod.rs
+++ b/fathom-test/src/support/mod.rs
@@ -2,6 +2,7 @@ use codespan_reporting::diagnostic::{Diagnostic, LabelStyle, Severity};
 use codespan_reporting::files::{Files, SimpleFiles};
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{BufferWriter, ColorChoice, StandardStream};
+use fathom::driver::compiler;
 use fathom::pass::{core_to_pretty, core_to_surface, surface_to_core, surface_to_doc};
 use std::fs;
 use std::path::PathBuf;
@@ -45,6 +46,12 @@ lazy_static::lazy_static! {
 pub fn run_integration_test(test_name: &str, fathom_path: &str) {
     let mut files = SimpleFiles::new();
     let mut test = Test::setup(&mut files, test_name, fathom_path);
+
+    let mut compiler = compiler::Compiler::setup(
+        &mut files,
+        test_name,
+        INPUT_DIR.join(fathom_path).to_str().unwrap(),
+    );
 
     // Run stages
 

--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -18,6 +18,7 @@ fathom-runtime = { version = "0.1.0", path="../fathom-runtime" }
 im = "15"
 itertools = "0.9"
 lalrpop-util = "0.19"
+lazy_static = "1.4"
 logos = "0.11"
 num-bigint = "0.2"
 num-traits = "0.2"

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -1,0 +1,3 @@
+//! High-level compiler API for use by test harnass and CLI
+
+pub mod compiler;

--- a/fathom/src/driver/compiler.rs
+++ b/fathom/src/driver/compiler.rs
@@ -14,7 +14,7 @@ lazy_static::lazy_static! {
     static ref GLOBALS: lang::core::Globals = lang::core::Globals::default();
 }
 
-pub fn run_compiler(module_name: &str, fathom_path: &PathBuf) {
+pub fn run_compiler(module_name: &str, fathom_path: &PathBuf) -> lang::core::Module {
     let mut files = SimpleFiles::new();
     let mut compiler = Compiler::setup(
         &mut files,
@@ -34,6 +34,8 @@ pub fn run_compiler(module_name: &str, fathom_path: &PathBuf) {
     // compiler.binary_parse_tests();
 
     // compiler.finish(&files);
+    //todo return diagnostics
+    core_module
 }
 
 pub struct Compiler {

--- a/fathom/src/driver/compiler.rs
+++ b/fathom/src/driver/compiler.rs
@@ -1,0 +1,79 @@
+use codespan_reporting::files::{Files, SimpleFiles};
+use codespan_reporting::term;
+use codespan_reporting::term::termcolor::{BufferWriter, ColorChoice, StandardStream};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::pass::{core_to_pretty, core_to_surface, surface_to_core, surface_to_doc};
+use crate::reporting;
+
+lazy_static::lazy_static! {
+    static ref INPUT_DIR: PathBuf = env::current_dir().unwrap(); // FIXME
+}
+
+pub fn run_compiler(module_name: &str, fathom_path: &PathBuf) {
+    let mut files = SimpleFiles::new();
+    let mut compiler = Compiler::setup(
+        &mut files,
+        module_name,
+        fathom_path.clone().into_os_string().to_str().unwrap(),
+    );
+
+    // Run stages
+
+    eprintln!("trying to compile");
+
+    // let surface_module = compiler.parse_surface(&files);
+    // compiler.compile_doc(&surface_module);
+    // let core_module = compiler.elaborate(&files, &surface_module);
+    // compiler.roundtrip_surface_to_core(&files, &core_module);
+    // compiler.roundtrip_pretty_core(&mut files, &core_module);
+    // compiler.binary_parse_tests();
+
+    // compiler.finish(&files);
+}
+
+pub struct Compiler {
+    module_name: String,
+    term_config: codespan_reporting::term::Config,
+    input_fathom_path: PathBuf,
+    input_fathom_file_id: usize,
+    // snapshot_filename: PathBuf,
+    // directives: directives::Directives,
+    // failed_checks: Vec<&'static str>,
+    found_messages: Vec<reporting::Message>,
+}
+
+impl Compiler {
+    pub fn setup(
+        files: &mut SimpleFiles<String, String>,
+        module_name: &str,
+        fathom_path: &str,
+    ) -> Compiler {
+        // Set up output streams
+
+        let term_config = term::Config::default();
+        let stdout = StandardStream::stdout(ColorChoice::Auto);
+
+        // Set up files
+
+        let input_fathom_path = INPUT_DIR.join(fathom_path);
+        // let snapshot_filename = SNAPSHOTS_DIR.join(fathom_path).with_extension("");
+        let source = fs::read_to_string(&input_fathom_path).unwrap_or_else(|error| {
+            panic!("error reading `{}`: {}", input_fathom_path.display(), error)
+        });
+        let input_fathom_file_id = files.add(input_fathom_path.display().to_string(), source);
+
+        Compiler {
+            module_name: module_name.to_owned(),
+            term_config,
+            input_fathom_path,
+            input_fathom_file_id,
+            // snapshot_filename,
+            // directives,
+            // failed_checks: Vec::new(),
+            found_messages: Vec::new(),
+        }
+    }
+}

--- a/fathom/src/driver/compiler.rs
+++ b/fathom/src/driver/compiler.rs
@@ -1,13 +1,13 @@
-use codespan_reporting::diagnostic::{Diagnostic, LabelStyle, Severity};
+use codespan_reporting::diagnostic::Diagnostic;
 use codespan_reporting::files::{Files, SimpleFiles};
 use codespan_reporting::term;
-use codespan_reporting::term::termcolor::{BufferWriter, ColorChoice, StandardStream};
+use codespan_reporting::term::termcolor::{BufferWriter, ColorChoice};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 
 use crate::lang;
-use crate::pass::{core_to_pretty, core_to_surface, surface_to_core, surface_to_doc};
+use crate::pass::surface_to_core;
 use crate::reporting;
 
 lazy_static::lazy_static! {
@@ -26,23 +26,17 @@ pub fn run_compiler(module_name: &str, fathom_path: &PathBuf) -> lang::core::Mod
     // Run stages
 
     let surface_module = compiler.parse_surface(&files);
-    // compiler.compile_doc(&surface_module);
     let core_module = compiler.elaborate(&files, &surface_module);
-    // compiler.roundtrip_surface_to_core(&files, &core_module);
-    // compiler.roundtrip_pretty_core(&mut files, &core_module);
-    // compiler.binary_parse_tests();
 
     &compiler.finish(&files);
     core_module
 }
 
 pub struct Compiler {
-    module_name: String,
+    pub module_name: String,
     term_config: codespan_reporting::term::Config,
-    input_fathom_path: PathBuf,
+    pub input_fathom_path: PathBuf,
     input_fathom_file_id: usize,
-    // snapshot_filename: PathBuf,
-    // directives: directives::Directives,
     failed_checks: Vec<&'static str>,
     pub found_messages: Vec<reporting::Message>,
     surface_module: Option<lang::surface::Module>,
@@ -62,7 +56,6 @@ impl Compiler {
         // Set up output streams
 
         let term_config = term::Config::default();
-        let stdout = StandardStream::stdout(ColorChoice::Auto);
 
         // Set up files
 
@@ -77,8 +70,6 @@ impl Compiler {
             term_config,
             input_fathom_path,
             input_fathom_file_id,
-            // snapshot_filename,
-            // directives,
             failed_checks: Vec::new(),
             found_messages: Vec::new(),
             surface_module: None,
@@ -142,7 +133,7 @@ impl Compiler {
         if !found_diagnostics.is_empty() {
             self.failed_checks.push("unexpected_diagnostics");
 
-            eprintln!("Unexpected diagnostics found:");
+            eprintln!("Unexpected errors found:");
             eprintln!();
 
             // Use a buffer so that this doesn't get printed interleaved with the

--- a/fathom/src/lib.rs
+++ b/fathom/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 
+pub mod driver;
 pub mod lang;
 pub mod pass;
 


### PR DESCRIPTION
The idea here is to pull the guts of the compiler, which are fairly intertwined with the test suite at the moment, into a "compiler driver" module to be created in the `fathom` crate.  Eventually, the hope is that this closes #261.

For now, :warning: this is still extremely messy, and will need a lot of TLC :warning: 