### PR TITLE
Bump MSRV to Rust 1.46+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.43.0", "stable", "beta", "nightly"]
+        rust: ["1.46.0", "stable", "beta", "nightly"]
     name: Check (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.43.0", "stable", "beta", "nightly"]
+        rust: ["1.46.0", "stable", "beta", "nightly"]
     name: Test Suite (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
 #     runs-on: ubuntu-20.04
 #     strategy:
 #       matrix:
-#         rust: ["1.43.0", "stable", "beta", "nightly"]
+#         rust: ["1.46.0", "stable", "beta", "nightly"]
 #     name: Clippy (${{ matrix.rust }})
 #     steps:
 #       - uses: actions/checkout@v2


### PR DESCRIPTION
Bumping due to im depending on a new version of sized-chunks. The error we got on Rust 1.43 was:

```
 error[E0658]: `if` is not allowed in a `const fn`
Error:    --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/sized-chunks-0.6.3/src/inline_array/mod.rs:108:5
    |
108 | /     if element_size == 0 {
109 | |         usize::MAX
110 | |     } else {
111 | |         (host_size - header_size) / element_size
112 | |     }
    | |_____^
    |
    = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
```