### PR TITLE
Binary interpreter API improvements

### DIFF
--- a/tests/input/constant/pass_format_array.rs
+++ b/tests/input/constant/pass_format_array.rs
@@ -15,10 +15,10 @@ fn eof_inner() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray") {
+    match read_context.read_item(&mut reader, &"SimpleFormatArray") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -38,13 +38,13 @@ fn valid_test() {
     writer.write::<U32Be>(6); // SimpleFormatArray::inner[5]
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
         read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray")
+            .read_item(&mut reader, &"SimpleFormatArray")
             .unwrap(),
         Value::ArrayTerm(vec![
             Arc::new(Value::int(1)),
@@ -70,10 +70,10 @@ fn invalid_test_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray") {
+    match read_context.read_item(&mut reader, &"SimpleFormatArray") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -94,13 +94,13 @@ fn valid_test_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
         read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray")
+            .read_item(&mut reader, &"SimpleFormatArray")
             .unwrap(),
         Value::ArrayTerm(vec![
             Arc::new(Value::int(1)),

--- a/tests/input/constant/pass_format_array.rs
+++ b/tests/input/constant/pass_format_array.rs
@@ -16,9 +16,9 @@ fn eof_inner() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"SimpleFormatArray") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -39,14 +39,13 @@ fn valid_test() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let simple_array = read_context
-        .read_item(&FIXTURE, &"SimpleFormatArray")
-        .unwrap();
     fathom_test_util::assert_is_equal!(
         globals,
-        simple_array,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray")
+            .unwrap(),
         Value::ArrayTerm(vec![
             Arc::new(Value::int(1)),
             Arc::new(Value::int(2)),
@@ -72,9 +71,9 @@ fn invalid_test_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"SimpleFormatArray") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -96,14 +95,13 @@ fn valid_test_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let simple_array = read_context
-        .read_item(&FIXTURE, &"SimpleFormatArray")
-        .unwrap();
     fathom_test_util::assert_is_equal!(
         globals,
-        simple_array,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"SimpleFormatArray")
+            .unwrap(),
         Value::ArrayTerm(vec![
             Arc::new(Value::int(1)),
             Arc::new(Value::int(2)),

--- a/tests/input/constant/pass_if_else_format_type.rs
+++ b/tests/input/constant/pass_if_else_format_type.rs
@@ -15,9 +15,9 @@ fn eof_inner() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"Test") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,10 +33,15 @@ fn valid_test() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(23.64e10),
+    );
 
     // TODO: Check remaining
 }
@@ -49,10 +54,15 @@ fn valid_test_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(781.453298),
+    );
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_if_else_format_type.rs
+++ b/tests/input/constant/pass_if_else_format_type.rs
@@ -14,10 +14,10 @@ fn eof_inner() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
+    match read_context.read_item(&mut reader, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -32,13 +32,13 @@ fn valid_test() {
     writer.write::<F64Be>(23.64e10); // Test::inner
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
         read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .read_item(&mut reader, &"Test")
             .unwrap(),
         Value::f64(23.64e10),
     );
@@ -53,13 +53,13 @@ fn valid_test_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
         read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .read_item(&mut reader, &"Test")
             .unwrap(),
         Value::f64(781.453298),
     );

--- a/tests/input/constant/pass_if_else_format_type_item.rs
+++ b/tests/input/constant/pass_if_else_format_type_item.rs
@@ -15,9 +15,9 @@ fn eof_inner() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"Test") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,10 +33,15 @@ fn valid_test() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(23.64e10),
+    );
 
     // TODO: Check remaining
 }
@@ -49,10 +54,15 @@ fn valid_test_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(781.453298),
+    );
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_if_else_format_type_item.rs
+++ b/tests/input/constant/pass_if_else_format_type_item.rs
@@ -14,10 +14,10 @@ fn eof_inner() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
+    match read_context.read_item(&mut reader, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -32,14 +32,12 @@ fn valid_test() {
     writer.write::<F64Be>(23.64e10); // Test::inner
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Test").unwrap(),
         Value::f64(23.64e10),
     );
 
@@ -53,14 +51,12 @@ fn valid_test_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Test").unwrap(),
         Value::f64(781.453298),
     );
 

--- a/tests/input/constant/pass_match_int_format_type.rs
+++ b/tests/input/constant/pass_match_int_format_type.rs
@@ -15,9 +15,9 @@ fn eof_inner() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"Test") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,10 +33,15 @@ fn valid_test() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(23.64e10),
+    );
 
     // TODO: Check remaining
 }
@@ -49,10 +54,15 @@ fn valid_test_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(781.453298),
+    );
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_match_int_format_type.rs
+++ b/tests/input/constant/pass_match_int_format_type.rs
@@ -14,10 +14,10 @@ fn eof_inner() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
+    match read_context.read_item(&mut reader, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -32,14 +32,12 @@ fn valid_test() {
     writer.write::<F64Le>(23.64e10); // Test::inner
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Test").unwrap(),
         Value::f64(23.64e10),
     );
 
@@ -53,14 +51,12 @@ fn valid_test_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Test").unwrap(),
         Value::f64(781.453298),
     );
 

--- a/tests/input/constant/pass_match_int_format_type_item.rs
+++ b/tests/input/constant/pass_match_int_format_type_item.rs
@@ -15,9 +15,9 @@ fn eof_inner() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"Test") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,10 +33,15 @@ fn valid_test() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(23.64e10));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(23.64e10),
+    );
 
     // TODO: Check remaining
 }
@@ -49,10 +54,15 @@ fn valid_test_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let test = read_context.read_item(&FIXTURE, &"Test").unwrap();
-    fathom_test_util::assert_is_equal!(globals, test, Value::f64(781.453298));
+    fathom_test_util::assert_is_equal!(
+        globals,
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
+            .unwrap(),
+        Value::f64(781.453298),
+    );
 
     // TODO: Check remaining
 }

--- a/tests/input/constant/pass_match_int_format_type_item.rs
+++ b/tests/input/constant/pass_match_int_format_type_item.rs
@@ -14,10 +14,10 @@ fn eof_inner() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Test") {
+    match read_context.read_item(&mut reader, &"Test") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -32,14 +32,12 @@ fn valid_test() {
     writer.write::<F64Le>(23.64e10); // Test::inner
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Test").unwrap(),
         Value::f64(23.64e10),
     );
 
@@ -53,14 +51,12 @@ fn valid_test_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Test")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Test").unwrap(),
         Value::f64(781.453298),
     );
 

--- a/tests/input/constant/pass_simple.rs
+++ b/tests/input/constant/pass_simple.rs
@@ -11,10 +11,10 @@ fn eof_inner() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Byte") {
+    match read_context.read_item(&mut reader, &"Byte") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -29,12 +29,10 @@ fn valid_singleton() {
     writer.write::<U8>(31); // Byte
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    let byte = read_context
-        .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
-        .unwrap();
+    let byte = read_context.read_item(&mut reader, &"Byte").unwrap();
 
     fathom_test_util::assert_is_equal!(globals, byte, Value::int(31));
 
@@ -48,12 +46,10 @@ fn valid_singleton_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    let byte = read_context
-        .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
-        .unwrap();
+    let byte = read_context.read_item(&mut reader, &"Byte").unwrap();
 
     fathom_test_util::assert_is_equal!(globals, byte, Value::int(255));
 

--- a/tests/input/constant/pass_simple.rs
+++ b/tests/input/constant/pass_simple.rs
@@ -12,9 +12,9 @@ fn eof_inner() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"Byte") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Byte") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -30,9 +30,11 @@ fn valid_singleton() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let byte = read_context.read_item(&FIXTURE, &"Byte").unwrap();
+    let byte = read_context
+        .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
+        .unwrap();
 
     fathom_test_util::assert_is_equal!(globals, byte, Value::int(31));
 
@@ -47,9 +49,11 @@ fn valid_singleton_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    let byte = read_context.read_item(&FIXTURE, &"Byte").unwrap();
+    let byte = read_context
+        .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
+        .unwrap();
 
     fathom_test_util::assert_is_equal!(globals, byte, Value::int(255));
 

--- a/tests/input/struct/dependent_fields.rs
+++ b/tests/input/struct/dependent_fields.rs
@@ -17,10 +17,10 @@ fn eof_len() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat") {
+    match read_context.read_item(&mut reader, &"ArrayFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -36,10 +36,10 @@ fn eof_data() {
     writer.write::<U32Be>(1); // ArrayFormat::data[0]
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat") {
+    match read_context.read_item(&mut reader, &"ArrayFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -57,14 +57,12 @@ fn valid_array_format() {
     writer.write::<U32Be>(3); // ArrayFormat::data[2]
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"ArrayFormat").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("len".to_owned(), Arc::new(Value::int(3))),
             (
@@ -88,14 +86,12 @@ fn valid_array_format_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"ArrayFormat").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("len".to_owned(), Arc::new(Value::int(0))),
             ("data".to_owned(), Arc::new(Value::ArrayTerm(Vec::new()))),

--- a/tests/input/struct/dependent_fields.rs
+++ b/tests/input/struct/dependent_fields.rs
@@ -18,9 +18,9 @@ fn eof_len() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"ArrayFormat") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -37,9 +37,9 @@ fn eof_data() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"ArrayFormat") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -58,11 +58,13 @@ fn valid_array_format() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, &"ArrayFormat").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("len".to_owned(), Arc::new(Value::int(3))),
             (
@@ -87,11 +89,13 @@ fn valid_array_format_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, &"ArrayFormat").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"ArrayFormat")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("len".to_owned(), Arc::new(Value::int(0))),
             ("data".to_owned(), Arc::new(Value::ArrayTerm(Vec::new()))),

--- a/tests/input/struct/pass_empty.rs
+++ b/tests/input/struct/pass_empty.rs
@@ -14,11 +14,13 @@ fn valid_empty() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, "EmptyFormat").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, "EmptyFormat")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![])),
     );
 
@@ -32,11 +34,13 @@ fn valid_empty_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, "EmptyFormat").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, "EmptyFormat")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![])),
     );
 

--- a/tests/input/struct/pass_empty.rs
+++ b/tests/input/struct/pass_empty.rs
@@ -13,14 +13,12 @@ fn valid_empty() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, "EmptyFormat")
-            .unwrap(),
+        read_context.read_item(&mut reader, "EmptyFormat").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![])),
     );
 
@@ -33,14 +31,12 @@ fn valid_empty_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, "EmptyFormat")
-            .unwrap(),
+        read_context.read_item(&mut reader, "EmptyFormat").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![])),
     );
 

--- a/tests/input/struct/pass_pair.rs
+++ b/tests/input/struct/pass_pair.rs
@@ -14,10 +14,10 @@ fn eof_first() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat") {
+    match read_context.read_item(&mut reader, &"PairFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -32,10 +32,10 @@ fn eof_second() {
     writer.write::<U8>(255); // PairFormat::first
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat") {
+    match read_context.read_item(&mut reader, &"PairFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -51,14 +51,12 @@ fn valid_pair() {
     writer.write::<I8>(-30); // PairFormat::second
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"PairFormat").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("first".to_owned(), Arc::new(Value::int(31))),
             ("second".to_owned(), Arc::new(Value::int(-30))),
@@ -76,14 +74,12 @@ fn valid_pair_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"PairFormat").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("first".to_owned(), Arc::new(Value::int(255))),
             ("second".to_owned(), Arc::new(Value::int(-30))),

--- a/tests/input/struct/pass_pair.rs
+++ b/tests/input/struct/pass_pair.rs
@@ -15,9 +15,9 @@ fn eof_first() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"PairFormat") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,9 +33,9 @@ fn eof_second() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"PairFormat") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -52,11 +52,13 @@ fn valid_pair() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, &"PairFormat").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("first".to_owned(), Arc::new(Value::int(31))),
             ("second".to_owned(), Arc::new(Value::int(-30))),
@@ -75,11 +77,13 @@ fn valid_pair_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, &"PairFormat").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"PairFormat")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![
             ("first".to_owned(), Arc::new(Value::int(255))),
             ("second".to_owned(), Arc::new(Value::int(-30))),

--- a/tests/input/struct/pass_singleton.rs
+++ b/tests/input/struct/pass_singleton.rs
@@ -15,9 +15,9 @@ fn eof_inner() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
-    match read_context.read_item(&FIXTURE, &"Byte") {
+    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Byte") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -33,11 +33,13 @@ fn valid_singleton() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, &"Byte").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![(
             "inner".to_owned(),
             Arc::new(Value::int(31)),
@@ -55,11 +57,13 @@ fn valid_singleton_trailing() {
 
     let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
+    let mut read_context = binary::read::Context::new(&globals);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context.read_item(&FIXTURE, &"Byte").unwrap(),
+        read_context
+            .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
+            .unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![(
             "inner".to_owned(),
             Arc::new(Value::int(255)),

--- a/tests/input/struct/pass_singleton.rs
+++ b/tests/input/struct/pass_singleton.rs
@@ -14,10 +14,10 @@ fn eof_inner() {
     let writer = FormatWriter::new(vec![]);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
-    match read_context.read_item(&mut read_scope.reader(), &FIXTURE, &"Byte") {
+    match read_context.read_item(&mut reader, &"Byte") {
         Err(ReadError::Eof(_)) => {}
         Err(err) => panic!("eof error expected, found: {:?}", err),
         Ok(_) => panic!("error expected, found: Ok(_)"),
@@ -32,14 +32,12 @@ fn valid_singleton() {
     writer.write::<U8>(31); // Byte::inner
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Byte").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![(
             "inner".to_owned(),
             Arc::new(Value::int(31)),
@@ -56,14 +54,12 @@ fn valid_singleton_trailing() {
     writer.write::<U8>(42);
 
     let globals = core::Globals::default();
-    let read_scope = ReadScope::new(writer.buffer());
-    let mut read_context = binary::read::Context::new(&globals);
+    let mut reader = ReadScope::new(writer.buffer()).reader();
+    let mut read_context = binary::read::Context::new(&globals, &FIXTURE);
 
     fathom_test_util::assert_is_equal!(
         globals,
-        read_context
-            .read_item(&mut read_scope.reader(), &FIXTURE, &"Byte")
-            .unwrap(),
+        read_context.read_item(&mut reader, &"Byte").unwrap(),
         Value::StructTerm(BTreeMap::from_iter(vec![(
             "inner".to_owned(),
             Arc::new(Value::int(255)),


### PR DESCRIPTION
This changes the binary interpreter's API to be a bit easier to work with. Instead of supplying a module when reading an item from a `ReadScope`, the module is loaded up when the interpreter context is initially constructed. The `ReadScope` is then passed as an argument to `Context::read_item`.