### PR TITLE
Implement JSON output for diagnostics

### DIFF
--- a/fathom-cli/src/lib.rs
+++ b/fathom-cli/src/lib.rs
@@ -1,5 +1,5 @@
 use codespan_reporting::term::termcolor::ColorChoice;
-use fathom::driver::TermWidth;
+use fathom::driver::{diagnostic, TermWidth};
 use structopt::StructOpt;
 
 mod commands;
@@ -17,6 +17,16 @@ pub struct Options {
         parse(try_from_str = parse_color_choice),
     )]
     color: ColorChoice,
+    /// How diagnostics are rendered
+    #[structopt(
+        long = "diagnostic-style",
+        name = "STYLE",
+        default_value = "human",
+        case_insensitive = true,
+        possible_values = &["human", "json"],
+        parse(try_from_str = parse_diagnostic_style),
+    )]
+    diagnostic_style: diagnostic::Style,
     /// The width of terminal to use when wrapping diagnostic output
     #[structopt(
         long = "term-width",
@@ -27,6 +37,7 @@ pub struct Options {
         parse(try_from_str = parse_term_width),
     )]
     term_width: TermWidth,
+
     #[structopt(subcommand)]
     command: Command,
 }
@@ -56,6 +67,14 @@ fn parse_color_choice(src: &str) -> Result<ColorChoice, &'static str> {
         () if src.eq_ignore_ascii_case("ansi") => Ok(ColorChoice::AlwaysAnsi),
         () if src.eq_ignore_ascii_case("never") => Ok(ColorChoice::Never),
         () => Err("valid values: auto, always, ansi, never"),
+    }
+}
+
+fn parse_diagnostic_style(src: &str) -> Result<diagnostic::Style, &'static str> {
+    match () {
+        () if src.eq_ignore_ascii_case("human") => Ok(diagnostic::Style::Human),
+        () if src.eq_ignore_ascii_case("json") => Ok(diagnostic::Style::Json),
+        () => Err("valid values: human, json"),
     }
 }
 

--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -24,6 +24,8 @@ num-bigint = "0.4"
 num-traits = "0.2"
 pretty = "0.10"
 termsize = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 proptest = "1"

--- a/fathom/src/driver/diagnostic.rs
+++ b/fathom/src/driver/diagnostic.rs
@@ -1,0 +1,58 @@
+//! This stuff would probably be better off in `codespan_reporting`...
+
+use codespan_reporting::diagnostic::{Diagnostic, LabelStyle, Severity};
+use codespan_reporting::files::{self, Files};
+
+pub mod api;
+
+#[derive(Debug, Copy, Clone)]
+pub enum Style {
+    Human,
+    Json,
+}
+
+pub fn to_json_diagnostic<'files, F: Files<'files>>(
+    files: &'files F,
+    diagnostic: &Diagnostic<F::FileId>,
+) -> Result<api::Diagnostic, files::Error> {
+    let labels = diagnostic
+        .labels
+        .iter()
+        .map(|label| {
+            let start = files.location(label.file_id, label.range.start)?;
+            let end = files.location(label.file_id, label.range.end)?;
+
+            Ok(api::Label {
+                file: files.name(label.file_id)?.to_string(),
+                start: api::Location {
+                    line: start.line_number,
+                    column: start.column_number,
+                    byte: label.range.start,
+                },
+                end: api::Location {
+                    line: end.line_number,
+                    column: end.column_number,
+                    byte: label.range.end,
+                },
+                style: match label.style {
+                    LabelStyle::Primary => api::LabelStyle::Primary,
+                    LabelStyle::Secondary => api::LabelStyle::Secondary,
+                },
+                message: label.message.clone(),
+            })
+        })
+        .collect::<Result<_, files::Error>>()?;
+
+    Ok(api::Diagnostic {
+        message: diagnostic.message.clone(),
+        severity: match diagnostic.severity {
+            Severity::Bug => api::Severity::Bug,
+            Severity::Error => api::Severity::Error,
+            Severity::Warning => api::Severity::Warning,
+            Severity::Note => api::Severity::Note,
+            Severity::Help => api::Severity::Help,
+        },
+        labels,
+        notes: diagnostic.notes.clone(),
+    })
+}

--- a/fathom/src/driver/diagnostic/api.rs
+++ b/fathom/src/driver/diagnostic/api.rs
@@ -1,0 +1,47 @@
+//! Serialized diagnostic output, for tooling and screenreaders, etc.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Severity {
+    Bug,
+    Error,
+    Warning,
+    Note,
+    Help,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Diagnostic {
+    pub message: String,
+    pub severity: Severity,
+    pub labels: Vec<Label>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LabelStyle {
+    Primary,
+    Secondary,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Label {
+    pub file: String,
+    pub start: Location,
+    pub end: Location,
+    pub style: LabelStyle,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Location {
+    pub line: usize,
+    pub column: usize,
+    pub byte: usize,
+}


### PR DESCRIPTION
Playing around with a way of rendering codespan diagnostics as JSON. This should then let us read structured error info from the the CLI commands in our tests, which is important for supporting matching against errors.

It would be really nice to upstream this to codespan-reporting at some stage, as the current method for rendering errors is not the greatest for accessibility and screen readers (see https://github.com/brendanzab/codespan/issues/30), which makes me quite embarrassed!