### PR TITLE
Rework how we manage file ids in the AST.

### DIFF
--- a/fathom-test/src/support/directives/lexer.rs
+++ b/fathom-test/src/support/directives/lexer.rs
@@ -1,5 +1,6 @@
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::{Files, SimpleFiles};
+use fathom::lang::FileId;
 use std::ops::Range;
 
 use super::SpannedString;
@@ -23,13 +24,13 @@ pub type Token = (Range<usize>, SpannedString, Option<SpannedString>);
 /// eol         ::= "\n"
 /// ```
 pub struct Lexer<'input> {
-    file_id: usize,
+    file_id: FileId,
     eof: usize,
     chars: std::str::CharIndices<'input>,
 }
 
 impl<'input> Lexer<'input> {
-    pub fn new(files: &'input SimpleFiles<String, String>, file_id: usize) -> Lexer<'input> {
+    pub fn new(files: &'input SimpleFiles<String, String>, file_id: FileId) -> Lexer<'input> {
         let source = files.source(file_id).unwrap();
         Lexer {
             file_id,

--- a/fathom-test/src/support/directives/mod.rs
+++ b/fathom-test/src/support/directives/mod.rs
@@ -1,5 +1,6 @@
 use codespan_reporting::diagnostic::Severity;
 use codespan_reporting::files::Location;
+use fathom::lang::FileId;
 use regex::Regex;
 use std::fmt;
 use std::ops::Range;
@@ -42,7 +43,7 @@ impl Default for Directives {
 
 #[derive(Clone, Debug)]
 pub struct ExpectedDiagnostic {
-    pub file_id: usize,
+    pub file_id: FileId,
     pub line_index: usize,
     pub location: Location,
     pub severity: Severity,

--- a/fathom-test/src/support/directives/parser.rs
+++ b/fathom-test/src/support/directives/parser.rs
@@ -1,18 +1,19 @@
 use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
 use codespan_reporting::files::{Files, SimpleFiles};
+use fathom::lang::FileId;
 use std::ops::Range;
 
 use super::{Directives, ExpectedDiagnostic, SpannedString, Token};
 
 pub struct Parser<'a> {
     files: &'a SimpleFiles<String, String>,
-    file_id: usize,
+    file_id: FileId,
     directives: Directives,
     diagnostics: Vec<Diagnostic<usize>>,
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(files: &'a SimpleFiles<String, String>, file_id: usize) -> Parser<'a> {
+    pub fn new(files: &'a SimpleFiles<String, String>, file_id: FileId) -> Parser<'a> {
         Parser {
             files,
             file_id,

--- a/fathom-test/src/support/mod.rs
+++ b/fathom-test/src/support/mod.rs
@@ -2,6 +2,7 @@ use codespan_reporting::diagnostic::{Diagnostic, LabelStyle, Severity};
 use codespan_reporting::files::{Files, SimpleFiles};
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{BufferWriter, ColorChoice, StandardStream};
+use fathom::lang::FileId;
 use fathom::pass::{core_to_pretty, core_to_surface, surface_to_core, surface_to_doc};
 use std::fs;
 use std::path::PathBuf;
@@ -70,7 +71,7 @@ struct Test {
     test_name: String,
     term_config: codespan_reporting::term::Config,
     input_fathom_path: PathBuf,
-    input_fathom_file_id: usize,
+    input_fathom_file_id: FileId,
     snapshot_filename: PathBuf,
     directives: directives::Directives,
     failed_checks: Vec<&'static str>,
@@ -524,7 +525,7 @@ impl Test {
 
 fn retain_unexpected(
     files: &SimpleFiles<String, String>,
-    found_diagnostics: &mut Vec<Diagnostic<usize>>,
+    found_diagnostics: &mut Vec<Diagnostic<FileId>>,
     expected_diagnostics: &mut Vec<ExpectedDiagnostic>,
 ) {
     use std::collections::BTreeSet;
@@ -552,7 +553,7 @@ fn retain_unexpected(
 
 fn is_expected(
     files: &SimpleFiles<String, String>,
-    found_diagnostic: &Diagnostic<usize>,
+    found_diagnostic: &Diagnostic<FileId>,
     expected_diagnostic: &ExpectedDiagnostic,
 ) -> bool {
     // TODO: higher quality diagnostic message matching

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
-use crate::lang::{core, surface};
+use crate::lang::{core, surface, FileId};
 use crate::pass::{core_to_pretty, surface_to_core, surface_to_doc, surface_to_pretty};
 use crate::reporting::Message;
 
@@ -231,7 +231,7 @@ impl Driver {
         }
     }
 
-    fn parse_surface_module(&mut self, file_id: usize) -> surface::Module {
+    fn parse_surface_module(&mut self, file_id: FileId) -> surface::Module {
         let file = self.files.get(file_id).unwrap();
         surface::Module::parse(file_id, file.source(), &mut self.messages)
     }

--- a/fathom/src/lang.rs
+++ b/fathom/src/lang.rs
@@ -6,6 +6,9 @@ pub mod core;
 //       🠃
 //      ...
 
+/// File identifier
+pub type FileId = usize;
+
 /// A range of source code.
 ///
 /// This is added to simplify working with ranges, because [`std::ops::Range`]

--- a/fathom/src/lang.rs
+++ b/fathom/src/lang.rs
@@ -9,6 +9,53 @@ pub mod core;
 /// File identifier
 pub type FileId = usize;
 
+/// Location metadata, for diagnostic reporting purposes.
+#[derive(Debug, Copy, Clone)]
+pub enum Location {
+    /// Generated code.
+    Generated,
+    /// Ranges in a text file.
+    FileRange(FileId, Range),
+}
+
+impl Location {
+    pub fn generated() -> Location {
+        Location::Generated
+    }
+
+    pub fn file_range(file_id: FileId, range: impl Into<Range>) -> Location {
+        Location::FileRange(file_id, range.into())
+    }
+
+    pub fn start(self) -> Location {
+        match self {
+            Location::Generated => Location::Generated,
+            Location::FileRange(file_id, range) => Location::FileRange(file_id, range.start()),
+        }
+    }
+
+    pub fn end(self) -> Location {
+        match self {
+            Location::Generated => Location::Generated,
+            Location::FileRange(file_id, range) => Location::FileRange(file_id, range.end()),
+        }
+    }
+
+    pub fn merge(self, other: Location) -> Location {
+        match (self, other) {
+            (Location::Generated, Location::Generated) => Location::Generated,
+            (Location::FileRange(file_id0, range0), Location::FileRange(file_id1, range1)) => {
+                assert_eq!(
+                    file_id0, file_id1,
+                    "tried to merge source locations with different file ids"
+                );
+                Location::FileRange(file_id0, Range::merge(range0, range1))
+            }
+            (_, _) => Location::Generated,
+        }
+    }
+}
+
 /// A range of source code.
 ///
 /// This is added to simplify working with ranges, because [`std::ops::Range`]
@@ -17,6 +64,29 @@ pub type FileId = usize;
 pub struct Range {
     pub start: usize,
     pub end: usize,
+}
+
+impl Range {
+    pub fn merge(self, other: Range) -> Range {
+        Range {
+            start: std::cmp::min(self.start, other.start),
+            end: std::cmp::max(self.end, other.end),
+        }
+    }
+
+    pub fn start(self) -> Range {
+        Range {
+            start: self.start,
+            end: self.start,
+        }
+    }
+
+    pub fn end(self) -> Range {
+        Range {
+            start: self.end,
+            end: self.end,
+        }
+    }
 }
 
 impl Into<std::ops::Range<usize>> for Range {
@@ -36,29 +106,24 @@ impl From<std::ops::Range<usize>> for Range {
 
 /// Data that covers some range of source code.
 #[derive(Debug, Clone)]
-pub struct Ranged<Data> {
-    pub range: Range,
+pub struct Located<Data> {
+    pub location: Location,
     pub data: Data,
 }
 
-impl<Data> Ranged<Data> {
-    pub fn new(range: Range, data: Data) -> Ranged<Data> {
-        Ranged { range, data }
+impl<Data> Located<Data> {
+    pub fn new(location: Location, data: Data) -> Located<Data> {
+        Located { location, data }
+    }
+
+    pub fn generated(data: Data) -> Located<Data> {
+        Located::new(Location::generated(), data)
     }
 }
 
-impl<Data: PartialEq> PartialEq for Ranged<Data> {
+impl<Data: PartialEq> PartialEq for Located<Data> {
     /// Ignores source location metadata.
-    fn eq(&self, other: &Ranged<Data>) -> bool {
+    fn eq(&self, other: &Located<Data>) -> bool {
         self.data == other.data
-    }
-}
-
-impl<Data> From<Data> for Ranged<Data> {
-    #![allow(clippy::reversed_empty_ranges)]
-    fn from(data: Data) -> Ranged<Data> {
-        // TODO: Use a better marker for data that does not originate from to a
-        // specific source location.
-        Ranged::new(Range::from(0..0), data)
     }
 }

--- a/fathom/src/lang/core.rs
+++ b/fathom/src/lang/core.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::ieee754;
-use crate::lang::Ranged;
+use crate::lang::{FileId, Ranged};
 use crate::reporting::Message;
 
 mod lexer;
@@ -24,7 +24,7 @@ pub mod typing;
 #[derive(Debug, Clone)]
 pub struct Module {
     /// The file in which this module was defined.
-    pub file_id: usize,
+    pub file_id: FileId,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// The items in this module.
@@ -32,7 +32,7 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn parse(file_id: usize, source: &str, messages: &mut Vec<Message>) -> Module {
+    pub fn parse(file_id: FileId, source: &str, messages: &mut Vec<Message>) -> Module {
         let tokens = lexer::tokens(file_id, source);
         grammar::ModuleParser::new()
             .parse(file_id, messages, tokens)

--- a/fathom/src/lang/core.rs
+++ b/fathom/src/lang/core.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::ieee754;
-use crate::lang::{FileId, Ranged};
+use crate::lang::{FileId, Located};
 use crate::reporting::Message;
 
 mod lexer;
@@ -23,8 +23,6 @@ pub mod typing;
 /// A module of items.
 #[derive(Debug, Clone)]
 pub struct Module {
-    /// The file in which this module was defined.
-    pub file_id: FileId,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// The items in this module.
@@ -39,7 +37,6 @@ impl Module {
             .unwrap_or_else(|error| {
                 messages.push(Message::from_lalrpop(file_id, error));
                 Module {
-                    file_id,
                     doc: Arc::new([]),
                     items: Vec::new(),
                 }
@@ -55,7 +52,7 @@ impl PartialEq for Module {
 }
 
 /// Items in the core language.
-pub type Item = Ranged<ItemData>;
+pub type Item = Located<ItemData>;
 
 /// Items in a module.
 #[derive(Debug, Clone, PartialEq)]
@@ -135,7 +132,7 @@ impl PartialEq for Primitive {
 }
 
 /// Terms in the core language.
-pub type Term = Ranged<TermData>;
+pub type Term = Located<TermData>;
 
 /// Terms.
 #[derive(Debug, Clone, PartialEq)]
@@ -186,7 +183,7 @@ pub enum TermData {
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldDeclaration {
     pub doc: Arc<[String]>,
-    pub label: Ranged<String>,
+    pub label: Located<String>,
     // FIXME: can't use `r#type` in LALRPOP grammars
     pub type_: Arc<Term>,
 }
@@ -194,7 +191,7 @@ pub struct FieldDeclaration {
 /// A field in a struct term.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldDefinition {
-    pub label: Ranged<String>,
+    pub label: Located<String>,
     pub term: Arc<Term>,
 }
 
@@ -222,80 +219,79 @@ impl Default for Globals {
         use self::Sort::*;
         use self::TermData::*;
 
+        let term = Term::generated;
+
         let mut entries = BTreeMap::new();
 
-        entries.insert("Int".to_owned(), (Arc::new(Term::from(Sort(Type))), None));
-        entries.insert("F32".to_owned(), (Arc::new(Term::from(Sort(Type))), None));
-        entries.insert("F64".to_owned(), (Arc::new(Term::from(Sort(Type))), None));
-        entries.insert("Bool".to_owned(), (Arc::new(Term::from(Sort(Type))), None));
+        entries.insert("Int".to_owned(), (Arc::new(term(Sort(Type))), None));
+        entries.insert("F32".to_owned(), (Arc::new(term(Sort(Type))), None));
+        entries.insert("F64".to_owned(), (Arc::new(term(Sort(Type))), None));
+        entries.insert("Bool".to_owned(), (Arc::new(term(Sort(Type))), None));
         entries.insert(
             "true".to_owned(),
-            (Arc::new(Term::from(Global("Bool".to_owned()))), None),
+            (Arc::new(term(Global("Bool".to_owned()))), None),
         );
         entries.insert(
             "false".to_owned(),
-            (Arc::new(Term::from(Global("Bool".to_owned()))), None),
+            (Arc::new(term(Global("Bool".to_owned()))), None),
         );
         entries.insert(
             "Array".to_owned(),
             (
-                Arc::new(Term::from(FunctionType(
-                    Arc::new(Term::from(Global("Int".to_owned()))),
-                    Arc::new(Term::from(FunctionType(
-                        Arc::new(Term::from(Sort(Type))),
-                        Arc::new(Term::from(Sort(Type))),
+                Arc::new(term(FunctionType(
+                    Arc::new(term(Global("Int".to_owned()))),
+                    Arc::new(term(FunctionType(
+                        Arc::new(term(Sort(Type))),
+                        Arc::new(term(Sort(Type))),
                     ))),
                 ))),
                 None,
             ),
         );
-        entries.insert("Pos".to_owned(), (Arc::new(Term::from(Sort(Type))), None));
+        entries.insert("Pos".to_owned(), (Arc::new(term(Sort(Type))), None));
 
-        entries.insert("U8".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("U16Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("U16Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("U32Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("U32Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("U64Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("U64Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("S8".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("S16Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("S16Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("S32Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("S32Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("S64Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("S64Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("F32Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("F32Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("F64Le".to_owned(), (Arc::new(Term::from(FormatType)), None));
-        entries.insert("F64Be".to_owned(), (Arc::new(Term::from(FormatType)), None));
+        entries.insert("U8".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("U16Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("U16Be".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("U32Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("U32Be".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("U64Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("U64Be".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("S8".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("S16Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("S16Be".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("S32Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("S32Be".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("S64Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("S64Be".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("F32Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("F32Be".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("F64Le".to_owned(), (Arc::new(term(FormatType)), None));
+        entries.insert("F64Be".to_owned(), (Arc::new(term(FormatType)), None));
         entries.insert(
             "FormatArray".to_owned(),
             (
-                Arc::new(Term::from(FunctionType(
-                    Arc::new(Term::from(Global("Int".to_owned()))),
-                    Arc::new(Term::from(FunctionType(
-                        Arc::new(Term::from(FormatType)),
-                        Arc::new(Term::from(FormatType)),
+                Arc::new(term(FunctionType(
+                    Arc::new(term(Global("Int".to_owned()))),
+                    Arc::new(term(FunctionType(
+                        Arc::new(term(FormatType)),
+                        Arc::new(term(FormatType)),
                     ))),
                 ))),
                 None,
             ),
         );
-        entries.insert(
-            "CurrentPos".to_owned(),
-            (Arc::new(Term::from(FormatType)), None),
-        );
+        entries.insert("CurrentPos".to_owned(), (Arc::new(term(FormatType)), None));
         entries.insert(
             "Link".to_owned(),
             (
-                Arc::new(Term::from(FunctionType(
-                    Arc::new(Term::from(Global("Pos".to_owned()))),
-                    Arc::new(Term::from(FunctionType(
-                        Arc::new(Term::from(Global("Int".to_owned()))),
-                        Arc::new(Term::from(FunctionType(
-                            Arc::new(Term::from(FormatType)),
-                            Arc::new(Term::from(FormatType)),
+                Arc::new(term(FunctionType(
+                    Arc::new(term(Global("Pos".to_owned()))),
+                    Arc::new(term(FunctionType(
+                        Arc::new(term(Global("Int".to_owned()))),
+                        Arc::new(term(FunctionType(
+                            Arc::new(term(FormatType)),
+                            Arc::new(term(FormatType)),
                         ))),
                     ))),
                 ))),

--- a/fathom/src/lang/core/binary/read.rs
+++ b/fathom/src/lang/core/binary/read.rs
@@ -42,7 +42,7 @@ impl<'me> Context<'me> {
                 ),
             };
 
-            let item = semantics::Item::new(item.range, item_data);
+            let item = semantics::Item::new(item.location, item_data);
             context.items.insert(name, item);
         }
 

--- a/fathom/src/lang/core/grammar.lalrpop
+++ b/fathom/src/lang/core/grammar.lalrpop
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::lang::{Range, Ranged};
+use crate::lang::{FileId, Range, Ranged};
 use crate::lang::core::{
     Constant, FieldDeclaration, FieldDefinition, ItemData, LocalIndex, Module, Primitive, Sort,
     StructType, StructFormat, Term, TermData,
@@ -9,7 +9,7 @@ use crate::lang::core::lexer::Token;
 use crate::literal;
 use crate::reporting::{LexerMessage, Message};
 
-grammar<'source>(file_id: usize, messages: &mut Vec<Message>);
+grammar<'source>(file_id: FileId, messages: &mut Vec<Message>);
 
 extern {
     type Location = usize;

--- a/fathom/src/lang/core/grammar.lalrpop
+++ b/fathom/src/lang/core/grammar.lalrpop
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::lang::{FileId, Range, Ranged};
+use crate::lang::{FileId, Location, Located};
 use crate::lang::core::{
     Constant, FieldDeclaration, FieldDefinition, ItemData, LocalIndex, Module, Primitive, Sort,
     StructType, StructFormat, Term, TermData,
@@ -59,9 +59,8 @@ extern {
 }
 
 pub Module: Module = {
-    <doc: "inner doc comment"*> <items: Ranged<ItemData>*> => {
+    <doc: "inner doc comment"*> <items: Located<ItemData>*> => {
         Module {
-            file_id,
             doc: Arc::from(doc),
             items,
         }
@@ -98,10 +97,10 @@ ItemData: ItemData = {
     },
 };
 
-#[inline] Term: Term = Ranged<TermData>;
-#[inline] ArrowTerm: Term = Ranged<ArrowTermData>;
-#[inline] AppTerm: Term = Ranged<AppTermData>;
-#[inline] AtomicTerm: Term = Ranged<AtomicTermData>;
+#[inline] Term: Term = Located<TermData>;
+#[inline] ArrowTerm: Term = Located<ArrowTermData>;
+#[inline] AppTerm: Term = Located<AppTermData>;
+#[inline] AtomicTerm: Term = Located<AtomicTermData>;
 
 TermData: TermData = {
     ArrowTermData,
@@ -148,26 +147,26 @@ AtomicTermData: TermData = {
         let branches = branches
             .into_iter()
             .filter_map(|(start, literal, end, term)| Some((
-                literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_big_int()?,
+                literal::State::new(Location::file_range(file_id, start..end), literal, messages).number_to_big_int()?,
                 Arc::new(term),
             ))).collect();
 
         TermData::IntElim(Arc::new(head), branches, Arc::new(default))
     },
     "int" <start: @L> <literal: "numeric literal"> <end: @R> => {
-        match literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_big_int() {
+        match literal::State::new(Location::file_range(file_id, start..end), literal, messages).number_to_big_int() {
             Some(value) => TermData::Primitive(Primitive::Int(value)),
             None => TermData::Error,
         }
     },
     "f32" <start: @L> <literal: "numeric literal"> <end: @R> => {
-        match literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_float() {
+        match literal::State::new(Location::file_range(file_id, start..end), literal, messages).number_to_float() {
             Some(value) => TermData::Primitive(Primitive::F32(value)),
             None => TermData::Error,
         }
     },
     "f64" <start: @L> <literal: "numeric literal"> <end: @R> => {
-        match literal::State::new(file_id, Range::from(start..end), literal, messages).number_to_float() {
+        match literal::State::new(Location::file_range(file_id, start..end), literal, messages).number_to_float() {
             Some(value) => TermData::Primitive(Primitive::F64(value)),
             None => TermData::Error,
         }
@@ -177,7 +176,7 @@ AtomicTermData: TermData = {
 
 #[inline]
 FieldDeclaration: FieldDeclaration = {
-    <doc: "doc comment"*> <label: Ranged<Name>> ":" <type_: Term> => {
+    <doc: "doc comment"*> <label: Located<Name>> ":" <type_: Term> => {
         FieldDeclaration {
             doc: Arc::from(doc),
             label,
@@ -188,7 +187,7 @@ FieldDeclaration: FieldDeclaration = {
 
 #[inline]
 FieldDefinition: FieldDefinition = {
-    <label: Ranged<Name>> "=" <term: Term> => {
+    <label: Located<Name>> "=" <term: Term> => {
         FieldDefinition { label, term: Arc::new(term) }
     },
 };
@@ -207,6 +206,6 @@ Separated<Elem, Separator>: Vec<Elem> = {
 };
 
 #[inline]
-Ranged<T>: Ranged<T> = {
-    <start: @L> <data: T> <end: @R> => Ranged::new(Range::from(start..end), data),
+Located<T>: Located<T> = {
+    <start: @L> <data: T> <end: @R> => Located::new(Location::file_range(file_id, start..end), data),
 };

--- a/fathom/src/lang/core/lexer.rs
+++ b/fathom/src/lang/core/lexer.rs
@@ -1,7 +1,7 @@
 use logos::Logos;
 use std::fmt;
 
-use crate::lang::Range;
+use crate::lang::{FileId, Range};
 use crate::reporting::LexerMessage;
 
 /// Tokens in the core language.
@@ -139,7 +139,7 @@ impl<'source> fmt::Display for Token<'source> {
 pub type Spanned<Tok, Loc> = (Loc, Tok, Loc);
 
 pub fn tokens<'source>(
-    file_id: usize,
+    file_id: FileId,
     source: &'source str,
 ) -> impl 'source + Iterator<Item = Result<Spanned<Token<'source>, usize>, LexerMessage>> {
     Token::lexer(source)

--- a/fathom/src/lang/core/lexer.rs
+++ b/fathom/src/lang/core/lexer.rs
@@ -1,7 +1,7 @@
 use logos::Logos;
 use std::fmt;
 
-use crate::lang::{FileId, Range};
+use crate::lang::{FileId, Location};
 use crate::reporting::LexerMessage;
 
 /// Tokens in the core language.
@@ -146,8 +146,7 @@ pub fn tokens<'source>(
         .spanned()
         .map(move |(token, range)| match token {
             Token::Error => Err(LexerMessage::InvalidToken {
-                file_id,
-                range: Range::from(range),
+                location: Location::file_range(file_id, range),
             }),
             token => Ok((range.start, token, range.end)),
         })

--- a/fathom/src/lang/core/typing.rs
+++ b/fathom/src/lang/core/typing.rs
@@ -12,7 +12,7 @@ use crate::lang::core::{
     FieldDeclaration, Globals, ItemData, LocalLevel, Locals, Module, Primitive, Sort, Term,
     TermData,
 };
-use crate::lang::{FileId, Range};
+use crate::lang::Location;
 use crate::reporting::{CoreTypingMessage, Message};
 
 /// Returns the sorts of sorts.
@@ -108,10 +108,10 @@ impl<'me> Context<'me> {
     fn force_item<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range, &'context semantics::ItemData, &'value [Elim])> {
+    ) -> Option<(Location, &'context semantics::ItemData, &'value [Elim])> {
         let (name, elims) = value.try_item()?;
         match self.item_definitions.get(name) {
-            Some(item) => Some((item.range, &item.data, elims)),
+            Some(item) => Some((item.location, &item.data, elims)),
             None => panic!("could not find an item called `{}` in the context", name),
         }
     }
@@ -121,10 +121,10 @@ impl<'me> Context<'me> {
     fn force_struct_type<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range, Arc<[FieldDeclaration]>, &'value [Elim])> {
+    ) -> Option<(Location, Arc<[FieldDeclaration]>, &'value [Elim])> {
         match self.force_item(value) {
-            Some((range, semantics::ItemData::StructType(field_declarations), elims)) => {
-                Some((range, field_declarations.clone(), elims))
+            Some((location, semantics::ItemData::StructType(field_declarations), elims)) => {
+                Some((location, field_declarations.clone(), elims))
             }
             Some(_) | None => None,
         }
@@ -173,14 +173,12 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.local_declarations.is_empty())]
     #[debug_ensures(self.local_definitions.is_empty())]
     pub fn is_module(&mut self, module: &Module) {
-        let file_id = module.file_id;
-
         for item in &module.items {
             use std::collections::hash_map::Entry;
 
             let (item_name, item_data, item_type) = match &item.data {
                 ItemData::Constant(constant) => {
-                    let r#type = self.synth_type(file_id, &constant.term);
+                    let r#type = self.synth_type(&constant.term);
                     let value = self.eval(&constant.term);
 
                     (
@@ -197,16 +195,15 @@ impl<'me> Context<'me> {
                     let type_type = Arc::new(Value::Sort(Sort::Type));
 
                     for field in struct_type.fields.iter() {
-                        self.check_type(file_id, &field.type_, &type_type);
+                        self.check_type(&field.type_, &type_type);
                         let field_type = self.eval(&field.type_);
 
                         if seen_field_labels.insert(field.label.data.clone()) {
                             self.push_local_param(field_type);
                         } else {
                             self.push_message(CoreTypingMessage::FieldRedeclaration {
-                                file_id,
                                 field_name: field.label.data.clone(),
-                                record_range: item.range,
+                                record_location: item.location,
                             });
                         }
                     }
@@ -227,16 +224,15 @@ impl<'me> Context<'me> {
                     let format_type = Arc::new(Value::FormatType);
 
                     for field in struct_format.fields.iter() {
-                        self.check_type(file_id, &field.type_, &format_type);
+                        self.check_type(&field.type_, &format_type);
                         let field_type = semantics::apply_repr(self.eval(&field.type_));
 
                         if seen_field_labels.insert(field.label.data.clone()) {
                             self.push_local_param(field_type);
                         } else {
                             self.push_message(CoreTypingMessage::FieldRedeclaration {
-                                file_id,
                                 field_name: field.label.data.clone(),
-                                record_range: item.range,
+                                record_location: item.location,
                             });
                         }
                     }
@@ -254,15 +250,14 @@ impl<'me> Context<'me> {
             match self.item_definitions.entry(item_name.clone()) {
                 Entry::Vacant(entry) => {
                     self.item_declarations.insert(item_name, item_type);
-                    entry.insert(semantics::Item::new(item.range, item_data));
+                    entry.insert(semantics::Item::new(item.location, item_data));
                 }
                 Entry::Occupied(entry) => {
-                    let original_range = entry.get().range;
+                    let original_location = entry.get().location;
                     self.push_message(CoreTypingMessage::ItemRedefinition {
-                        file_id,
                         name: item_name,
-                        found_range: item.range,
-                        original_range,
+                        found_location: item.location,
+                        original_location,
                     });
                 }
             }
@@ -277,14 +272,13 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn synth_sort(&mut self, file_id: FileId, term: &Term) -> Option<Sort> {
-        match self.synth_type(file_id, term).as_ref() {
+    pub fn synth_sort(&mut self, term: &Term) -> Option<Sort> {
+        match self.synth_type(term).as_ref() {
             Value::Error => None,
             Value::Sort(sort) => Some(*sort),
             r#type => {
                 self.push_message(CoreTypingMessage::UniverseMismatch {
-                    file_id,
-                    term_range: term.range,
+                    term_location: term.location,
                     found_type: self.read_back(&r#type),
                 });
                 None
@@ -297,7 +291,7 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn check_type(&mut self, file_id: FileId, term: &Term, expected_type: &Arc<Value>) {
+    pub fn check_type(&mut self, term: &Term, expected_type: &Arc<Value>) {
         match (&term.data, expected_type.as_ref()) {
             (TermData::Error, _) | (_, Value::Error) => {}
 
@@ -310,8 +304,7 @@ impl<'me> Context<'me> {
                     Some((_, field_declarations, [])) => field_declarations,
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
-                            file_id,
-                            range: term.range,
+                            location: term.location,
                             feature_name: "struct parameters",
                         });
                         return;
@@ -319,8 +312,7 @@ impl<'me> Context<'me> {
                     None => {
                         let expected_type = self.read_back(expected_type);
                         self.push_message(CoreTypingMessage::UnexpectedStructTerm {
-                            file_id,
-                            term_range: term.range,
+                            term_location: term.location,
                             expected_type,
                         });
                         return;
@@ -350,7 +342,7 @@ impl<'me> Context<'me> {
                             let r#type =
                                 self.eval_with_locals(&mut type_locals, &field_declaration.type_);
                             // TODO: stop on errors
-                            self.check_type(file_id, &field_definition.term, &r#type);
+                            self.check_type(&field_definition.term, &r#type);
                             let value = self.eval(&field_definition.term);
 
                             type_locals.push(value);
@@ -369,21 +361,18 @@ impl<'me> Context<'me> {
                 // Record any errors in the context.
                 if !duplicate_labels.is_empty() {
                     self.push_message(CoreTypingMessage::DuplicateStructFields {
-                        file_id,
                         duplicate_labels,
                     });
                 }
                 if !missing_labels.is_empty() {
                     self.push_message(CoreTypingMessage::MissingStructFields {
-                        file_id,
-                        term_range: term.range,
+                        term_location: term.location,
                         missing_labels,
                     });
                 }
                 if !unexpected_labels.is_empty() {
                     self.push_message(CoreTypingMessage::UnexpectedStructFields {
-                        file_id,
-                        term_range: term.range,
+                        term_location: term.location,
                         unexpected_labels,
                     });
                 }
@@ -392,7 +381,7 @@ impl<'me> Context<'me> {
             (TermData::ArrayTerm(elem_terms), _) => match expected_type.try_global() {
                 Some(("Array", [Elim::Function(len), Elim::Function(elem_type)])) => {
                     for elem_term in elem_terms {
-                        self.check_type(file_id, elem_term, elem_type);
+                        self.check_type(elem_term, elem_type);
                     }
 
                     match len.as_ref() {
@@ -402,8 +391,7 @@ impl<'me> Context<'me> {
                             let found_len =
                                 Arc::new(Value::Primitive(Primitive::Int(elem_terms.len().into())));
                             self.push_message(CoreTypingMessage::TypeMismatch {
-                                file_id,
-                                term_range: term.range,
+                                term_location: term.location,
                                 expected_type: self.read_back(expected_type),
                                 found_type: self.read_back(&Value::global(
                                     "Array",
@@ -418,8 +406,7 @@ impl<'me> Context<'me> {
                 }
                 Some(_) | None => {
                     self.push_message(CoreTypingMessage::UnexpectedArrayTerm {
-                        file_id,
-                        term_range: term.range,
+                        term_location: term.location,
                         expected_type: self.read_back(expected_type),
                     });
                 }
@@ -427,24 +414,23 @@ impl<'me> Context<'me> {
 
             (TermData::BoolElim(term, if_true, if_false), _) => {
                 let bool_type = Arc::new(Value::global("Bool", Vec::new()));
-                self.check_type(file_id, term, &bool_type);
-                self.check_type(file_id, if_true, expected_type);
-                self.check_type(file_id, if_false, expected_type);
+                self.check_type(term, &bool_type);
+                self.check_type(if_true, expected_type);
+                self.check_type(if_false, expected_type);
             }
             (TermData::IntElim(head, branches, default), _) => {
                 let int_type = Arc::new(Value::global("Int", Vec::new()));
-                self.check_type(file_id, head, &int_type);
+                self.check_type(head, &int_type);
                 for term in branches.values() {
-                    self.check_type(file_id, term, expected_type);
+                    self.check_type(term, expected_type);
                 }
-                self.check_type(file_id, default, expected_type);
+                self.check_type(default, expected_type);
             }
 
-            (_, expected_type) => match self.synth_type(file_id, term) {
+            (_, expected_type) => match self.synth_type(term) {
                 found_type if self.is_equal(&found_type, expected_type) => {}
                 found_type => self.push_message(CoreTypingMessage::TypeMismatch {
-                    file_id,
-                    term_range: term.range,
+                    term_location: term.location,
                     expected_type: self.read_back(expected_type),
                     found_type: self.read_back(&found_type),
                 }),
@@ -457,15 +443,14 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn synth_type(&mut self, file_id: FileId, term: &Term) -> Arc<Value> {
+    pub fn synth_type(&mut self, term: &Term) -> Arc<Value> {
         match &term.data {
             TermData::Global(global_name) => match self.globals.get(global_name) {
                 Some((r#type, _)) => self.eval(r#type),
                 None => {
                     self.push_message(CoreTypingMessage::GlobalNameNotFound {
-                        file_id,
                         global_name: global_name.clone(),
-                        global_name_range: term.range,
+                        global_name_location: term.location,
                     });
                     Arc::new(Value::Error)
                 }
@@ -474,9 +459,8 @@ impl<'me> Context<'me> {
                 Some(r#type) => r#type.clone(),
                 None => {
                     self.push_message(CoreTypingMessage::ItemNameNotFound {
-                        file_id,
                         item_name: item_name.clone(),
-                        item_name_range: term.range,
+                        item_name_location: term.location,
                     });
                     Arc::new(Value::Error)
                 }
@@ -485,19 +469,18 @@ impl<'me> Context<'me> {
                 Some(r#type) => r#type.clone(),
                 None => {
                     self.push_message(CoreTypingMessage::LocalIndexNotFound {
-                        file_id,
                         local_index: *local_index,
-                        local_index_range: term.range,
+                        local_index_location: term.location,
                     });
                     Arc::new(Value::Error)
                 }
             },
 
-            TermData::Ann(term, r#type) => match self.synth_sort(file_id, r#type) {
+            TermData::Ann(term, r#type) => match self.synth_sort(r#type) {
                 None => Arc::new(Value::Error),
                 Some(_) => {
                     let r#type = self.eval(r#type);
-                    self.check_type(file_id, term, &r#type);
+                    self.check_type(term, &r#type);
                     r#type
                 }
             },
@@ -505,16 +488,15 @@ impl<'me> Context<'me> {
                 Some(sort) => Arc::new(Value::Sort(sort)),
                 None => {
                     self.push_message(CoreTypingMessage::TermHasNoType {
-                        file_id,
-                        term_range: term.range,
+                        term_location: term.location,
                     });
                     Arc::new(Value::Error)
                 }
             },
 
             TermData::FunctionType(param_type, body_type) => {
-                let param_sort = self.synth_sort(file_id, param_type);
-                let body_sort = self.synth_sort(file_id, body_type);
+                let param_sort = self.synth_sort(param_type);
+                let body_sort = self.synth_sort(body_type);
 
                 match (param_sort, body_sort) {
                     (Some(param_sort), Some(body_sort)) => {
@@ -524,18 +506,17 @@ impl<'me> Context<'me> {
                 }
             }
             TermData::FunctionElim(head, argument) => {
-                match self.synth_type(file_id, head).as_ref() {
+                match self.synth_type(head).as_ref() {
                     Value::FunctionType(param_type, body_type) => {
-                        self.check_type(file_id, argument, &param_type);
+                        self.check_type(argument, &param_type);
                         (*body_type).clone() // FIXME: Clone
                     }
                     Value::Error => Arc::new(Value::Error),
                     head_type => {
                         self.push_message(CoreTypingMessage::NotAFunction {
-                            file_id,
-                            head_range: head.range,
+                            head_location: head.location,
                             head_type: self.read_back(head_type),
-                            argument_range: argument.range,
+                            argument_location: argument.location,
                         });
                         Arc::new(Value::Error)
                     }
@@ -544,13 +525,12 @@ impl<'me> Context<'me> {
 
             TermData::StructTerm(_) => {
                 self.push_message(CoreTypingMessage::AmbiguousTerm {
-                    file_id,
-                    term_range: term.range,
+                    term_location: term.location,
                 });
                 Arc::new(Value::Error)
             }
             TermData::StructElim(head, label) => {
-                let head_type = self.synth_type(file_id, head);
+                let head_type = self.synth_type(head);
                 if let Value::Error = head_type.as_ref() {
                     return Arc::new(Value::Error);
                 }
@@ -579,8 +559,7 @@ impl<'me> Context<'me> {
                     }
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
-                            file_id,
-                            range: term.range,
+                            location: term.location,
                             feature_name: "struct parameters",
                         });
                         return Arc::new(Value::Error);
@@ -590,8 +569,7 @@ impl<'me> Context<'me> {
 
                 let head_type = self.read_back(&head_type);
                 self.push_message(CoreTypingMessage::FieldNotFound {
-                    file_id,
-                    head_range: head.range,
+                    head_location: head.location,
                     head_type,
                     label: label.clone(),
                 });
@@ -600,8 +578,7 @@ impl<'me> Context<'me> {
 
             TermData::ArrayTerm(_) => {
                 self.push_message(CoreTypingMessage::AmbiguousTerm {
-                    file_id,
-                    term_range: term.range,
+                    term_location: term.location,
                 });
                 Arc::new(Value::Error)
             }
@@ -614,16 +591,15 @@ impl<'me> Context<'me> {
             },
             TermData::BoolElim(head, if_true, if_false) => {
                 let bool_type = Arc::new(Value::global("Bool", Vec::new()));
-                self.check_type(file_id, head, &bool_type);
-                let if_true_type = self.synth_type(file_id, if_true);
-                let if_false_type = self.synth_type(file_id, if_false);
+                self.check_type(head, &bool_type);
+                let if_true_type = self.synth_type(if_true);
+                let if_false_type = self.synth_type(if_false);
 
                 if self.is_equal(&if_true_type, &if_false_type) {
                     if_true_type
                 } else {
                     self.push_message(CoreTypingMessage::TypeMismatch {
-                        file_id,
-                        term_range: if_false.range,
+                        term_location: if_false.location,
                         expected_type: self.read_back(&if_true_type),
                         found_type: self.read_back(&if_false_type),
                     });
@@ -632,8 +608,7 @@ impl<'me> Context<'me> {
             }
             TermData::IntElim(_, _, _) => {
                 self.push_message(CoreTypingMessage::AmbiguousTerm {
-                    file_id,
-                    term_range: term.range,
+                    term_location: term.location,
                 });
                 Arc::new(Value::Error)
             }

--- a/fathom/src/lang/core/typing.rs
+++ b/fathom/src/lang/core/typing.rs
@@ -12,7 +12,7 @@ use crate::lang::core::{
     FieldDeclaration, Globals, ItemData, LocalLevel, Locals, Module, Primitive, Sort, Term,
     TermData,
 };
-use crate::lang::Range;
+use crate::lang::{FileId, Range};
 use crate::reporting::{CoreTypingMessage, Message};
 
 /// Returns the sorts of sorts.
@@ -277,7 +277,7 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn synth_sort(&mut self, file_id: usize, term: &Term) -> Option<Sort> {
+    pub fn synth_sort(&mut self, file_id: FileId, term: &Term) -> Option<Sort> {
         match self.synth_type(file_id, term).as_ref() {
             Value::Error => None,
             Value::Sort(sort) => Some(*sort),
@@ -297,7 +297,7 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn check_type(&mut self, file_id: usize, term: &Term, expected_type: &Arc<Value>) {
+    pub fn check_type(&mut self, file_id: FileId, term: &Term, expected_type: &Arc<Value>) {
         match (&term.data, expected_type.as_ref()) {
             (TermData::Error, _) | (_, Value::Error) => {}
 
@@ -457,7 +457,7 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn synth_type(&mut self, file_id: usize, term: &Term) -> Arc<Value> {
+    pub fn synth_type(&mut self, file_id: FileId, term: &Term) -> Arc<Value> {
         match &term.data {
             TermData::Global(global_name) => match self.globals.get(global_name) {
                 Some((r#type, _)) => self.eval(r#type),

--- a/fathom/src/lang/surface.rs
+++ b/fathom/src/lang/surface.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::lang::{FileId, Ranged};
+use crate::lang::{FileId, Located};
 use crate::reporting::Message;
 
 mod lexer;
@@ -15,8 +15,6 @@ mod grammar {
 /// A module of items.
 #[derive(Debug, Clone)]
 pub struct Module {
-    /// The file in which this module was defined.
-    pub file_id: FileId,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// The items in this module.
@@ -31,7 +29,6 @@ impl Module {
             .unwrap_or_else(|error| {
                 messages.push(Message::from_lalrpop(file_id, error));
                 Module {
-                    file_id,
                     doc: Arc::new([]),
                     items: Vec::new(),
                 }
@@ -40,7 +37,7 @@ impl Module {
 }
 
 /// Items in the surface language.
-pub type Item = Ranged<ItemData>;
+pub type Item = Located<ItemData>;
 
 /// Items in a module.
 #[derive(Debug, Clone)]
@@ -65,7 +62,7 @@ pub struct Constant {
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// Name of this definition.
-    pub name: Ranged<String>,
+    pub name: Located<String>,
     /// Optional type annotation
     // FIXME: can't use `r#type` in LALRPOP grammars
     pub type_: Option<Term>,
@@ -79,7 +76,7 @@ pub struct StructType {
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// Name of this definition.
-    pub name: Ranged<String>,
+    pub name: Located<String>,
     /// Type of this struct definition.
     // FIXME: can't use `r#type` in LALRPOP grammars
     pub type_: Option<Term>,
@@ -88,7 +85,7 @@ pub struct StructType {
 }
 
 /// Patterns in the surface language.
-pub type Pattern = Ranged<PatternData>;
+pub type Pattern = Located<PatternData>;
 
 /// Pattern data.
 #[derive(Debug, Clone)]
@@ -100,7 +97,7 @@ pub enum PatternData {
 }
 
 /// Terms in the surface language.
-pub type Term = Ranged<TermData>;
+pub type Term = Located<TermData>;
 
 /// Term data.
 #[derive(Debug, Clone)]
@@ -123,7 +120,7 @@ pub enum TermData {
     /// Struct terms.
     StructTerm(Vec<FieldDefinition>),
     /// Struct term eliminations (field lookup).
-    StructElim(Box<Term>, Ranged<String>),
+    StructElim(Box<Term>, Located<String>),
 
     /// Sequence terms.
     SequenceTerm(Vec<Term>),
@@ -149,7 +146,7 @@ pub enum TermData {
 #[derive(Debug, Clone)]
 pub struct FieldDeclaration {
     pub doc: Arc<[String]>,
-    pub label: Ranged<String>,
+    pub label: Located<String>,
     // FIXME: can't use `r#type` in LALRPOP grammars
     pub type_: Term,
 }
@@ -157,6 +154,6 @@ pub struct FieldDeclaration {
 /// A field in a struct term.
 #[derive(Debug, Clone)]
 pub struct FieldDefinition {
-    pub label: Ranged<String>,
+    pub label: Located<String>,
     pub term: Term,
 }

--- a/fathom/src/lang/surface.rs
+++ b/fathom/src/lang/surface.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::lang::Ranged;
+use crate::lang::{FileId, Ranged};
 use crate::reporting::Message;
 
 mod lexer;
@@ -16,7 +16,7 @@ mod grammar {
 #[derive(Debug, Clone)]
 pub struct Module {
     /// The file in which this module was defined.
-    pub file_id: usize,
+    pub file_id: FileId,
     /// Doc comment.
     pub doc: Arc<[String]>,
     /// The items in this module.
@@ -24,7 +24,7 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn parse(file_id: usize, source: &str, messages: &mut Vec<Message>) -> Module {
+    pub fn parse(file_id: FileId, source: &str, messages: &mut Vec<Message>) -> Module {
         let tokens = lexer::tokens(file_id, source);
         grammar::ModuleParser::new()
             .parse(file_id, tokens)

--- a/fathom/src/lang/surface/grammar.lalrpop
+++ b/fathom/src/lang/surface/grammar.lalrpop
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::lang::{Range, Ranged};
+use crate::lang::{FileId, Range, Ranged};
 use crate::lang::surface::{
     Constant, FieldDeclaration, FieldDefinition, ItemData, Module, Pattern, PatternData, StructType,
     Term, TermData,
@@ -8,7 +8,7 @@ use crate::lang::surface::{
 use crate::lang::surface::lexer::Token;
 use crate::reporting::LexerMessage;
 
-grammar<'source>(file_id: usize);
+grammar<'source>(file_id: FileId);
 
 extern {
     type Location = usize;

--- a/fathom/src/lang/surface/grammar.lalrpop
+++ b/fathom/src/lang/surface/grammar.lalrpop
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::lang::{FileId, Range, Ranged};
+use crate::lang::{FileId, Location, Located};
 use crate::lang::surface::{
     Constant, FieldDeclaration, FieldDefinition, ItemData, Module, Pattern, PatternData, StructType,
     Term, TermData,
@@ -59,11 +59,10 @@ extern {
 }
 
 pub Module: Module = {
-    <doc: "inner doc comment"*> <items: Ranged<ItemData>*> => {
+    <doc: "inner doc comment"*> <items: Located<ItemData>*> => {
         let doc = Arc::from(doc);
 
         Module {
-            file_id,
             doc: Arc::from(doc),
             items,
         }
@@ -72,7 +71,7 @@ pub Module: Module = {
 
 ItemData: ItemData = {
     <doc: "doc comment"*>
-    "const" <name: Ranged<Name>> <type_: (":" <Term>)?> "=" <term: Term> ";" => {
+    "const" <name: Located<Name>> <type_: (":" <Term>)?> "=" <term: Term> ";" => {
         ItemData::Constant(Constant {
             doc: Arc::from(doc),
             name,
@@ -81,7 +80,7 @@ ItemData: ItemData = {
         })
     },
     <doc: "doc comment"*>
-    "struct" <name: Ranged<Name>> <type_: (":" <Term>)?> "{"
+    "struct" <name: Located<Name>> <type_: (":" <Term>)?> "{"
         <fields: Separated<FieldDeclaration, ",">>
     "}" => {
         ItemData::StructType(StructType {
@@ -93,17 +92,17 @@ ItemData: ItemData = {
     },
 };
 
-#[inline] Pattern: Pattern = Ranged<PatternData>;
+#[inline] Pattern: Pattern = Located<PatternData>;
 
 PatternData: PatternData = {
     <name: Name> => PatternData::Name(name),
     <literal: "numeric literal"> => PatternData::NumberLiteral(literal.to_owned()),
 };
 
-#[inline] Term: Term = Ranged<TermData>;
-#[inline] ArrowTerm: Term = Ranged<ArrowTermData>;
-#[inline] AppTerm: Term = Ranged<AppTermData>;
-#[inline] AtomicTerm: Term = Ranged<AtomicTermData>;
+#[inline] Term: Term = Located<TermData>;
+#[inline] ArrowTerm: Term = Located<ArrowTermData>;
+#[inline] AppTerm: Term = Located<AppTermData>;
+#[inline] AtomicTerm: Term = Located<AtomicTermData>;
 
 TermData: TermData = {
     ArrowTermData,
@@ -131,7 +130,7 @@ AtomicTermData: TermData = {
     "Kind" => TermData::KindType,
     "repr" => TermData::Repr,
     "struct" "{" <fields: Separated<FieldDefinition, ",">> "}" => TermData::StructTerm(fields),
-    <term: AtomicTerm> "." <name: Ranged<Name>> => TermData::StructElim(Box::new(term), name),
+    <term: AtomicTerm> "." <name: Located<Name>> => TermData::StructElim(Box::new(term), name),
     "[" <elem_terms: Separated<Term, ",">> "]" => TermData::SequenceTerm(elem_terms),
     <literal: "numeric literal"> => TermData::NumberLiteral(literal.to_owned()),
     "if" <head: Term> "{" <if_true: Term> "}" "else" "{" <if_false: Term> "}" => {
@@ -146,14 +145,14 @@ AtomicTermData: TermData = {
 
 #[inline]
 FieldDeclaration: FieldDeclaration = {
-    <docs: "doc comment"*> <label: Ranged<Name>> ":" <type_: Term> => {
+    <docs: "doc comment"*> <label: Located<Name>> ":" <type_: Term> => {
         FieldDeclaration { doc: Arc::from(docs), label, type_ }
     },
 };
 
 #[inline]
 FieldDefinition: FieldDefinition = {
-    <label: Ranged<Name>> "=" <term: Term> => FieldDefinition { label, term },
+    <label: Located<Name>> "=" <term: Term> => FieldDefinition { label, term },
 };
 
 #[inline]
@@ -170,6 +169,6 @@ Separated<Elem, Separator>: Vec<Elem> = {
 };
 
 #[inline]
-Ranged<T>: Ranged<T> = {
-    <start: @L> <data: T> <end: @R> => Ranged::new(Range::from(start..end), data),
+Located<T>: Located<T> = {
+    <start: @L> <data: T> <end: @R> => Located::new(Location::file_range(file_id, start..end), data),
 };

--- a/fathom/src/lang/surface/lexer.rs
+++ b/fathom/src/lang/surface/lexer.rs
@@ -1,7 +1,7 @@
 use logos::Logos;
 use std::fmt;
 
-use crate::lang::{FileId, Range};
+use crate::lang::{FileId, Location};
 use crate::reporting::LexerMessage;
 
 /// Tokens in the surface language.
@@ -149,8 +149,7 @@ pub fn tokens<'source>(
         .spanned()
         .map(move |(token, range)| match token {
             Token::Error => Err(LexerMessage::InvalidToken {
-                file_id,
-                range: Range::from(range),
+                location: Location::file_range(file_id, range),
             }),
             token => Ok((range.start, token, range.end)),
         })

--- a/fathom/src/lang/surface/lexer.rs
+++ b/fathom/src/lang/surface/lexer.rs
@@ -1,7 +1,7 @@
 use logos::Logos;
 use std::fmt;
 
-use crate::lang::Range;
+use crate::lang::{FileId, Range};
 use crate::reporting::LexerMessage;
 
 /// Tokens in the surface language.
@@ -142,7 +142,7 @@ impl<'source> fmt::Display for Token<'source> {
 pub type Spanned<Tok, Loc> = (Loc, Tok, Loc);
 
 pub fn tokens<'source>(
-    file_id: usize,
+    file_id: FileId,
     source: &'source str,
 ) -> impl 'source + Iterator<Item = Result<Spanned<Token<'source>, usize>, LexerMessage>> {
     Token::lexer(source)

--- a/fathom/src/literal.rs
+++ b/fathom/src/literal.rs
@@ -6,7 +6,7 @@ use logos::Logos;
 use num_bigint::BigInt;
 use num_traits::Float;
 
-use crate::lang::Range;
+use crate::lang::{FileId, Range};
 use crate::reporting::LiteralParseMessage::*;
 use crate::reporting::Message;
 
@@ -100,7 +100,7 @@ enum Digit10 {
 
 /// Literal parser state.
 pub struct State<'source, 'messages> {
-    file_id: usize,
+    file_id: FileId,
     range: Range,
     source: &'source str,
     messages: &'messages mut Vec<Message>,
@@ -108,7 +108,7 @@ pub struct State<'source, 'messages> {
 
 impl<'source, 'messages> State<'source, 'messages> {
     pub fn new(
-        file_id: usize,
+        file_id: FileId,
         range: Range,
         source: &'source str,
         messages: &'messages mut Vec<Message>,

--- a/fathom/src/pass/surface_to_core.rs
+++ b/fathom/src/pass/surface_to_core.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use crate::lang::core::semantics::{self, Elim, Value};
 use crate::lang::core::{self, Primitive, Sort};
 use crate::lang::surface::{ItemData, Module, Pattern, PatternData, StructType, Term, TermData};
-use crate::lang::Range;
+use crate::lang::{FileId, Range};
 use crate::literal;
 use crate::pass::core_to_surface;
 use crate::reporting::{Message, SurfaceToCoreMessage};
@@ -318,7 +318,7 @@ impl<'me> Context<'me> {
 
     fn is_struct_type(
         &mut self,
-        file_id: usize,
+        file_id: FileId,
         struct_type: &StructType,
     ) -> (core::ItemData, semantics::ItemData) {
         use std::collections::hash_map::Entry;
@@ -373,7 +373,7 @@ impl<'me> Context<'me> {
 
     pub fn is_struct_format(
         &mut self,
-        file_id: usize,
+        file_id: FileId,
         struct_type: &StructType,
     ) -> (core::ItemData, semantics::ItemData) {
         use std::collections::hash_map::Entry;
@@ -433,7 +433,7 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
     pub fn is_type(
         &mut self,
-        file_id: usize,
+        file_id: FileId,
         surface_term: &Term,
     ) -> (core::Term, Option<core::Sort>) {
         let (core_term, core_type) = self.synth_type(file_id, surface_term);
@@ -466,7 +466,7 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
     pub fn check_type(
         &mut self,
-        file_id: usize,
+        file_id: FileId,
         surface_term: &Term,
         expected_type: &Arc<Value>,
     ) -> core::Term {
@@ -723,7 +723,7 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn synth_type(&mut self, file_id: usize, surface_term: &Term) -> (core::Term, Arc<Value>) {
+    pub fn synth_type(&mut self, file_id: FileId, surface_term: &Term) -> (core::Term, Arc<Value>) {
         match &surface_term.data {
             TermData::Name(name) => {
                 if let Some((index, r#type)) = self.get_local(name) {
@@ -1006,7 +1006,7 @@ impl<'me> Context<'me> {
 
     fn from_int_branches(
         &mut self,
-        file_id: usize,
+        file_id: FileId,
         range: Range,
         surface_branches: &[(Pattern, Term)],
         expected_type: &Arc<Value>,

--- a/fathom/src/pass/surface_to_core.rs
+++ b/fathom/src/pass/surface_to_core.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use crate::lang::core::semantics::{self, Elim, Value};
 use crate::lang::core::{self, Primitive, Sort};
 use crate::lang::surface::{ItemData, Module, Pattern, PatternData, StructType, Term, TermData};
-use crate::lang::{FileId, Range};
+use crate::lang::Location;
 use crate::literal;
 use crate::pass::core_to_surface;
 use crate::reporting::{Message, SurfaceToCoreMessage};
@@ -116,10 +116,10 @@ impl<'me> Context<'me> {
     fn force_item<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range, &'context semantics::ItemData, &'value [Elim])> {
+    ) -> Option<(Location, &'context semantics::ItemData, &'value [Elim])> {
         let (name, elims) = value.try_item()?;
         match self.item_definitions.get(name) {
-            Some(item) => Some((item.range, &item.data, elims)),
+            Some(item) => Some((item.location, &item.data, elims)),
             None => panic!("could not find an item called `{}` in the context", name),
         }
     }
@@ -129,10 +129,10 @@ impl<'me> Context<'me> {
     fn force_struct_type<'context, 'value>(
         &'context self,
         value: &'value Value,
-    ) -> Option<(Range, Arc<[core::FieldDeclaration]>, &'value [Elim])> {
+    ) -> Option<(Location, Arc<[core::FieldDeclaration]>, &'value [Elim])> {
         match self.force_item(value) {
-            Some((range, semantics::ItemData::StructType(field_declarations), elims)) => {
-                Some((range, field_declarations.clone(), elims))
+            Some((location, semantics::ItemData::StructType(field_declarations), elims)) => {
+                Some((location, field_declarations.clone(), elims))
             }
             Some(_) | None => None,
         }
@@ -214,7 +214,6 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.local_declarations.is_empty())]
     #[debug_ensures(self.local_definitions.is_empty())]
     pub fn from_module(&mut self, surface_module: &Module) -> core::Module {
-        let file_id = surface_module.file_id;
         let mut core_items = Vec::new();
 
         for item in surface_module.items.iter() {
@@ -224,24 +223,24 @@ impl<'me> Context<'me> {
                 ItemData::Constant(constant) => {
                     let (core_term, r#type) = match &constant.type_ {
                         Some(surface_type) => {
-                            let (core_type, _) = self.is_type(file_id, surface_type);
+                            let (core_type, _) = self.is_type(surface_type);
                             match &core_type.data {
                                 core::TermData::Error => (
-                                    core::Term::new(constant.term.range, core::TermData::Error),
+                                    core::Term::new(constant.term.location, core::TermData::Error),
                                     Arc::new(Value::Error),
                                 ),
                                 _ => {
                                     let r#type = self.eval(&core_type);
                                     let term_data = core::TermData::Ann(
-                                        Arc::new(self.check_type(file_id, &constant.term, &r#type)),
+                                        Arc::new(self.check_type(&constant.term, &r#type)),
                                         Arc::new(core_type),
                                     );
 
-                                    (core::Term::new(constant.term.range, term_data), r#type)
+                                    (core::Term::new(constant.term.location, term_data), r#type)
                                 }
                             }
                         }
-                        None => self.synth_type(file_id, &constant.term),
+                        None => self.synth_type(&constant.term),
                     };
 
                     let item_data = semantics::ItemData::Constant(self.eval(&core_term));
@@ -256,26 +255,24 @@ impl<'me> Context<'me> {
                 ItemData::StructType(struct_type) => match &struct_type.type_ {
                     None => {
                         self.push_message(SurfaceToCoreMessage::MissingStructAnnotation {
-                            file_id,
                             name: struct_type.name.data.clone(),
-                            name_range: struct_type.name.range,
+                            name_location: struct_type.name.location,
                         });
                         continue;
                     }
                     Some(r#type) => {
-                        let (core_type, _) = self.is_type(file_id, &r#type);
+                        let (core_type, _) = self.is_type(&r#type);
                         let r#type = self.eval(&core_type);
                         let (core_item_data, item_data) = match r#type.as_ref() {
-                            Value::Sort(Sort::Type) => self.is_struct_type(file_id, struct_type),
-                            Value::FormatType => self.is_struct_format(file_id, struct_type),
+                            Value::Sort(Sort::Type) => self.is_struct_type(struct_type),
+                            Value::FormatType => self.is_struct_format(struct_type),
                             Value::Error => continue,
                             r#type => {
                                 let ann_type = self.read_back_to_surface(r#type);
                                 self.push_message(SurfaceToCoreMessage::InvalidStructAnnotation {
-                                    file_id,
                                     name: struct_type.name.data.clone(),
                                     ann_type,
-                                    ann_range: core_type.range,
+                                    ann_location: core_type.location,
                                 });
                                 continue;
                             }
@@ -289,18 +286,17 @@ impl<'me> Context<'me> {
             // FIXME: Avoid shadowing builtin definitions
             match self.item_definitions.entry(name.data.clone()) {
                 Entry::Vacant(entry) => {
-                    let core_item = core::Item::new(item.range, core_item_data);
+                    let core_item = core::Item::new(item.location, core_item_data);
                     core_items.push(core_item.clone());
                     self.item_declarations.insert(entry.key().clone(), r#type);
-                    entry.insert(semantics::Item::new(item.range, item_data));
+                    entry.insert(semantics::Item::new(item.location, item_data));
                 }
                 Entry::Occupied(entry) => {
-                    let original_range = entry.get().range;
+                    let original_location = entry.get().location;
                     self.push_message(SurfaceToCoreMessage::ItemRedefinition {
-                        file_id,
                         name: name.data.clone(),
-                        found_range: item.range,
-                        original_range,
+                        found_location: item.location,
+                        original_location,
                     });
                 }
             }
@@ -310,7 +306,6 @@ impl<'me> Context<'me> {
         self.item_declarations.clear();
 
         core::Module {
-            file_id,
             doc: surface_module.doc.clone(),
             items: core_items,
         }
@@ -318,21 +313,20 @@ impl<'me> Context<'me> {
 
     fn is_struct_type(
         &mut self,
-        file_id: FileId,
         struct_type: &StructType,
     ) -> (core::ItemData, semantics::ItemData) {
         use std::collections::hash_map::Entry;
 
         // Field labels that have previously seen, along with the source
-        // range where they were introduced (for diagnostic reporting).
+        // location where they were introduced (for diagnostic reporting).
         let mut seen_field_labels = HashMap::new();
         // Fields that have been elaborated into the core syntax.
         let mut core_field_declarations = Vec::with_capacity(struct_type.fields.len());
 
         for field in &struct_type.fields {
-            let field_range = Range::from(field.label.range.start..field.type_.range.end);
+            let field_location = Location::merge(field.label.location, field.type_.location);
             let format_type = Arc::new(Value::Sort(Sort::Type));
-            let core_type = self.check_type(file_id, &field.type_, &format_type);
+            let core_type = self.check_type(&field.type_, &format_type);
 
             match seen_field_labels.entry(field.label.data.clone()) {
                 Entry::Vacant(entry) => {
@@ -345,14 +339,13 @@ impl<'me> Context<'me> {
                         type_: core_type,
                     });
                     self.push_local_param(field.label.data.clone(), r#type);
-                    entry.insert(field_range);
+                    entry.insert(field_location);
                 }
                 Entry::Occupied(entry) => {
                     self.push_message(SurfaceToCoreMessage::FieldRedeclaration {
-                        file_id,
                         name: entry.key().clone(),
-                        found_range: field_range,
-                        original_range: *entry.get(),
+                        found_location: field_location,
+                        original_location: *entry.get(),
                     });
                 }
             }
@@ -373,21 +366,20 @@ impl<'me> Context<'me> {
 
     pub fn is_struct_format(
         &mut self,
-        file_id: FileId,
         struct_type: &StructType,
     ) -> (core::ItemData, semantics::ItemData) {
         use std::collections::hash_map::Entry;
 
         // Field names that have previously seen, along with the source
-        // range where they were introduced (for diagnostic reporting).
+        // location where they were introduced (for diagnostic reporting).
         let mut seen_field_labels = HashMap::new();
         // Fields that have been elaborated into the core syntax.
         let mut core_field_declarations = Vec::with_capacity(struct_type.fields.len());
 
         for field in &struct_type.fields {
-            let field_range = Range::from(field.label.range.start..field.type_.range.end);
+            let field_location = Location::merge(field.label.location, field.type_.location);
             let format_type = Arc::new(Value::FormatType);
-            let core_type = self.check_type(file_id, &field.type_, &format_type);
+            let core_type = self.check_type(&field.type_, &format_type);
 
             match seen_field_labels.entry(field.label.data.clone()) {
                 Entry::Vacant(entry) => {
@@ -400,14 +392,13 @@ impl<'me> Context<'me> {
                         type_: core_type,
                     });
                     self.push_local_param(field.label.data.clone(), r#type);
-                    entry.insert(field_range);
+                    entry.insert(field_location);
                 }
                 Entry::Occupied(entry) => {
                     self.push_message(SurfaceToCoreMessage::FieldRedeclaration {
-                        file_id,
                         name: entry.key().clone(),
-                        found_range: field_range,
-                        original_range: *entry.get(),
+                        found_location: field_location,
+                        original_location: *entry.get(),
                     });
                 }
             }
@@ -431,27 +422,22 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn is_type(
-        &mut self,
-        file_id: FileId,
-        surface_term: &Term,
-    ) -> (core::Term, Option<core::Sort>) {
-        let (core_term, core_type) = self.synth_type(file_id, surface_term);
+    pub fn is_type(&mut self, surface_term: &Term) -> (core::Term, Option<core::Sort>) {
+        let (core_term, core_type) = self.synth_type(surface_term);
         match core_type.as_ref() {
             Value::Error => (
-                core::Term::new(surface_term.range, core::TermData::Error),
+                core::Term::new(surface_term.location, core::TermData::Error),
                 None,
             ),
             Value::Sort(sort) => (core_term, Some(*sort)),
             core_type => {
                 let found_type = self.read_back_to_surface(core_type);
                 self.push_message(SurfaceToCoreMessage::UniverseMismatch {
-                    file_id,
-                    term_range: surface_term.range,
+                    term_location: surface_term.location,
                     found_type,
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     None,
                 )
             }
@@ -464,15 +450,10 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn check_type(
-        &mut self,
-        file_id: FileId,
-        surface_term: &Term,
-        expected_type: &Arc<Value>,
-    ) -> core::Term {
+    pub fn check_type(&mut self, surface_term: &Term, expected_type: &Arc<Value>) -> core::Term {
         match (&surface_term.data, expected_type.as_ref()) {
-            (TermData::Error, _) => core::Term::new(surface_term.range, core::TermData::Error),
-            (_, Value::Error) => core::Term::new(surface_term.range, core::TermData::Error),
+            (TermData::Error, _) => core::Term::new(surface_term.location, core::TermData::Error),
+            (_, Value::Error) => core::Term::new(surface_term.location, core::TermData::Error),
 
             (TermData::StructTerm(surface_field_definitions), _) => {
                 use std::collections::btree_map::Entry;
@@ -482,20 +463,18 @@ impl<'me> Context<'me> {
                     Some((_, field_declarations, [])) => field_declarations,
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
-                            file_id,
-                            range: surface_term.range,
+                            location: surface_term.location,
                             feature_name: "struct parameters",
                         });
-                        return core::Term::new(surface_term.range, core::TermData::Error);
+                        return core::Term::new(surface_term.location, core::TermData::Error);
                     }
                     None => {
                         let expected_type = self.read_back_to_surface(expected_type);
                         self.push_message(SurfaceToCoreMessage::UnexpectedStructTerm {
-                            file_id,
-                            term_range: surface_term.range,
+                            term_location: surface_term.location,
                             expected_type,
                         });
-                        return core::Term::new(surface_term.range, core::TermData::Error);
+                        return core::Term::new(surface_term.location, core::TermData::Error);
                     }
                 };
 
@@ -526,7 +505,7 @@ impl<'me> Context<'me> {
                             let r#type =
                                 self.eval_with_locals(&mut type_locals, &field_declaration.type_);
                             // TODO: stop on errors
-                            let core_term = Arc::new(self.check_type(file_id, &term, &r#type));
+                            let core_term = Arc::new(self.check_type(&term, &r#type));
                             let value = self.eval(&core_term);
 
                             type_locals.push(value);
@@ -551,32 +530,29 @@ impl<'me> Context<'me> {
                 if !duplicate_labels.is_empty() {
                     has_problems = true;
                     self.push_message(SurfaceToCoreMessage::DuplicateStructFields {
-                        file_id,
                         duplicate_labels,
                     });
                 }
                 if !missing_labels.is_empty() {
                     has_problems = true;
                     self.push_message(SurfaceToCoreMessage::MissingStructFields {
-                        file_id,
-                        term_range: surface_term.range,
+                        term_location: surface_term.location,
                         missing_labels,
                     });
                 }
                 if !unexpected_labels.is_empty() {
                     has_problems = true;
                     self.push_message(SurfaceToCoreMessage::UnexpectedStructFields {
-                        file_id,
-                        term_range: surface_term.range,
+                        term_location: surface_term.location,
                         unexpected_labels,
                     });
                 }
                 if has_problems {
-                    return core::Term::new(surface_term.range, core::TermData::Error);
+                    return core::Term::new(surface_term.location, core::TermData::Error);
                 }
 
                 core::Term::new(
-                    surface_term.range,
+                    surface_term.location,
                     core::TermData::StructTerm(core_field_definitions),
                 )
             }
@@ -586,7 +562,7 @@ impl<'me> Context<'me> {
                     let elem_terms = surface_elem_terms
                         .iter()
                         .map(|surface_elem_term| {
-                            Arc::new(self.check_type(file_id, surface_elem_term, elem_type))
+                            Arc::new(self.check_type(surface_elem_term, elem_type))
                         })
                         .collect();
 
@@ -595,36 +571,34 @@ impl<'me> Context<'me> {
                             if *len == surface_elem_terms.len().into() =>
                         {
                             core::Term::new(
-                                surface_term.range,
+                                surface_term.location,
                                 core::TermData::ArrayTerm(elem_terms),
                             )
                         }
                         len => {
                             let expected_len = self.read_back_to_surface(&len);
                             self.push_message(SurfaceToCoreMessage::MismatchedArrayLength {
-                                file_id,
-                                term_range: surface_term.range,
+                                term_location: surface_term.location,
                                 found_len: elem_terms.len(),
                                 expected_len,
                             });
-                            core::Term::new(surface_term.range, core::TermData::Error)
+                            core::Term::new(surface_term.location, core::TermData::Error)
                         }
                     }
                 }
                 Some(_) | None => {
                     let expected_type = self.read_back_to_surface(expected_type);
                     self.push_message(SurfaceToCoreMessage::UnexpectedSequenceTerm {
-                        file_id,
-                        term_range: surface_term.range,
+                        term_location: surface_term.location,
                         expected_type,
                     });
-                    core::Term::new(surface_term.range, core::TermData::Error)
+                    core::Term::new(surface_term.location, core::TermData::Error)
                 }
             },
 
             (TermData::NumberLiteral(source), _) => {
                 let parse_state =
-                    literal::State::new(file_id, surface_term.range, source, &mut self.messages);
+                    literal::State::new(surface_term.location, source, &mut self.messages);
                 let term_data = match expected_type.try_global() {
                     Some(("Int", [])) => parse_state
                         .number_to_big_int()
@@ -641,78 +615,73 @@ impl<'me> Context<'me> {
                     _ => {
                         let expected_type = self.read_back_to_surface(expected_type);
                         self.push_message(SurfaceToCoreMessage::NumericLiteralNotSupported {
-                            file_id,
-                            literal_range: surface_term.range,
+                            literal_location: surface_term.location,
                             expected_type,
                         });
                         core::TermData::Error
                     }
                 };
 
-                core::Term::new(surface_term.range, term_data)
+                core::Term::new(surface_term.location, term_data)
             }
             (TermData::If(surface_head, surface_if_true, surface_if_false), _) => {
                 let bool_type = Arc::new(Value::global("Bool", Vec::new()));
                 let term_data = core::TermData::BoolElim(
-                    Arc::new(self.check_type(file_id, surface_head, &bool_type)),
-                    Arc::new(self.check_type(file_id, surface_if_true, expected_type)),
-                    Arc::new(self.check_type(file_id, surface_if_false, expected_type)),
+                    Arc::new(self.check_type(surface_head, &bool_type)),
+                    Arc::new(self.check_type(surface_if_true, expected_type)),
+                    Arc::new(self.check_type(surface_if_false, expected_type)),
                 );
 
-                core::Term::new(surface_term.range, term_data)
+                core::Term::new(surface_term.location, term_data)
             }
             (TermData::Match(surface_head, surface_branches), _) => {
-                let (head, head_type) = self.synth_type(file_id, surface_head);
+                let (head, head_type) = self.synth_type(surface_head);
                 if let Value::Error = head_type.as_ref() {
-                    return core::Term::new(surface_term.range, core::TermData::Error);
+                    return core::Term::new(surface_term.location, core::TermData::Error);
                 }
 
                 match head_type.try_global() {
                     Some(("Bool", [])) => {
                         self.push_message(Message::NotYetImplemented {
-                            file_id,
-                            range: surface_term.range,
+                            location: surface_term.location,
                             feature_name: "boolean patterns",
                         });
-                        core::Term::new(surface_term.range, core::TermData::Error)
+                        core::Term::new(surface_term.location, core::TermData::Error)
                     }
                     Some(("Int", [])) => {
                         let (branches, default) = self.from_int_branches(
-                            file_id,
-                            surface_head.range,
+                            surface_head.location,
                             surface_branches,
                             expected_type,
                         );
 
                         core::Term::new(
-                            surface_term.range,
+                            surface_term.location,
                             core::TermData::IntElim(Arc::new(head), branches, default),
                         )
                     }
                     _ => {
                         let found_type = self.read_back_to_surface(&head_type);
                         self.push_message(SurfaceToCoreMessage::UnsupportedPatternType {
-                            file_id,
-                            scrutinee_range: surface_head.range,
+                            scrutinee_location: surface_head.location,
                             found_type,
                         });
-                        core::Term::new(surface_term.range, core::TermData::Error)
+                        core::Term::new(surface_term.location, core::TermData::Error)
                     }
                 }
             }
 
-            (_, expected_type) => match self.synth_type(file_id, surface_term) {
+            (_, expected_type) => match self.synth_type(surface_term) {
                 (core_term, found_type) if self.is_equal(&found_type, expected_type) => core_term,
                 (_, found_type) => {
                     let expected_type = self.read_back_to_surface(expected_type);
                     let found_type = self.read_back_to_surface(&found_type);
                     self.push_message(SurfaceToCoreMessage::TypeMismatch {
-                        file_id,
-                        term_range: surface_term.range,
+                        term_location: surface_term.location,
                         expected_type,
                         found_type,
                     });
-                    core::Term::new(surface_term.range, core::TermData::Error)
+                    core::Term::new(surface_term.location, core::TermData::Error)
                 }
             },
         }
@@ -723,73 +692,71 @@ impl<'me> Context<'me> {
     #[debug_ensures(self.item_definitions.len() == old(self.item_definitions.len()))]
     #[debug_ensures(self.local_declarations.size() == old(self.local_declarations.size()))]
     #[debug_ensures(self.local_definitions.size() == old(self.local_definitions.size()))]
-    pub fn synth_type(&mut self, file_id: FileId, surface_term: &Term) -> (core::Term, Arc<Value>) {
+    pub fn synth_type(&mut self, surface_term: &Term) -> (core::Term, Arc<Value>) {
         match &surface_term.data {
             TermData::Name(name) => {
                 if let Some((index, r#type)) = self.get_local(name) {
                     let term_data = core::TermData::Local(index);
-                    let core_term = core::Term::new(surface_term.range, term_data);
+                    let core_term = core::Term::new(surface_term.location, term_data);
                     return (core_term, r#type.clone());
                 }
                 if let Some(r#type) = self.item_declarations.get(name) {
                     let term_data = core::TermData::Item(name.to_owned());
-                    let core_term = core::Term::new(surface_term.range, term_data);
+                    let core_term = core::Term::new(surface_term.location, term_data);
                     return (core_term, r#type.clone());
                 }
                 if let Some((r#type, _)) = self.globals.get(name) {
                     let term_data = core::TermData::Global(name.to_owned());
-                    let core_term = core::Term::new(surface_term.range, term_data);
+                    let core_term = core::Term::new(surface_term.location, term_data);
                     return (core_term, self.eval(r#type));
                 }
 
                 self.push_message(SurfaceToCoreMessage::VarNameNotFound {
-                    file_id,
                     name: name.clone(),
-                    name_range: surface_term.range,
+                    name_location: surface_term.location,
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     Arc::new(Value::Error),
                 )
             }
 
             TermData::Ann(surface_term, surface_type) => {
-                let (core_type, _) = self.is_type(file_id, surface_type);
+                let (core_type, _) = self.is_type(surface_type);
                 match &core_type.data {
                     core::TermData::Error => (
-                        core::Term::new(surface_term.range, core::TermData::Error),
+                        core::Term::new(surface_term.location, core::TermData::Error),
                         Arc::new(Value::Error),
                     ),
                     _ => {
                         let r#type = self.eval(&core_type);
                         let term_data = core::TermData::Ann(
-                            Arc::new(self.check_type(file_id, surface_term, &r#type)),
+                            Arc::new(self.check_type(surface_term, &r#type)),
                             Arc::new(core_type),
                         );
 
-                        (core::Term::new(surface_term.range, term_data), r#type)
+                        (core::Term::new(surface_term.location, term_data), r#type)
                     }
                 }
             }
 
             TermData::KindType => {
                 self.push_message(SurfaceToCoreMessage::TermHasNoType {
-                    file_id,
-                    term_range: surface_term.range,
+                    term_location: surface_term.location,
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     Arc::new(Value::Error),
                 )
             }
             TermData::TypeType => (
-                core::Term::new(surface_term.range, core::TermData::Sort(Sort::Type)),
+                core::Term::new(surface_term.location, core::TermData::Sort(Sort::Type)),
                 Arc::new(Value::Sort(Sort::Kind)),
             ),
 
             TermData::FunctionType(param_type, body_type) => {
-                let (core_param_type, param_sort) = self.is_type(file_id, param_type);
-                let (core_body_type, body_sort) = self.is_type(file_id, body_type);
+                let (core_param_type, param_sort) = self.is_type(param_type);
+                let (core_body_type, body_sort) = self.is_type(body_type);
 
                 match (param_sort, body_sort) {
                     (Some(param_sort), Some(body_sort)) => {
@@ -798,45 +765,44 @@ impl<'me> Context<'me> {
                             Arc::new(core_body_type),
                         );
                         (
-                            core::Term::new(surface_term.range, term_data),
+                            core::Term::new(surface_term.location, term_data),
                             Arc::new(Value::Sort(core::typing::rule(param_sort, body_sort))),
                         )
                     }
                     (_, _) => (
-                        core::Term::new(surface_term.range, core::TermData::Error),
+                        core::Term::new(surface_term.location, core::TermData::Error),
                         Arc::new(Value::Error),
                     ),
                 }
             }
             TermData::FunctionElim(head, arguments) => {
-                let (mut core_head, mut head_type) = self.synth_type(file_id, head);
+                let (mut core_head, mut head_type) = self.synth_type(head);
 
                 for argument in arguments {
                     match head_type.as_ref() {
                         Value::FunctionType(param_type, body_type) => {
                             let term_data = core::TermData::FunctionElim(
                                 Arc::new(core_head),
-                                Arc::new(self.check_type(file_id, argument, &param_type)),
+                                Arc::new(self.check_type(argument, &param_type)),
                             );
-                            core_head = core::Term::new(surface_term.range, term_data);
+                            core_head = core::Term::new(surface_term.location, term_data);
                             head_type = body_type.clone();
                         }
                         Value::Error => {
                             return (
-                                core::Term::new(surface_term.range, core::TermData::Error),
+                                core::Term::new(surface_term.location, core::TermData::Error),
                                 Arc::new(Value::Error),
                             );
                         }
                         head_type => {
                             let head_type = self.read_back_to_surface(head_type);
                             self.push_message(SurfaceToCoreMessage::NotAFunction {
-                                file_id,
-                                head_range: head.range,
+                                head_location: head.location,
                                 head_type,
-                                argument_range: argument.range,
+                                argument_location: argument.location,
                             });
                             return (
-                                core::Term::new(surface_term.range, core::TermData::Error),
+                                core::Term::new(surface_term.location, core::TermData::Error),
                                 Arc::new(Value::Error),
                             );
                         }
@@ -848,19 +814,18 @@ impl<'me> Context<'me> {
 
             TermData::StructTerm(_) => {
                 self.push_message(SurfaceToCoreMessage::AmbiguousStructTerm {
-                    file_id,
-                    term_range: surface_term.range,
+                    term_location: surface_term.location,
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     Arc::new(Value::Error),
                 )
             }
             TermData::StructElim(head, label) => {
-                let (core_head, head_type) = self.synth_type(file_id, head);
+                let (core_head, head_type) = self.synth_type(head);
                 if let Value::Error = head_type.as_ref() {
                     return (
-                        core::Term::new(surface_term.range, core::TermData::Error),
+                        core::Term::new(surface_term.location, core::TermData::Error),
                         Arc::new(Value::Error),
                     );
                 }
@@ -876,7 +841,7 @@ impl<'me> Context<'me> {
                         for field_declaration in field_declarations.iter() {
                             if field_declaration.label == *label {
                                 let core_term = core::Term::new(
-                                    surface_term.range,
+                                    surface_term.location,
                                     core::TermData::StructElim(
                                         Arc::new(core_head),
                                         field_declaration.label.data.clone(),
@@ -898,12 +863,11 @@ impl<'me> Context<'me> {
                     }
                     Some((_, _, _)) => {
                         self.push_message(crate::reporting::Message::NotYetImplemented {
-                            file_id,
-                            range: surface_term.range,
+                            location: surface_term.location,
                             feature_name: "struct parameters",
                         });
                         return (
-                            core::Term::new(surface_term.range, core::TermData::Error),
+                            core::Term::new(surface_term.location, core::TermData::Error),
                             Arc::new(Value::Error),
                         );
                     }
@@ -913,43 +877,40 @@ impl<'me> Context<'me> {
                 // If we could not find a matching field, it's a type error.
                 let head_type = self.read_back_to_surface(&head_type);
                 self.push_message(SurfaceToCoreMessage::FieldNotFound {
-                    file_id,
-                    head_range: head.range,
+                    head_location: head.location,
                     head_type,
                     label: label.clone(),
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     Arc::new(Value::Error),
                 )
             }
 
             TermData::SequenceTerm(_) => {
                 self.push_message(SurfaceToCoreMessage::AmbiguousSequenceTerm {
-                    file_id,
-                    range: surface_term.range,
+                    location: surface_term.location,
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     Arc::new(Value::Error),
                 )
             }
 
             TermData::NumberLiteral(_) => {
                 self.push_message(SurfaceToCoreMessage::AmbiguousNumericLiteral {
-                    file_id,
-                    literal_range: surface_term.range,
+                    literal_location: surface_term.location,
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     Arc::new(Value::Error),
                 )
             }
             TermData::If(surface_head, surface_if_true, surface_if_false) => {
                 let bool_type = Arc::new(Value::global("Bool", Vec::new()));
-                let head = self.check_type(file_id, surface_head, &bool_type);
-                let (if_true, if_true_type) = self.synth_type(file_id, surface_if_true);
-                let (if_false, if_false_type) = self.synth_type(file_id, surface_if_false);
+                let head = self.check_type(surface_head, &bool_type);
+                let (if_true, if_true_type) = self.synth_type(surface_if_true);
+                let (if_false, if_false_type) = self.synth_type(surface_if_false);
 
                 if self.is_equal(&if_true_type, &if_false_type) {
                     let term_data = core::TermData::BoolElim(
@@ -957,40 +918,41 @@ impl<'me> Context<'me> {
                         Arc::new(if_true),
                         Arc::new(if_false),
                     );
-                    (core::Term::new(surface_term.range, term_data), if_true_type)
+                    (
+                        core::Term::new(surface_term.location, term_data),
+                        if_true_type,
+                    )
                 } else {
                     let expected_type = self.read_back_to_surface(&if_true_type);
                     let found_type = self.read_back_to_surface(&if_false_type);
                     self.push_message(SurfaceToCoreMessage::TypeMismatch {
-                        file_id,
-                        term_range: surface_if_false.range,
+                        term_location: surface_if_false.location,
                         expected_type,
                         found_type,
                     });
                     (
-                        core::Term::new(surface_term.range, core::TermData::Error),
+                        core::Term::new(surface_term.location, core::TermData::Error),
                         Arc::new(Value::Error),
                     )
                 }
             }
             TermData::Match(_, _) => {
                 self.push_message(SurfaceToCoreMessage::AmbiguousMatchExpression {
-                    file_id,
-                    term_range: surface_term.range,
+                    term_location: surface_term.location,
                 });
                 (
-                    core::Term::new(surface_term.range, core::TermData::Error),
+                    core::Term::new(surface_term.location, core::TermData::Error),
                     Arc::new(Value::Error),
                 )
             }
 
             TermData::FormatType => (
-                core::Term::new(surface_term.range, core::TermData::FormatType),
+                core::Term::new(surface_term.location, core::TermData::FormatType),
                 Arc::new(Value::Sort(Sort::Kind)),
             ),
 
             TermData::Repr => (
-                core::Term::new(surface_term.range, core::TermData::Repr),
+                core::Term::new(surface_term.location, core::TermData::Repr),
                 Arc::new(Value::FunctionType(
                     Arc::new(Value::FormatType),
                     Arc::new(Value::Sort(Sort::Type)),
@@ -998,7 +960,7 @@ impl<'me> Context<'me> {
             ),
 
             TermData::Error => (
-                core::Term::new(surface_term.range, core::TermData::Error),
+                core::Term::new(surface_term.location, core::TermData::Error),
                 Arc::new(Value::Error),
             ),
         }
@@ -1006,8 +968,7 @@ impl<'me> Context<'me> {
 
     fn from_int_branches(
         &mut self,
-        file_id: FileId,
-        range: Range,
+        location: Location,
         surface_branches: &[(Pattern, Term)],
         expected_type: &Arc<Value>,
     ) -> (BTreeMap<BigInt, Arc<core::Term>>, Arc<core::Term>) {
@@ -1018,15 +979,13 @@ impl<'me> Context<'me> {
 
         for (pattern, surface_term) in surface_branches {
             let unreachable_pattern = || SurfaceToCoreMessage::UnreachablePattern {
-                file_id,
-                pattern_range: pattern.range,
+                pattern_location: pattern.location,
             };
 
             match &pattern.data {
                 PatternData::NumberLiteral(source) => {
-                    let core_term = self.check_type(file_id, surface_term, expected_type);
-                    let parse_state =
-                        literal::State::new(file_id, range, source, &mut self.messages);
+                    let core_term = self.check_type(surface_term, expected_type);
+                    let parse_state = literal::State::new(location, source, &mut self.messages);
                     match parse_state.number_to_big_int() {
                         None => {} // Skipping - an error message should have already been recorded
                         Some(value) => match &default {
@@ -1044,7 +1003,7 @@ impl<'me> Context<'me> {
                     // TODO: check if name is bound
                     // - if so compare for equality
                     // - otherwise bind local variable
-                    let core_term = self.check_type(file_id, surface_term, expected_type);
+                    let core_term = self.check_type(surface_term, expected_type);
                     match &default {
                         None => default = Some(Arc::new(core_term)),
                         Some(_) => self.push_message(unreachable_pattern()),
@@ -1055,10 +1014,9 @@ impl<'me> Context<'me> {
 
         let default = default.unwrap_or_else(|| {
             self.push_message(SurfaceToCoreMessage::NoDefaultPattern {
-                file_id,
-                match_range: range,
+                match_location: location,
             });
-            Arc::new(core::Term::new(range, core::TermData::Error))
+            Arc::new(core::Term::new(location, core::TermData::Error))
         });
 
         (branches, default)

--- a/fathom/src/reporting.rs
+++ b/fathom/src/reporting.rs
@@ -11,15 +11,37 @@ use itertools::Itertools;
 use pretty::DocAllocator;
 use std::path::PathBuf;
 
-use crate::lang::{core, surface, FileId, Range, Ranged};
+use crate::lang::{core, surface, FileId, Located, Location};
 use crate::literal;
+
+macro_rules! label {
+    ($style:ident($location:expr) $(= $message:expr)? $(,)?) => {
+        match $location {
+            Location::Generated => None,
+            Location::FileRange(file_id, range) => {
+                Some(Label::$style(*file_id, *range)$(.with_message($message))?)
+            },
+        }
+    };
+}
+
+macro_rules! labels {
+    (($style:ident($location:expr) $(= $message:expr)?) $(,)?) => {
+        label!($style($location) $(= $message)?)
+            .collect::<Vec<Label<FileId>>>()
+    };
+    ($($style:ident($location:expr) $(= $message:expr)?),* $(,)?) => {
+        std::iter::empty()
+            $(.chain(label!($style($location) $(= $message)?)))*
+            .collect::<Vec<Label<FileId>>>()
+    };
+}
 
 /// Global diagnostic messages
 #[derive(Debug, Clone)]
 pub enum Message {
     NotYetImplemented {
-        file_id: FileId,
-        range: Range,
+        location: Location,
         feature_name: &'static str,
     },
     ReadFile {
@@ -72,13 +94,11 @@ impl Message {
 
         match error {
             InvalidToken { location } => Message::from(LexerMessage::InvalidToken {
-                file_id,
-                range: Range::from(location..location),
+                location: Location::file_range(file_id, location..location),
             }),
             UnrecognizedEOF { location, expected } => {
                 Message::from(ParseMessage::UnrecognizedEof {
-                    file_id,
-                    range: Range::from(location..location),
+                    location: Location::file_range(file_id, location..location),
                     expected,
                 })
             }
@@ -86,16 +106,14 @@ impl Message {
                 token: (start, token, end),
                 expected,
             } => Message::from(ParseMessage::UnrecognizedToken {
-                file_id,
-                range: Range::from(start..end),
+                location: Location::file_range(file_id, start..end),
                 token: token.to_string(),
                 expected,
             }),
             ExtraToken {
                 token: (start, token, end),
             } => Message::from(ParseMessage::ExtraToken {
-                file_id,
-                range: Range::from(start..end),
+                location: Location::file_range(file_id, start..end),
                 token: token.to_string(),
             }),
             User { error } => Message::from(error),
@@ -109,15 +127,15 @@ impl Message {
     {
         match self {
             Message::NotYetImplemented {
-                file_id,
-                range,
+                location,
                 feature_name,
             } => Diagnostic::bug()
                 .with_message(format!("not yet implemented: {}", feature_name))
-                .with_labels(vec![Label::primary(*file_id, *range)
-                    .with_message("relies on an unimplemented language feature")]),
+                .with_labels(labels![
+                    primary(location) = "relies on an unimplemented language feature",
+                ]),
             Message::ReadFile { path, error } => Diagnostic::error()
-                .with_message(format!("failed to read file `{}`", path.display(),))
+                .with_message(format!("failed to read file `{}`", path.display()))
                 // TODO: add user-friendly suggestions
                 .with_notes(vec![format!("{}", error.to_lowercase())]),
             Message::Lexer(message) => message.to_diagnostic(),
@@ -132,15 +150,15 @@ impl Message {
 /// Messages produced during lexing
 #[derive(Debug, Clone)]
 pub enum LexerMessage {
-    InvalidToken { file_id: FileId, range: Range },
+    InvalidToken { location: Location },
 }
 
 impl LexerMessage {
     pub fn to_diagnostic(&self) -> Diagnostic<FileId> {
         match self {
-            LexerMessage::InvalidToken { file_id, range } => Diagnostic::error()
+            LexerMessage::InvalidToken { location } => Diagnostic::error()
                 .with_message("invalid token")
-                .with_labels(vec![Label::primary(*file_id, *range)]),
+                .with_labels(labels![primary(location)]),
         }
     }
 }
@@ -149,19 +167,16 @@ impl LexerMessage {
 #[derive(Clone, Debug)]
 pub enum ParseMessage {
     UnrecognizedEof {
-        file_id: FileId,
-        range: Range,
+        location: Location,
         expected: Vec<String>,
     },
     UnrecognizedToken {
-        file_id: FileId,
-        range: Range,
+        location: Location,
         token: String,
         expected: Vec<String>,
     },
     ExtraToken {
-        file_id: FileId,
-        range: Range,
+        location: Location,
         token: String,
     },
 }
@@ -169,36 +184,21 @@ pub enum ParseMessage {
 impl ParseMessage {
     pub fn to_diagnostic(&self) -> Diagnostic<FileId> {
         match self {
-            ParseMessage::UnrecognizedEof {
-                file_id,
-                range,
-                expected,
-            } => Diagnostic::error()
+            ParseMessage::UnrecognizedEof { location, expected } => Diagnostic::error()
                 .with_message("unexpected end of file")
-                .with_labels(vec![
-                    Label::primary(*file_id, *range).with_message("unexpected end of file")
-                ])
+                .with_labels(labels![primary(location) = "unexpected end of file"])
                 .with_notes(format_expected(expected).map_or(Vec::new(), |message| vec![message])),
             ParseMessage::UnrecognizedToken {
-                file_id,
-                range,
+                location,
                 token,
                 expected,
             } => Diagnostic::error()
                 .with_message(format!("unexpected token {}", token))
-                .with_labels(vec![
-                    Label::primary(*file_id, *range).with_message("unexpected token")
-                ])
+                .with_labels(labels![primary(location) = "unexpected token"])
                 .with_notes(format_expected(expected).map_or(Vec::new(), |message| vec![message])),
-            ParseMessage::ExtraToken {
-                file_id,
-                range,
-                token,
-            } => Diagnostic::error()
+            ParseMessage::ExtraToken { location, token } => Diagnostic::error()
                 .with_message(format!("extra token {}", token))
-                .with_labels(vec![
-                    Label::primary(*file_id, *range).with_message("extra token")
-                ]),
+                .with_labels(labels![primary(location) = "extra token"]),
         }
     }
 }
@@ -213,74 +213,64 @@ fn format_expected(expected: &[impl std::fmt::Display]) -> Option<String> {
 
 #[derive(Clone, Debug)]
 pub enum LiteralParseMessage {
-    ExpectedRadixOrDecimalDigit(usize, Range),
-    ExpectedStartOfNumericLiteral(usize, Range),
-    ExpectedDigit(usize, Range, literal::Base),
-    ExpectedDigitOrSeparator(usize, Range, literal::Base),
-    ExpectedDigitSeparatorOrExp(usize, Range, literal::Base),
-    ExpectedDigitSeparatorFracOrExp(usize, Range, literal::Base),
-    FloatLiteralExponentNotSupported(usize, Range),
-    UnsupportedFloatLiteralBase(usize, Range, literal::Base),
-    UnexpectedEndOfLiteral(usize, Range),
+    ExpectedRadixOrDecimalDigit(Location),
+    ExpectedStartOfNumericLiteral(Location),
+    ExpectedDigit(Location, literal::Base),
+    ExpectedDigitOrSeparator(Location, literal::Base),
+    ExpectedDigitSeparatorOrExp(Location, literal::Base),
+    ExpectedDigitSeparatorFracOrExp(Location, literal::Base),
+    FloatLiteralExponentNotSupported(Location),
+    UnsupportedFloatLiteralBase(Location, literal::Base),
+    UnexpectedEndOfLiteral(Location),
 }
 
 impl LiteralParseMessage {
     pub fn to_diagnostic(&self) -> Diagnostic<FileId> {
         match self {
-            LiteralParseMessage::ExpectedRadixOrDecimalDigit(file_id, range) => Diagnostic::error()
+            LiteralParseMessage::ExpectedRadixOrDecimalDigit(location) => Diagnostic::error()
                 .with_message("expected a radix or decimal digit")
-                .with_labels(vec![Label::primary(*file_id, *range)]),
-            LiteralParseMessage::ExpectedStartOfNumericLiteral(file_id, range) => {
-                Diagnostic::error()
-                    .with_message("expected the start of a numeric literal")
-                    .with_labels(vec![Label::primary(*file_id, *range)])
-            }
-            LiteralParseMessage::ExpectedDigit(file_id, range, base) => Diagnostic::error()
+                .with_labels(labels![primary(location)]),
+            LiteralParseMessage::ExpectedStartOfNumericLiteral(location) => Diagnostic::error()
+                .with_message("expected the start of a numeric literal")
+                .with_labels(labels![primary(location)]),
+            LiteralParseMessage::ExpectedDigit(location, base) => Diagnostic::error()
                 .with_message(format!("expected a base {} digit", base.to_u8()))
-                .with_labels(vec![Label::primary(*file_id, *range)]),
-            LiteralParseMessage::ExpectedDigitOrSeparator(file_id, range, base) => {
-                Diagnostic::error()
-                    .with_message(format!(
-                        "expected a base {} digit or digit separator",
-                        base.to_u8(),
-                    ))
-                    .with_labels(vec![Label::primary(*file_id, *range)])
-            }
-            LiteralParseMessage::ExpectedDigitSeparatorOrExp(file_id, range, base) => {
-                Diagnostic::error()
-                    .with_message(format!(
-                        "expected a base {} digit, digit separator, or exponent",
-                        base.to_u8(),
-                    ))
-                    .with_labels(vec![Label::primary(*file_id, *range)])
-            }
-            LiteralParseMessage::ExpectedDigitSeparatorFracOrExp(file_id, range, base) => {
+                .with_labels(labels![primary(location)]),
+            LiteralParseMessage::ExpectedDigitOrSeparator(location, base) => Diagnostic::error()
+                .with_message(format!(
+                    "expected a base {} digit or digit separator",
+                    base.to_u8(),
+                ))
+                .with_labels(labels![primary(location)]),
+            LiteralParseMessage::ExpectedDigitSeparatorOrExp(location, base) => Diagnostic::error()
+                .with_message(format!(
+                    "expected a base {} digit, digit separator, or exponent",
+                    base.to_u8(),
+                ))
+                .with_labels(labels![primary(location)]),
+            LiteralParseMessage::ExpectedDigitSeparatorFracOrExp(location, base) => {
                 Diagnostic::error()
                     .with_message(format!(
                         "expected a base {} digit, digit separator, period, or exponent",
                         base.to_u8(),
                     ))
-                    .with_labels(vec![Label::primary(*file_id, *range)])
+                    .with_labels(labels![primary(location)])
             }
-            LiteralParseMessage::FloatLiteralExponentNotSupported(file_id, range) => {
-                Diagnostic::error()
-                    .with_message("exponents are not yet supported for float literals")
-                    .with_labels(vec![Label::primary(*file_id, *range)])
-            }
-            LiteralParseMessage::UnsupportedFloatLiteralBase(file_id, range, base) => {
-                Diagnostic::error()
-                    .with_message(format!(
-                        "base {} float literals are not yet supported",
-                        base.to_u8(),
-                    ))
-                    .with_labels(vec![Label::primary(*file_id, *range)])
-                    .with_notes(vec![
-                        "only base 10 float literals are currently supported".to_owned()
-                    ])
-            }
-            LiteralParseMessage::UnexpectedEndOfLiteral(file_id, range) => Diagnostic::error()
+            LiteralParseMessage::FloatLiteralExponentNotSupported(location) => Diagnostic::error()
+                .with_message("exponents are not yet supported for float literals")
+                .with_labels(labels![primary(location)]),
+            LiteralParseMessage::UnsupportedFloatLiteralBase(location, base) => Diagnostic::error()
+                .with_message(format!(
+                    "base {} float literals are not yet supported",
+                    base.to_u8(),
+                ))
+                .with_labels(labels![primary(location)])
+                .with_notes(vec![
+                    "only base 10 float literals are currently supported".to_owned()
+                ]),
+            LiteralParseMessage::UnexpectedEndOfLiteral(location) => Diagnostic::error()
                 .with_message("unexpected end of literal")
-                .with_labels(vec![Label::primary(*file_id, *range)]),
+                .with_labels(labels![primary(location)]),
         }
     }
 }
@@ -291,84 +281,68 @@ impl LiteralParseMessage {
 #[derive(Debug, Clone)]
 pub enum CoreTypingMessage {
     GlobalNameNotFound {
-        file_id: FileId,
         global_name: String,
-        global_name_range: Range,
+        global_name_location: Location,
     },
     ItemNameNotFound {
-        file_id: FileId,
         item_name: String,
-        item_name_range: Range,
+        item_name_location: Location,
     },
     LocalIndexNotFound {
-        file_id: FileId,
         local_index: core::LocalIndex,
-        local_index_range: Range,
+        local_index_location: Location,
     },
     FieldRedeclaration {
-        file_id: FileId,
         field_name: String,
-        record_range: Range,
+        record_location: Location,
     },
     ItemRedefinition {
-        file_id: FileId,
         name: String,
-        found_range: Range,
-        original_range: Range,
+        found_location: Location,
+        original_location: Location,
     },
     TypeMismatch {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         expected_type: core::Term,
         found_type: core::Term,
     },
     UniverseMismatch {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         found_type: core::Term,
     },
     TermHasNoType {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
     },
     NotAFunction {
-        file_id: FileId,
-        head_range: Range,
+        head_location: Location,
         head_type: core::Term,
-        argument_range: Range,
+        argument_location: Location,
     },
     FieldNotFound {
-        file_id: FileId,
-        head_range: Range,
+        head_location: Location,
         head_type: core::Term,
         label: String,
     },
     AmbiguousTerm {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
     },
     UnexpectedArrayTerm {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         expected_type: core::Term,
     },
     DuplicateStructFields {
-        file_id: FileId,
-        duplicate_labels: Vec<Ranged<String>>,
+        duplicate_labels: Vec<Located<String>>,
     },
     MissingStructFields {
-        file_id: FileId,
-        term_range: Range,
-        missing_labels: Vec<Ranged<String>>,
+        term_location: Location,
+        missing_labels: Vec<Located<String>>,
     },
     UnexpectedStructFields {
-        file_id: FileId,
-        term_range: Range,
-        unexpected_labels: Vec<Ranged<String>>,
+        term_location: Location,
+        unexpected_labels: Vec<Located<String>>,
     },
     UnexpectedStructTerm {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         expected_type: core::Term,
     },
 }
@@ -383,63 +357,60 @@ impl CoreTypingMessage {
 
         match self {
             CoreTypingMessage::GlobalNameNotFound {
-                file_id,
                 global_name,
-                global_name_range,
+                global_name_location,
             } => Diagnostic::bug()
                 .with_message(format!("global `{}` is not defined", global_name))
-                .with_labels(vec![Label::primary(*file_id, *global_name_range)
-                    .with_message("global is not defined")]),
+                .with_labels(labels![
+                    primary(global_name_location) = "global is not defined",
+                ]),
             CoreTypingMessage::ItemNameNotFound {
-                file_id,
                 item_name,
-                item_name_range,
+                item_name_location,
             } => Diagnostic::bug()
                 .with_message(format!("cannot find item `{}` in this scope", item_name))
-                .with_labels(vec![Label::primary(*file_id, *item_name_range)
-                    .with_message("item not found in this scope")]),
+                .with_labels(labels![
+                    primary(item_name_location) = "item not found in this scope",
+                ]),
             CoreTypingMessage::LocalIndexNotFound {
-                file_id,
                 local_index,
-                local_index_range,
+                local_index_location,
             } => Diagnostic::bug()
                 .with_message(format!(
                     "cannot find local `{}` in this scope",
                     local_index.0,
                 ))
-                .with_labels(vec![Label::primary(*file_id, local_index_range.clone())
-                    .with_message("local not found in this scope")]),
+                .with_labels(labels![
+                    primary(local_index_location) = "local not found in this scope",
+                ]),
             CoreTypingMessage::FieldRedeclaration {
-                file_id,
                 field_name,
-                record_range,
+                record_location,
             } => Diagnostic::bug()
                 .with_message(format!("field `{}` is already declared", field_name))
-                .with_labels(vec![Label::primary(*file_id, *record_range)
-                    .with_message(format!("field `{}` declared twice", field_name))])
+                .with_labels(labels![
+                    primary(record_location) = format!("field `{}` declared twice", field_name),
+                ])
                 .with_notes(vec![format!(
                     "`{}` must be defined only per struct",
                     field_name,
                 )]),
             CoreTypingMessage::ItemRedefinition {
-                file_id,
                 name,
-                found_range,
-                original_range,
+                found_location,
+                original_location,
             } => Diagnostic::bug()
                 .with_message(format!("the name `{}` is defined multiple times", name))
-                .with_labels(vec![
-                    Label::primary(*file_id, *found_range).with_message("redefined here"),
-                    Label::secondary(*file_id, *original_range)
-                        .with_message("previous definition here"),
+                .with_labels(labels![
+                    primary(found_location) = "redefined here",
+                    secondary(original_location) = "previous definition here",
                 ])
                 .with_notes(vec![format!(
                     "`{}` must be defined only once in this module",
                     name,
                 )]),
             CoreTypingMessage::TypeMismatch {
-                file_id,
-                term_range,
+                term_location,
                 expected_type,
                 found_type,
             } => {
@@ -448,13 +419,13 @@ impl CoreTypingMessage {
 
                 Diagnostic::bug()
                     .with_message("type mismatch")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected `{}`, found `{}`",
                             expected_type.pretty(std::usize::MAX),
                             found_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
                     .with_notes(vec![[
                         format!("expected `{}`", expected_type.pretty(std::usize::MAX)),
                         format!("   found `{}`", found_type.pretty(std::usize::MAX)),
@@ -462,40 +433,33 @@ impl CoreTypingMessage {
                     .join("\n")])
             }
             CoreTypingMessage::UniverseMismatch {
-                file_id,
-                term_range,
+                term_location,
                 found_type,
             } => {
                 let found_type = to_doc(found_type);
 
                 Diagnostic::bug()
                     .with_message("universe mismatch")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected a universe, found `{}`",
                             found_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
                     .with_notes(vec![[
                         format!("expected a universe"),
                         format!("   found `{}`", found_type.pretty(std::usize::MAX)),
                     ]
                     .join("\n")])
             }
-            CoreTypingMessage::TermHasNoType {
-                file_id,
-                term_range,
-            } => Diagnostic::bug()
+            CoreTypingMessage::TermHasNoType { term_location } => Diagnostic::bug()
                 .with_message("term has no type")
-                .with_labels(vec![
-                    Label::primary(*file_id, *term_range).with_message("cannot synthesize type")
-                ])
+                .with_labels(labels![primary(term_location) = "cannot synthesize type"])
                 .with_notes(vec![format!("term has no type")]),
             CoreTypingMessage::NotAFunction {
-                file_id,
-                head_range,
+                head_location,
                 head_type,
-                argument_range,
+                argument_location,
             } => {
                 let head_type = to_doc(head_type);
 
@@ -503,13 +467,12 @@ impl CoreTypingMessage {
                     .with_message(format!(
                         "applied something that is not a function to an argument"
                     ))
-                    .with_labels(vec![
-                        Label::primary(*file_id, *head_range).with_message(format!(
+                    .with_labels(labels![
+                        primary(head_location) = (format!(
                             "expected a function, found `{}`",
                             head_type.pretty(std::usize::MAX),
                         )),
-                        Label::secondary(*file_id, *argument_range)
-                            .with_message("applied to this argument"),
+                        secondary(argument_location) = "applied to this argument",
                     ])
                     .with_notes(vec![[
                         format!("expected a function"),
@@ -518,8 +481,7 @@ impl CoreTypingMessage {
                     .join("\n")])
             }
             CoreTypingMessage::FieldNotFound {
-                file_id,
-                head_range,
+                head_location,
                 head_type,
                 label,
             } => {
@@ -531,97 +493,84 @@ impl CoreTypingMessage {
                         &label,
                         head_type.pretty(std::usize::MAX),
                     ))
-                    .with_labels(vec![Label::primary(*file_id, *head_range)
-                        .with_message("field not found in this term")])
+                    .with_labels(labels![
+                        primary(head_location) = "field not found in this term",
+                    ])
             }
-            CoreTypingMessage::AmbiguousTerm {
-                file_id,
-                term_range,
-            } => Diagnostic::bug()
+            CoreTypingMessage::AmbiguousTerm { term_location } => Diagnostic::bug()
                 .with_message("ambiguous term")
-                .with_labels(vec![
-                    Label::primary(*file_id, *term_range).with_message("type annotation required")
-                ]),
+                .with_labels(labels![primary(term_location) = "type annotation required"]),
             CoreTypingMessage::UnexpectedArrayTerm {
-                file_id,
-                term_range,
+                term_location,
                 expected_type,
             } => {
                 let expected_type = to_doc(expected_type);
 
                 Diagnostic::bug()
                     .with_message("unexpected array term")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected `{}`, found array term",
                             expected_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
             }
-            CoreTypingMessage::DuplicateStructFields {
-                file_id,
-                duplicate_labels,
-            } => Diagnostic::error()
+            CoreTypingMessage::DuplicateStructFields { duplicate_labels } => Diagnostic::error()
                 .with_message("duplicate fields found in struct")
                 .with_labels(
                     duplicate_labels
                         .iter()
-                        .map(|label| {
-                            Label::primary(*file_id, label.range)
-                                .with_message("field already defined")
+                        .flat_map(|label| {
+                            label!(primary(&label.location) = "field already defined")
                         })
                         .collect(),
                 ),
             CoreTypingMessage::MissingStructFields {
-                file_id,
-                term_range,
+                term_location,
                 missing_labels,
             } => Diagnostic::bug()
                 .with_message("missing fields for struct")
                 .with_labels(
-                    std::iter::once(Label::primary(*file_id, *term_range).with_message(format!(
-                        "missing fields {}",
-                        missing_labels.iter().map(|label| &label.data).format(", ")
-                    )))
-                    .chain(missing_labels.iter().map(|label| {
-                        Label::secondary(*file_id, label.range)
-                            .with_message("field defined on struct here")
-                    }))
-                    .collect(),
+                    std::iter::empty()
+                        .chain(label!(
+                            primary(term_location) = format!(
+                                "missing fields {}",
+                                missing_labels.iter().map(|label| &label.data).format(", ")
+                            ),
+                        ))
+                        .chain(missing_labels.iter().flat_map(|label| {
+                            label!(secondary(&label.location) = "field defined on struct here")
+                        }))
+                        .collect(),
                 ),
             CoreTypingMessage::UnexpectedStructFields {
-                file_id,
-                term_range,
+                term_location,
                 unexpected_labels,
             } => Diagnostic::bug()
                 .with_message("unexpected fields found in struct")
                 .with_labels(
                     unexpected_labels
                         .iter()
-                        .map(|label| {
-                            Label::primary(*file_id, label.range).with_message("unexpected field")
-                        })
-                        .chain(std::iter::once(
-                            Label::secondary(*file_id, *term_range)
-                                .with_message("struct instantiated here"),
+                        .flat_map(|label| label!(primary(&label.location) = "unexpected field"))
+                        .chain(label!(
+                            secondary(term_location) = "struct instantiated here"
                         ))
                         .collect(),
                 ),
             CoreTypingMessage::UnexpectedStructTerm {
-                file_id,
-                term_range,
+                term_location,
                 expected_type,
             } => {
                 let expected_type = to_doc(expected_type);
 
                 Diagnostic::bug()
                     .with_message("unexpected struct term")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected `{}`, found struct",
                             expected_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
             }
         }
     }
@@ -633,122 +582,98 @@ impl CoreTypingMessage {
 #[derive(Debug, Clone)]
 pub enum SurfaceToCoreMessage {
     MissingStructAnnotation {
-        file_id: FileId,
         name: String,
-        name_range: Range,
+        name_location: Location,
     },
     InvalidStructAnnotation {
-        file_id: FileId,
         name: String,
         ann_type: surface::Term,
-        ann_range: Range,
+        ann_location: Location,
     },
     FieldRedeclaration {
-        file_id: FileId,
         name: String,
-        found_range: Range,
-        original_range: Range,
+        found_location: Location,
+        original_location: Location,
     },
     ItemRedefinition {
-        file_id: FileId,
         name: String,
-        found_range: Range,
-        original_range: Range,
+        found_location: Location,
+        original_location: Location,
     },
     TypeMismatch {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         expected_type: surface::Term,
         found_type: surface::Term,
     },
     UniverseMismatch {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         found_type: surface::Term,
     },
     TermHasNoType {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
     },
     NotAFunction {
-        file_id: FileId,
-        head_range: Range,
+        head_location: Location,
         head_type: surface::Term,
-        argument_range: Range,
+        argument_location: Location,
     },
     FieldNotFound {
-        file_id: FileId,
-        head_range: Range,
+        head_location: Location,
         head_type: surface::Term,
-        label: Ranged<String>,
+        label: Located<String>,
     },
     AmbiguousMatchExpression {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
     },
     VarNameNotFound {
-        file_id: FileId,
         name: String,
-        name_range: Range,
+        name_location: Location,
     },
     MismatchedArrayLength {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         found_len: usize,
         expected_len: surface::Term,
     },
     UnexpectedSequenceTerm {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         expected_type: surface::Term,
     },
     NumericLiteralNotSupported {
-        file_id: FileId,
-        literal_range: Range,
+        literal_location: Location,
         expected_type: surface::Term,
     },
     AmbiguousSequenceTerm {
-        file_id: FileId,
-        range: Range,
+        location: Location,
     },
     AmbiguousNumericLiteral {
-        file_id: FileId,
-        literal_range: Range,
+        literal_location: Location,
     },
     AmbiguousStructTerm {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
     },
     UnsupportedPatternType {
-        file_id: FileId,
-        scrutinee_range: Range,
+        scrutinee_location: Location,
         found_type: surface::Term,
     },
     NoDefaultPattern {
-        file_id: FileId,
-        match_range: Range,
+        match_location: Location,
     },
     UnreachablePattern {
-        file_id: FileId,
-        pattern_range: Range,
+        pattern_location: Location,
     },
     DuplicateStructFields {
-        file_id: FileId,
-        duplicate_labels: Vec<Ranged<String>>,
+        duplicate_labels: Vec<Located<String>>,
     },
     MissingStructFields {
-        file_id: FileId,
-        term_range: Range,
-        missing_labels: Vec<Ranged<String>>,
+        term_location: Location,
+        missing_labels: Vec<Located<String>>,
     },
     UnexpectedStructFields {
-        file_id: FileId,
-        term_range: Range,
-        unexpected_labels: Vec<Ranged<String>>,
+        term_location: Location,
+        unexpected_labels: Vec<Located<String>>,
     },
     UnexpectedStructTerm {
-        file_id: FileId,
-        term_range: Range,
+        term_location: Location,
         expected_type: surface::Term,
     },
 }
@@ -763,33 +688,28 @@ impl SurfaceToCoreMessage {
 
         match self {
             SurfaceToCoreMessage::MissingStructAnnotation {
-                file_id,
                 name,
-                name_range,
-            } => {
-                let expected_range = name_range.end..name_range.end;
-
-                Diagnostic::error()
-                    .with_message(format!("missing type annotation for struct `{}`", name))
-                    .with_labels(vec![Label::primary(*file_id, expected_range)
-                        .with_message("annotation expected here")])
-            }
+                name_location,
+            } => Diagnostic::error()
+                .with_message(format!("missing type annotation for struct `{}`", name))
+                .with_labels(labels![
+                    primary(&name_location.end()) = "annotation expected here",
+                ]),
             SurfaceToCoreMessage::InvalidStructAnnotation {
-                file_id,
                 name,
                 ann_type,
-                ann_range,
+                ann_location,
             } => {
                 let ann_type = to_doc(ann_type);
 
                 Diagnostic::error()
                     .with_message(format!("invalid type annotation for struct `{}`", name))
-                    .with_labels(vec![Label::primary(*file_id, *ann_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(ann_location) = format!(
                             "expected `Type` or `Format`, found `{}`",
                             ann_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
                     .with_notes(vec![[
                         format!("expected `Type` or `Format`"),
                         format!("   found `{}`", ann_type.pretty(std::usize::MAX)),
@@ -797,37 +717,32 @@ impl SurfaceToCoreMessage {
                     .join("\n")])
             }
             SurfaceToCoreMessage::FieldRedeclaration {
-                file_id,
                 name,
-                found_range,
-                original_range,
+                found_location,
+                original_location,
             } => Diagnostic::error()
                 .with_message(format!("field `{}` is already declared", name))
-                .with_labels(vec![
-                    Label::primary(*file_id, *found_range).with_message("field already declared"),
-                    Label::secondary(*file_id, *original_range)
-                        .with_message("previous field declaration here"),
+                .with_labels(labels![
+                    primary(found_location) = "field already declared",
+                    secondary(original_location) = "previous field declaration here",
                 ])
                 .with_notes(vec![format!("`{}` must be defined only per struct", name)]),
             SurfaceToCoreMessage::ItemRedefinition {
-                file_id,
                 name,
-                found_range,
-                original_range,
+                found_location,
+                original_location,
             } => Diagnostic::error()
                 .with_message(format!("the name `{}` is defined multiple times", name))
-                .with_labels(vec![
-                    Label::primary(*file_id, *found_range).with_message("redefined here"),
-                    Label::secondary(*file_id, *original_range)
-                        .with_message("previous definition here"),
+                .with_labels(labels![
+                    primary(found_location) = ("redefined here"),
+                    secondary(original_location) = "previous definition here",
                 ])
                 .with_notes(vec![format!(
                     "`{}` must be defined only once in this module",
                     name,
                 )]),
             SurfaceToCoreMessage::TypeMismatch {
-                file_id,
-                term_range,
+                term_location,
                 expected_type,
                 found_type,
             } => {
@@ -836,13 +751,13 @@ impl SurfaceToCoreMessage {
 
                 Diagnostic::error()
                     .with_message("type mismatch")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected `{}`, found `{}`",
                             expected_type.pretty(std::usize::MAX),
                             found_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
                     .with_notes(vec![[
                         format!("expected `{}`", expected_type.pretty(std::usize::MAX)),
                         format!("   found `{}`", found_type.pretty(std::usize::MAX)),
@@ -850,40 +765,33 @@ impl SurfaceToCoreMessage {
                     .join("\n")])
             }
             SurfaceToCoreMessage::UniverseMismatch {
-                file_id,
-                term_range,
+                term_location,
                 found_type,
             } => {
                 let found_type = to_doc(found_type);
 
                 Diagnostic::error()
                     .with_message("universe mismatch")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected a universe, found `{}`",
                             found_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
                     .with_notes(vec![[
                         format!("expected a universe"),
                         format!("   found `{}`", found_type.pretty(std::usize::MAX)),
                     ]
                     .join("\n")])
             }
-            SurfaceToCoreMessage::TermHasNoType {
-                file_id,
-                term_range,
-            } => Diagnostic::error()
+            SurfaceToCoreMessage::TermHasNoType { term_location } => Diagnostic::error()
                 .with_message("term has no type")
-                .with_labels(vec![
-                    Label::primary(*file_id, *term_range).with_message("cannot synthesize type")
-                ])
+                .with_labels(labels![primary(term_location) = "cannot synthesize type"])
                 .with_notes(vec![format!("term has no type")]),
             SurfaceToCoreMessage::NotAFunction {
-                file_id,
-                head_range,
+                head_location,
                 head_type,
-                argument_range,
+                argument_location,
             } => {
                 let head_type = to_doc(head_type);
 
@@ -891,13 +799,12 @@ impl SurfaceToCoreMessage {
                     .with_message(format!(
                         "applied something that is not a function to an argument"
                     ))
-                    .with_labels(vec![
-                        Label::primary(*file_id, *head_range).with_message(format!(
+                    .with_labels(labels![
+                        primary(head_location) = (format!(
                             "expected a function, found `{}`",
                             head_type.pretty(std::usize::MAX),
                         )),
-                        Label::secondary(*file_id, *argument_range)
-                            .with_message("applied to this argument"),
+                        secondary(argument_location) = "applied to this argument",
                     ])
                     .with_notes(vec![[
                         format!("expected a function"),
@@ -906,8 +813,7 @@ impl SurfaceToCoreMessage {
                     .join("\n")])
             }
             SurfaceToCoreMessage::FieldNotFound {
-                file_id,
-                head_range,
+                head_location,
                 head_type,
                 label,
             } => {
@@ -919,62 +825,50 @@ impl SurfaceToCoreMessage {
                         &label.data,
                         head_type.pretty(std::usize::MAX),
                     ))
-                    .with_labels(vec![
-                        Label::primary(*file_id, label.range).with_message("non-existent field"),
-                        Label::secondary(*file_id, *head_range)
-                            .with_message("field not found in this term"),
+                    .with_labels(labels![
+                        primary(&label.location) = "non-existent field",
+                        secondary(head_location) = "field not found in this term",
                     ])
             }
-            SurfaceToCoreMessage::AmbiguousMatchExpression {
-                file_id,
-                term_range,
-            } => Diagnostic::error()
+            SurfaceToCoreMessage::AmbiguousMatchExpression { term_location } => Diagnostic::error()
                 .with_message("ambiguous match expression")
-                .with_labels(vec![
-                    Label::primary(*file_id, *term_range).with_message("type annotation required")
-                ]),
+                .with_labels(labels![primary(term_location) = "type annotation required"]),
             SurfaceToCoreMessage::VarNameNotFound {
-                file_id,
                 name,
-                name_range,
+                name_location,
             } => Diagnostic::error()
                 .with_message(format!("cannot find `{}` in this scope", name))
-                .with_labels(vec![
-                    Label::primary(*file_id, *name_range).with_message("not found in this scope")
-                ]),
+                .with_labels(labels![primary(name_location) = "not found in this scope"]),
             SurfaceToCoreMessage::MismatchedArrayLength {
-                file_id,
-                term_range: range,
+                term_location,
                 found_len,
                 expected_len,
             } => Diagnostic::error()
                 .with_message("mismatched array length")
-                .with_labels(vec![Label::primary(*file_id, *range).with_message(
-                    format!(
+                .with_labels(labels![
+                    primary(term_location) = format!(
                         "expected `{}` elements, found `{}` elements",
                         to_doc(&expected_len).pretty(std::usize::MAX),
                         found_len,
                     ),
-                )]),
+                ]),
             SurfaceToCoreMessage::UnexpectedSequenceTerm {
-                file_id,
-                term_range,
+                term_location,
                 expected_type,
             } => {
                 let expected_type = to_doc(expected_type);
 
                 Diagnostic::error()
                     .with_message("unexpected sequence term")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected `{}`, found sequence term",
                             expected_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
             }
             SurfaceToCoreMessage::NumericLiteralNotSupported {
-                file_id,
-                literal_range,
+                literal_location,
                 expected_type,
             } => {
                 let expected_type = to_doc(expected_type);
@@ -984,36 +878,28 @@ impl SurfaceToCoreMessage {
                         "cannot construct a `{}` from a numeric literal",
                         expected_type.pretty(std::usize::MAX),
                     ))
-                    .with_labels(vec![Label::primary(*file_id, *literal_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(literal_location) = format!(
                             "numeric literals not supported for type `{}`",
                             expected_type.pretty(std::usize::MAX),
                         ),
-                    )])
+                    ])
             }
-            SurfaceToCoreMessage::AmbiguousSequenceTerm { file_id, range } => Diagnostic::error()
+            SurfaceToCoreMessage::AmbiguousSequenceTerm { location } => Diagnostic::error()
                 .with_message("ambiguous sequence term")
-                .with_labels(vec![
-                    Label::primary(*file_id, *range).with_message("type annotation required")
-                ]),
-            SurfaceToCoreMessage::AmbiguousNumericLiteral {
-                file_id,
-                literal_range,
-            } => Diagnostic::error()
-                .with_message("ambiguous numeric literal")
-                .with_labels(vec![Label::primary(*file_id, *literal_range)
-                    .with_message("type annotation required")]),
-            SurfaceToCoreMessage::AmbiguousStructTerm {
-                file_id,
-                term_range,
-            } => Diagnostic::error()
+                .with_labels(labels![primary(location) = "type annotation required"]),
+            SurfaceToCoreMessage::AmbiguousNumericLiteral { literal_location } => {
+                Diagnostic::error()
+                    .with_message("ambiguous numeric literal")
+                    .with_labels(labels![
+                        primary(literal_location) = "type annotation required"
+                    ])
+            }
+            SurfaceToCoreMessage::AmbiguousStructTerm { term_location } => Diagnostic::error()
                 .with_message("ambiguous struct term")
-                .with_labels(vec![
-                    Label::primary(*file_id, *term_range).with_message("type annotation required")
-                ]),
+                .with_labels(labels![primary(term_location) = "type annotation required"]),
             SurfaceToCoreMessage::UnsupportedPatternType {
-                file_id,
-                scrutinee_range,
+                scrutinee_location,
                 found_type,
             } => {
                 let found_type = to_doc(found_type);
@@ -1023,8 +909,9 @@ impl SurfaceToCoreMessage {
                         "unsupported pattern type: `{}`",
                         found_type.pretty(std::usize::MAX)
                     ))
-                    .with_labels(vec![Label::primary(*file_id, *scrutinee_range)
-                        .with_message(format!("unsupported pattern type"))])
+                    .with_labels(labels![
+                        primary(scrutinee_location) = (format!("unsupported pattern type"))
+                    ])
                     .with_notes(vec![
                         format!(
                             "unsupported pattern type: `{}`",
@@ -1033,86 +920,68 @@ impl SurfaceToCoreMessage {
                         "can only currently match against terms of type `Bool` or `Int`".to_owned(),
                     ])
             }
-            SurfaceToCoreMessage::NoDefaultPattern {
-                file_id,
-                match_range,
-            } => Diagnostic::error()
+            SurfaceToCoreMessage::NoDefaultPattern { match_location } => Diagnostic::error()
                 .with_message("non-exhaustive patterns")
-                .with_labels(vec![
-                    Label::primary(*file_id, *match_range).with_message("missing default pattern")
-                ]),
-            SurfaceToCoreMessage::UnreachablePattern {
-                file_id,
-                pattern_range,
-            } => Diagnostic::warning()
+                .with_labels(labels![primary(match_location) = "missing default pattern"]),
+            SurfaceToCoreMessage::UnreachablePattern { pattern_location } => Diagnostic::warning()
                 .with_message("unreachable pattern")
-                .with_labels(vec![
-                    Label::primary(*file_id, *pattern_range).with_message("unreachable pattern")
-                ]),
-            SurfaceToCoreMessage::DuplicateStructFields {
-                file_id,
-                duplicate_labels,
-            } => Diagnostic::error()
+                .with_labels(labels![primary(pattern_location) = "unreachable pattern"]),
+            SurfaceToCoreMessage::DuplicateStructFields { duplicate_labels } => Diagnostic::error()
                 .with_message("duplicate fields found in struct")
                 .with_labels(
                     duplicate_labels
                         .iter()
-                        .map(|label| {
-                            Label::primary(*file_id, label.range)
-                                .with_message("field already defined")
+                        .flat_map(|label| {
+                            label!(primary(&label.location) = "field already defined")
                         })
                         .collect(),
                 ),
             SurfaceToCoreMessage::MissingStructFields {
-                file_id,
-                term_range,
+                term_location,
                 missing_labels,
             } => Diagnostic::error()
                 .with_message("missing fields for struct")
                 .with_labels(
-                    std::iter::once(Label::primary(*file_id, *term_range).with_message(format!(
-                        "missing fields {}",
-                        missing_labels.iter().map(|label| &label.data).format(", ")
-                    )))
-                    .chain(missing_labels.iter().map(|label| {
-                        Label::secondary(*file_id, label.range)
-                            .with_message("field defined on struct here")
-                    }))
-                    .collect(),
+                    std::iter::empty()
+                        .chain(label!(
+                            primary(term_location) = format!(
+                                "missing fields {}",
+                                missing_labels.iter().map(|label| &label.data).format(", ")
+                            ),
+                        ))
+                        .chain(missing_labels.iter().flat_map(|label| {
+                            label!(secondary(&label.location) = "field defined on struct here")
+                        }))
+                        .collect(),
                 ),
             SurfaceToCoreMessage::UnexpectedStructFields {
-                file_id,
-                term_range,
+                term_location,
                 unexpected_labels,
             } => Diagnostic::error()
                 .with_message("unexpected fields found in struct")
                 .with_labels(
                     unexpected_labels
                         .iter()
-                        .map(|label| {
-                            Label::primary(*file_id, label.range).with_message("unexpected field")
-                        })
-                        .chain(std::iter::once(
-                            Label::secondary(*file_id, *term_range)
-                                .with_message("struct instantiated here"),
+                        .flat_map(|label| label!(primary(&label.location) = "unexpected field"))
+                        .chain(label!(
+                            secondary(term_location) = "struct instantiated here"
                         ))
                         .collect(),
                 ),
             SurfaceToCoreMessage::UnexpectedStructTerm {
-                file_id,
-                term_range,
+                term_location,
                 expected_type,
             } => {
                 let expected_type = to_doc(expected_type);
 
                 Diagnostic::error()
                     .with_message("unexpected struct term")
-                    .with_labels(vec![Label::primary(*file_id, *term_range).with_message(
-                        format!(
+                    .with_labels(labels![
+                        primary(term_location) = format!(
                             "expected `{}`, found struct",
                             expected_type.pretty(std::usize::MAX)
                         ),
-                    )])
+                    ])
             }
         }
     }


### PR DESCRIPTION
Instead of storing the file id in the module, we instead store them in source locations wherever they are needed in the AST. This means the ASTs will consume more memory, but it simplifies the compiler a great deal. We can always optimise this later by compressing source locations or using a location sidetable.