### PR TITLE
Bump MSRV to 1.43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.42.0", "stable", "beta", "nightly"]
+        rust: ["1.43.0", "stable", "beta", "nightly"]
     name: Check (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.42.0", "stable", "beta", "nightly"]
+        rust: ["1.43.0", "stable", "beta", "nightly"]
     name: Test Suite (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
 #     runs-on: ubuntu-20.04
 #     strategy:
 #       matrix:
-#         rust: ["1.42.0", "stable", "beta", "nightly"]
+#         rust: ["1.43.0", "stable", "beta", "nightly"]
 #     name: Clippy (${{ matrix.rust }})
 #     steps:
 #       - uses: actions/checkout@v2


### PR DESCRIPTION
This was broken in lalrpop/lalrpop#564. See https://github.com/lalrpop/lalrpop/issues/580 for more information.