### PR TITLE
Implement overlap formats

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -142,6 +142,9 @@ pub enum Term<'arena> {
     ArrayIntro(&'arena [Term<'arena>]),
     /// Record formats, consisting of a list of dependent formats.
     FormatRecord(&'arena [StringId], &'arena [Term<'arena>]),
+    /// Overlap formats, consisting of a list of dependent formats, overlapping
+    /// in memory.
+    FormatOverlap(&'arena [StringId], &'arena [Term<'arena>]),
     /// Primitives.
     Prim(Prim),
     /// Constants.

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -122,6 +122,8 @@ pub enum Term<'arena, Range> {
     NumberLiteral(Range, StringId),
     /// Record format.
     FormatRecord(Range, &'arena [((Range, StringId), Term<'arena, Range>)]),
+    /// Overlap format.
+    FormatOverlap(Range, &'arena [((Range, StringId), Term<'arena, Range>)]),
     /// Reported error sentinel.
     ReportedError(Range),
 }
@@ -149,6 +151,7 @@ impl<'arena, Range: Clone> Term<'arena, Range> {
             | Term::StringLiteral(range, _)
             | Term::NumberLiteral(range, _)
             | Term::FormatRecord(range, _)
+            | Term::FormatOverlap(range, _)
             | Term::ReportedError(range) => range.clone(),
         }
     }

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -572,6 +572,12 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
                 Ok(Term::FormatRecord(labels, formats))
             }
+            Value::FormatOverlap(labels, formats) => {
+                let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
+                let formats = self.rename_telescope(flexible_var, formats)?;
+
+                Ok(Term::FormatOverlap(labels, formats))
+            }
             Value::Const(constant) => Ok(Term::Const(*constant)),
         }
     }

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -21,6 +21,7 @@ extern {
         "fun" => Token::KeywordFun,
         "let" => Token::KeywordLet,
         "match" => Token::KeywordMatch,
+        "overlap" => Token::KeywordOverlap,
         "Type" => Token::KeywordType,
 
         ":" => Token::Colon,
@@ -159,6 +160,13 @@ AtomicTerm: Term<'arena, ByteRange> = {
     <start: @L> "{" <first: (<RangedName> "<-" <Term>)> <format_fields: ("," <RangedName> "<-" <Term>)*> ","?  "}" <end: @R> => {
         let format_fields = std::iter::once(first).chain(format_fields);
         Term::FormatRecord(
+            ByteRange::new(start, end),
+            scope.to_scope_from_iter(format_fields),
+        )
+    },
+    <start: @L> "overlap" "{" <format_fields: (<RangedName> "<-" <Term> ",")*> <last: (<RangedName> "<-" <Term>)?> "}" <end: @R> => {
+        let format_fields = format_fields.into_iter().chain(last);
+        Term::FormatOverlap(
             ByteRange::new(start, end),
             scope.to_scope_from_iter(format_fields),
         )

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -17,6 +17,8 @@ pub enum Token<'source> {
     KeywordLet,
     #[token("match")]
     KeywordMatch,
+    #[token("overlap")]
+    KeywordOverlap,
     #[token("Type")]
     KeywordType,
 

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -265,6 +265,26 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 self.space(),
                 self.text("}"),
             ]),
+            Term::FormatOverlap(_, format_fields) => self.concat([
+                self.text("overlap "),
+                self.space(),
+                self.text("{"),
+                self.space(),
+                self.intersperse(
+                    format_fields.iter().map(|((_, label), format)| {
+                        self.concat([
+                            self.string_id(*label),
+                            self.space(),
+                            self.text("<-"),
+                            self.space(),
+                            self.term_prec(Prec::Top, format),
+                        ])
+                    }),
+                    self.concat([self.text(","), self.space()]),
+                ),
+                self.space(),
+                self.text("}"),
+            ]),
             Term::ReportedError(_) => self.text("#error"),
         }
     }

--- a/tests/succeed/format-overlap/dependent.fathom
+++ b/tests/succeed/format-overlap/dependent.fathom
@@ -1,0 +1,25 @@
+// This is kind of a pointless example to show dependencies between overlapped
+// formats. More compelling examples once we add more language features.
+
+let record0 = {
+    length <- u8,
+};
+
+let record1 = fun (length : U8) => {
+    _length <- u8, // Skip length
+    data <- array8 length u8,
+};
+
+let silly = overlap {
+    record0 <- record0,
+    record1 <- record1 record0.length,
+};
+
+let _ :
+        Repr silly -> {
+            record0 : { length : U8 },
+            record1 : { _length : U8, data : Array8 record0.length U8 },
+        }
+    = fun silly => silly;
+
+{}

--- a/tests/succeed/format-overlap/numbers.fathom
+++ b/tests/succeed/format-overlap/numbers.fathom
@@ -1,0 +1,9 @@
+let number = overlap {
+    u <- u32be,
+    s <- s32be,
+};
+
+let _ : Repr number -> { u : U32, s : S32 } =
+    fun n => n;
+
+{}


### PR DESCRIPTION
This implements a format comprised of a dependent sequence of overlapping formats. This allows later information to affect how past information is parsed, which could be useful for defining the tricky mutual recursion found in the font tables in OpenType.