### PR TITLE
Remove level substitutions in elaborator

### DIFF
--- a/fathom/src/lang/core.rs
+++ b/fathom/src/lang/core.rs
@@ -438,6 +438,15 @@ impl<Entry: Clone> Locals<Entry> {
     pub fn clear(&mut self) {
         self.entries.clear();
     }
+
+    /// Returns a reverse iterator over the entries in the environment and the
+    /// indices where those entries were bound.
+    pub fn iter_rev(&self) -> impl Iterator<Item = (LocalIndex, &Entry)> {
+        (self.entries.iter().rev()).scan(0, |current_index, entry| {
+            let local_index = LocalIndex(std::mem::replace(current_index, *current_index + 1));
+            Some((local_index, entry))
+        })
+    }
 }
 
 impl<Entry: Clone + fmt::Debug> fmt::Debug for Locals<Entry> {


### PR DESCRIPTION
Found a simpler way of doing looking up a type annotation based on its name, by storing variable names alongside their type annotations as opposed to in a separate `Vec`.