### PR TITLE
Link formats

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -24,6 +24,7 @@ elaboration, and core language is forthcoming.
   - [Overlap formats](#overlap-formats)
   - [Number formats](#number-formats)
   - [Array formats](#array-formats)
+  - [Link formats](#link-formats)
   - [Stream position formats](#stream-position-formats)
   - [Succeed format](#succeed-format)
   - [Fail format](#fail-format)
@@ -42,6 +43,7 @@ elaboration, and core language is forthcoming.
   - [Array types](#array-types)
   - [Array literals](#array-literals)
 - [Positions](#positions)
+- [References](#references)
 - [Void](#void)
 
 ## Structure
@@ -69,17 +71,17 @@ definition during evaluation.
 
 If no binding is found, names can refer to one of the built-in primitives:
 
-- `Format`
+- `Format`, `Repr`
 - `u8`, `u16be`, `u16le`, `u32be`, `u32le`, `u64be`, `u64le`
 - `s8`, `s16be`, `s16le`, `s32be`, `s32le`, `s64be`, `s64le`
 - `f32be`, `f32le`, `f64be`, `f64le`
 - `array8`, `array16`, `array32`, `array64`
+- `link8`, `link16`, `link32`, `link64`
 - `stream_pos`
 - `succeed`, `fail`
-- `Repr`
 - `U8`, `U16`, `U32`, `U64`, `S8`, `S16`, `S32`, `S64`, `F32`, `F64`
 - `Array8`, `Array16`, `Array32`, `Array64`
-- `Pos`
+- `Pos`, `Ref`
 - `Void`
 
 ### Let expressions
@@ -342,6 +344,31 @@ of the host array types.
 | `array32 len format`   | `Array32 len (Repr format)`         |
 | `array64 len format`   | `Array64 len (Repr format)`         |
 
+### Link formats
+
+Link formats allow for references to other parts of a binary stream to be
+registered during parsing. They take a base [position](#positions), an offset
+from that position, and a format to expect at that position.
+
+There is a different link type for each unsigned integer offset:
+
+- `link8 : Pos -> U8 -> Format -> Format`
+- `link16 : Pos -> U16 -> Format -> Format`
+- `link32 : Pos -> U32 -> Format -> Format`
+- `link64 : Pos -> U64 -> Format -> Format`
+
+#### Representation of link formats
+
+Links formats are [represented](#format-representations) as typed
+[references](#references) to other parts of the binary stream.
+
+| format                       | `Repr` format               |
+| ---------------------------- | --------------------------- |
+| `link8 pos offset format`    | `Ref (Repr format)`         |
+| `link16 pos offset format`   | `Ref (Repr format)`         |
+| `link32 pos offset format`   | `Ref (Repr format)`         |
+| `link64 pos offset format`   | `Ref (Repr format)`         |
+
 ### Stream position formats
 
 The stream position format is interpreted as the current stream position during
@@ -375,6 +402,8 @@ parsing.
 - `fail : Format`
 
 #### Representation of fail format
+
+The fail format should never produce a term, so is represented with [void](#void).
 
 | format | `Repr` format |
 | ------ | ------------- |
@@ -580,6 +609,16 @@ Stream positions are represented as an abstract datatype:
 
 Positions are usually encountered as a result of parsing a [stream position
 format](#stream-position-formats).
+
+## References
+
+References are like [stream positions](#positions), only they also have an
+expected type given as well:
+
+- `Ref : Type -> Type`
+
+References are usually encountered as a result of parsing a [link
+format](#link-formats).
 
 ## Void
 

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -193,6 +193,8 @@ pub enum Prim {
     Array64Type,
     /// Type of stream positions.
     PosType,
+    /// Type of stream references.
+    RefType,
 
     /// Type of format descriptions.
     FormatType,
@@ -236,16 +238,28 @@ pub enum Prim {
     FormatF64Be,
     /// 64-bit, IEEE-754 floating point formats (little-endian).
     FormatF64Le,
-    /// Array formats, with 8-bit indices.
+    /// Array formats, with unsigned 8-bit indices.
     FormatArray8,
-    /// Array formats, with 16-bit indices.
+    /// Array formats, with unsigned 16-bit indices.
     FormatArray16,
-    /// Array formats, with 32-bit indices.
+    /// Array formats, with unsigned 32-bit indices.
     FormatArray32,
-    /// Array formats, with 64-bit indices.
+    /// Array formats, with unsigned 64-bit indices.
     FormatArray64,
     /// A format which returns the current position in the input stream.
     FormatStreamPos,
+    /// A format that links to another location in the binary data stream,
+    /// relative to a base position and a unsigned 8-bit offset.
+    FormatLink8,
+    /// A format that links to another location in the binary data stream,
+    /// relative to a base position and a unsigned 16-bit offset.
+    FormatLink16,
+    /// A format that links to another location in the binary data stream,
+    /// relative to a base position and a unsigned 32-bit offset.
+    FormatLink32,
+    /// A format that links to another location in the binary data stream,
+    /// relative to a base position and a unsigned 64-bit offset.
+    FormatLink64,
     /// Format representations.
     FormatRepr,
 
@@ -273,6 +287,7 @@ impl Prim {
             Prim::Array32Type => "Array32",
             Prim::Array64Type => "Array64",
             Prim::PosType => "Pos",
+            Prim::RefType => "Ref",
 
             Prim::FormatType => "Format",
             Prim::FormatSucceed => "succeed",
@@ -299,6 +314,10 @@ impl Prim {
             Prim::FormatArray16 => "array16",
             Prim::FormatArray32 => "array32",
             Prim::FormatArray64 => "array64",
+            Prim::FormatLink8 => "link8",
+            Prim::FormatLink16 => "link16",
+            Prim::FormatLink32 => "link32",
+            Prim::FormatLink64 => "link64",
             Prim::FormatStreamPos => "stream_pos",
             Prim::FormatRepr => "Repr",
 
@@ -322,6 +341,7 @@ pub enum Const {
     F32(f32),
     F64(f64),
     Pos(u64),
+    Ref(u64),
 }
 
 #[cfg(test)]

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -53,7 +53,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 (Prim::FormatArray32, [Fun(len), Fun(elem)]) => self.read_array(reader, len, elem),
                 (Prim::FormatArray64, [Fun(len), Fun(elem)]) => self.read_array(reader, len, elem),
                 (Prim::FormatStreamPos, []) => read_stream_pos(reader),
-                _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid format")),
+                (Prim::FormatFail, []) => {
+                    Err(io::Error::new(io::ErrorKind::Other, "parse failure"))
+                }
+                _ => Err(io::Error::new(io::ErrorKind::Other, "invalid format")),
             },
             Value::FormatRecord(labels, formats) => {
                 let mut formats = formats.clone();
@@ -104,9 +107,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
             | Value::RecordType(_, _)
             | Value::RecordIntro(_, _)
             | Value::ArrayIntro(_)
-            | Value::Const(_) => {
-                return Err(io::Error::new(io::ErrorKind::Other, "invalid format"))
-            }
+            | Value::Const(_) => Err(io::Error::new(io::ErrorKind::Other, "invalid format")),
         }
     }
 

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -550,6 +550,18 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
                     (Prim::FormatArray64, [Elim::Fun(len), Elim::Fun(elem)]) => Arc::new(
                         Value::prim(Prim::Array64Type, [len.clone(), self.apply_repr(elem)]),
                     ),
+                    (Prim::FormatLink8, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
+                        Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
+                    }
+                    (Prim::FormatLink16, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
+                        Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
+                    }
+                    (Prim::FormatLink32, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
+                        Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
+                    }
+                    (Prim::FormatLink64, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
+                        Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
+                    }
                     (Prim::FormatStreamPos, []) => Arc::new(Value::prim(Prim::PosType, [])),
                     (Prim::ReportedError, []) => Arc::new(Value::prim(Prim::ReportedError, [])),
                     _ => panic_any(Error::InvalidFormatRepr),

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -92,6 +92,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             core::Const::F32(number) => self.check_number_pattern(number),
             core::Const::F64(number) => self.check_number_pattern(number),
             core::Const::Pos(number) => self.check_number_pattern(number),
+            core::Const::Ref(number) => self.check_number_pattern(number),
         }
     }
 
@@ -177,6 +178,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::Const::F32(number) => self.check_number_literal(number),
                 core::Const::F64(number) => self.check_number_literal(number),
                 core::Const::Pos(number) => self.check_number_literal(number),
+                core::Const::Ref(number) => self.check_number_literal(number),
             },
             core::Term::ConstElim(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
@@ -364,6 +366,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::Const::F32(number) => self.synth_number_literal(number, core::Prim::F32Type),
                 core::Const::F64(number) => self.synth_number_literal(number, core::Prim::F64Type),
                 core::Const::Pos(number) => self.synth_number_literal(number, core::Prim::PosType),
+                core::Const::Ref(number) => self.synth_number_literal(number, core::Prim::RefType),
             },
             core::Term::ConstElim(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -44,7 +44,7 @@ impl<'arena> RigidEnv<'arena> {
 
     pub fn default(
         interner: &RefCell<StringInterner>,
-        _scope: &'arena Scope<'arena>,
+        scope: &'arena Scope<'arena>,
     ) -> RigidEnv<'arena> {
         use crate::core::Term;
         use crate::env::LocalVar;
@@ -52,6 +52,7 @@ impl<'arena> RigidEnv<'arena> {
         const UNIVERSE: Term<'_> = Term::Universe;
         const VAR0: Term<'_> = Term::RigidVar(LocalVar::last());
         const FORMAT_TYPE: Term<'_> = Term::Prim(Prim::FormatType);
+        const FORMAT_FUN: Term<'_> = Term::FunType(None, &FORMAT_TYPE, &FORMAT_TYPE);
 
         let mut env = RigidEnv::new();
 
@@ -69,9 +70,15 @@ impl<'arena> RigidEnv<'arena> {
         };
         let format_array = |index_type: Prim| {
             let index_type = Arc::new(Value::prim(index_type, []));
-            let output_type = close(&Term::FunType(None, &FORMAT_TYPE, &FORMAT_TYPE));
 
-            Arc::new(Value::FunType(None, index_type, output_type))
+            Arc::new(Value::FunType(None, index_type, close(&FORMAT_FUN)))
+        };
+        let format_link = |offset_type: Prim| {
+            let pos_type = Arc::new(Value::prim(Prim::PosType, []));
+            let offset_type = scope.to_scope(Term::Prim(offset_type));
+            let output_type = close(scope.to_scope(Term::FunType(None, offset_type, &FORMAT_FUN)));
+
+            Arc::new(Value::FunType(None, pos_type, output_type))
         };
 
         let mut define_prim = |prim: Prim, r#type| {
@@ -95,6 +102,10 @@ impl<'arena> RigidEnv<'arena> {
         define_prim(Prim::Array32Type, array_type(Prim::U32Type));
         define_prim(Prim::Array64Type, array_type(Prim::U64Type));
         define_prim(Prim::PosType, universe());
+        define_prim(
+            Prim::RefType,
+            Arc::new(Value::FunType(None, universe(), close(&UNIVERSE))),
+        );
 
         define_prim(Prim::FormatType, universe());
         define_prim(
@@ -128,6 +139,10 @@ impl<'arena> RigidEnv<'arena> {
         define_prim(Prim::FormatArray16, format_array(Prim::U16Type));
         define_prim(Prim::FormatArray32, format_array(Prim::U32Type));
         define_prim(Prim::FormatArray64, format_array(Prim::U64Type));
+        define_prim(Prim::FormatLink8, format_link(Prim::U8Type));
+        define_prim(Prim::FormatLink16, format_link(Prim::U16Type));
+        define_prim(Prim::FormatLink32, format_link(Prim::U32Type));
+        define_prim(Prim::FormatLink64, format_link(Prim::U64Type));
         define_prim(Prim::FormatStreamPos, format_type());
         define_prim(
             Prim::FormatRepr,

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1277,7 +1277,6 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         scrutinee_expr: &'arena core::Term<'arena>,
         scrutinee_type: &ArcValue<'arena>,
         mut equations: &[(Pattern<'_, ByteRange>, Term<'_, ByteRange>)],
-        /* default expression: &Fn() -> Term<'arena> */
         expected_type: &ArcValue<'arena>,
     ) -> core::Term<'arena> {
         match equations.split_first() {
@@ -1357,6 +1356,9 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                                 CheckedPattern::Name(_, _)
                                 | CheckedPattern::Placeholder(_)
                                 | CheckedPattern::ReportedError(_) => {
+                                    // Push the default parameter of the constant elimination
+                                    self.push_rigid_param(def_pattern, scrutinee_type.clone());
+
                                     // Check the default expression and any other
                                     // unreachable equaltions following that.
                                     let default_expr = self.check_match(
@@ -1368,6 +1370,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                                         equations,
                                         expected_type,
                                     );
+
+                                    self.rigid_env.pop();
 
                                     return core::Term::ConstElim(
                                         scrutinee_expr,

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -281,10 +281,10 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 start_delim.clone(),
                 self.concat(
                     docs.clone()
-                        .map(|doc| self.concat([self.line(), doc, separator.clone()])),
+                        .map(|doc| self.concat([self.hardline(), doc, separator.clone()])),
                 )
                 .nest(INDENT),
-                self.line(),
+                self.hardline(),
                 end_delim.clone(),
             ]),
             self.concat([

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -272,29 +272,33 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
     fn sequence(
         &'arena self,
         start_delim: DocBuilder<'arena, Self>,
-        docs: impl Iterator<Item = DocBuilder<'arena, Self>> + Clone,
+        docs: impl ExactSizeIterator<Item = DocBuilder<'arena, Self>> + Clone,
         separator: DocBuilder<'arena, Self>,
         end_delim: DocBuilder<'arena, Self>,
     ) -> DocBuilder<'arena, Self> {
-        DocBuilder::flat_alt(
-            self.concat([
-                start_delim.clone(),
-                self.concat(
-                    docs.clone()
-                        .map(|doc| self.concat([self.hardline(), doc, separator.clone()])),
-                )
-                .nest(INDENT),
-                self.hardline(),
-                end_delim.clone(),
-            ]),
-            self.concat([
-                start_delim,
-                self.space(),
-                self.intersperse(docs, self.concat([separator, self.space()])),
-                self.space(),
-                end_delim,
-            ]),
-        )
+        if docs.len() == 0 {
+            self.concat([start_delim, end_delim])
+        } else {
+            DocBuilder::flat_alt(
+                self.concat([
+                    start_delim.clone(),
+                    self.concat(
+                        docs.clone()
+                            .map(|doc| self.concat([self.hardline(), doc, separator.clone()])),
+                    )
+                    .nest(INDENT),
+                    self.hardline(),
+                    end_delim.clone(),
+                ]),
+                self.concat([
+                    start_delim,
+                    self.space(),
+                    self.intersperse(docs, self.concat([separator, self.space()])),
+                    self.space(),
+                    end_delim,
+                ]),
+            )
+        }
     }
 }
 

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -77,6 +77,13 @@ let tag : Format =
     // array8 4 u8;
     u32be;
 
+/// # Unknown table format
+///
+/// This is a placeholder for a table that has an unknown identifier (due to the
+/// file conforming to a newer version of the specification), or for a table has
+/// not yet been implemented.
+let unknown_table : Format = {};
+
 /// A format that consumes no input.
 let empty : Format = {};
 
@@ -236,15 +243,15 @@ let character_map_subtable = fun (platform : Repr platform_id) => {
     // TODO: format-specific subtable data
     data <- match format {
         0 => byte_encoding_table platform,
-        2 => fail, // TODO: Format 2: High-byte mapping through table
-        4 => fail, // TODO: Format 4: Segment mapping to delta values
-        6 => fail, // TODO: Format 6: Trimmed table mapping
-        8 => fail, // TODO: Format 8: mixed 16-bit and 32-bit coverage
-        10 => fail, // TODO: Format 10: Trimmed array
-        12 => fail, // TODO: Format 12: Segmented coverage
-        13 => fail, // TODO: Format 13: Many-to-one range mappings
-        14 => fail, // TODO: Format 14: Unicode Variation Sequences
-        _ => fail,
+        2 => unknown_table, // TODO: Format 2: High-byte mapping through table
+        4 => unknown_table, // TODO: Format 4: Segment mapping to delta values
+        6 => unknown_table, // TODO: Format 6: Trimmed table mapping
+        8 => unknown_table, // TODO: Format 8: mixed 16-bit and 32-bit coverage
+        10 => unknown_table, // TODO: Format 10: Trimmed array
+        12 => unknown_table, // TODO: Format 12: Segmented coverage
+        13 => unknown_table, // TODO: Format 13: Many-to-one range mappings
+        14 => unknown_table, // TODO: Format 14: Unicode Variation Sequences
+        _ => unknown_table,
     },
 };
 
@@ -673,7 +680,7 @@ let naming = {
 //
 // - [Microsoft's OpenType Spec: BASE — Baseline Table](https://docs.microsoft.com/en-us/typography/opentype/spec/base)
 
-let baseline_data = fail;
+let baseline_data = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -682,7 +689,7 @@ let baseline_data = fail;
 //
 // - [Microsoft's OpenType Spec: GDEF — Glyph Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef)
 
-let glyph_definition_data = fail;
+let glyph_definition_data = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -691,7 +698,7 @@ let glyph_definition_data = fail;
 //
 // - [Microsoft's OpenType Spec: GPOS — Glyph Positioning Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos)
 
-let glyph_positioning_data = fail;
+let glyph_positioning_data = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -700,7 +707,7 @@ let glyph_positioning_data = fail;
 //
 // - [Microsoft's OpenType Spec: GSUB — Glyph Substitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub)
 
-let glyph_substitution_data = fail;
+let glyph_substitution_data = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -709,7 +716,7 @@ let glyph_substitution_data = fail;
 //
 // - [Microsoft's OpenType Spec: JSTF — Justification Table](https://docs.microsoft.com/en-us/typography/opentype/spec/jstf)
 
-let justification_data = fail;
+let justification_data = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -718,7 +725,7 @@ let justification_data = fail;
 //
 // - [Microsoft's OpenType Spec: MATH - The Mathematical Typesetting Table](https://docs.microsoft.com/en-us/typography/opentype/spec/math)
 
-let math_layout_data = fail;
+let math_layout_data = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -736,6 +743,7 @@ let math_layout_data = fail;
 //
 // - [Microsoft's OpenType Spec: Organization of an OpenType Font](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#organization-of-an-opentype-font)
 // - [Apple's TrueType Reference Manual: TrueType Font files](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html#Overview)
+
 
 /// # Font Table
 ///
@@ -757,40 +765,40 @@ let font_table = fun (table_id : Repr tag) => fun (length : U32) => match table_
     "hmtx" => horizontal_metrics 0 0,
     "maxp" => maximum_profile,
     "name" => naming,
-    "OS/2" => fail,
-    "post" => fail,
+    "OS/2" => unknown_table,
+    "post" => unknown_table,
 
     // TrueType Outline Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#tables-related-to-truetype-outlines
-    "cvt " => fail,
-    "fpgm" => fail,
-    "glyf" => fail,
-    "loca" => fail,
-    "prep" => fail,
-    "gasp" => fail,
+    "cvt " => unknown_table,
+    "fpgm" => unknown_table,
+    "glyf" => unknown_table,
+    "loca" => unknown_table,
+    "prep" => unknown_table,
+    "gasp" => unknown_table,
 
     // CFF Outline Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#tables-related-to-cff-outlines
-    "CFF " => fail,
-    "CFF2" => fail,
-    "VORG" => fail,
+    "CFF " => unknown_table,
+    "CFF2" => unknown_table,
+    "VORG" => unknown_table,
 
     // SVG Outline Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-related-to-svg-outlines
-    "SVG " => fail,
+    "SVG " => unknown_table,
 
     // Bitmap Glyph Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#tables-related-to-bitmap-glyphs
-    "EBDT" => fail,
-    "EBLC" => fail,
-    "EBSC" => fail,
-    "CBDT" => fail,
-    "CBLC" => fail,
-    "sbix" => fail,
+    "EBDT" => unknown_table,
+    "EBLC" => unknown_table,
+    "EBSC" => unknown_table,
+    "CBDT" => unknown_table,
+    "CBLC" => unknown_table,
+    "sbix" => unknown_table,
 
     // Advanced Typographic Tables
     //
@@ -805,42 +813,42 @@ let font_table = fun (table_id : Repr tag) => fun (length : U32) => match table_
     // OpenType Font Variation Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#tables-used-for-opentype-font-variations
-    "avar" => fail,
-    "cvar" => fail,
-    "fvar" => fail,
-    "gvar" => fail,
-    "HVAR" => fail,
-    "MVAR" => fail,
-    "STAT" => fail,
-    "VVAR" => fail,
+    "avar" => unknown_table,
+    "cvar" => unknown_table,
+    "fvar" => unknown_table,
+    "gvar" => unknown_table,
+    "HVAR" => unknown_table,
+    "MVAR" => unknown_table,
+    "STAT" => unknown_table,
+    "VVAR" => unknown_table,
 
     // Color Font Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#tables-related-to-color-fonts
-    "COLR" => fail,
-    "CPAL" => fail,
-    "CBDT" => fail,
-    "CBLC" => fail,
-    "sbix" => fail,
-    "SVG " => fail,
+    "COLR" => unknown_table,
+    "CPAL" => unknown_table,
+    "CBDT" => unknown_table,
+    "CBLC" => unknown_table,
+    "sbix" => unknown_table,
+    "SVG " => unknown_table,
 
     // Other OpenType Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#other-opentype-tables
-    "DSIG" => fail,
-    "hdmx" => fail,
-    "kern" => fail,
-    "LTSH" => fail,
-    "MERG" => fail,
-    "meta" => fail,
-    "STAT" => fail,
-    "PCLT" => fail,
-    "VDMX" => fail,
-    "vhea" => fail,
-    "vmtx" => fail,
+    "DSIG" => unknown_table,
+    "hdmx" => unknown_table,
+    "kern" => unknown_table,
+    "LTSH" => unknown_table,
+    "MERG" => unknown_table,
+    "meta" => unknown_table,
+    "STAT" => unknown_table,
+    "PCLT" => unknown_table,
+    "VDMX" => unknown_table,
+    "vhea" => unknown_table,
+    "vmtx" => unknown_table,
 
     // TODO: Error message
-    _ => fail,
+    _ => unknown_table,
 };
 
 /// # Table Record

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -94,10 +94,10 @@ let empty : Format = {};
 /// - [Microsoft's OpenType Spec: Offset16](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_Offset16)
 let offset16 = fun (base : Pos) => fun (format : Format) => {
     offset <- u16be,
-    // link <- match offset {
-    //     0 => empty,
-    //     _ => link base offset format, // TODO: Use an option type?
-    // },
+    link <- match offset {
+        0 => empty,
+        _ => link16 base offset format, // TODO: Use an option type?
+    },
 };
 
 /// 32-bit offset to a `format`, relative to some `base` position.
@@ -107,10 +107,10 @@ let offset16 = fun (base : Pos) => fun (format : Format) => {
 /// - [Microsoft's OpenType Spec: Offset32](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_Offset32)
 let offset32 = fun (base : Pos) => fun (format : Format) => {
     offset <- u32be,
-    // link <- match offset {
-    //     0 => empty,
-    //     _ => link base offset format, // TODO: Use an option type?
-    // },
+    link <- match offset {
+        0 => empty,
+        _ => link32 base offset format, // TODO: Use an option type?
+    },
 };
 
 /// Packed 32-bit value with major and minor version numbers.
@@ -753,7 +753,7 @@ let math_layout_data = unknown_table;
 ///
 /// - [Microsoft's OpenType Spec: Font Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#font-tables)
 /// - [Apple's TrueType Reference Manual: TrueType Font files](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html#Overview)
-let font_table = fun (table_id : Repr tag) => fun (length : U32) => match table_id {
+let font_table = fun (table_id : Repr tag) => match table_id {
     // Required Tables
     //
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#required-tables
@@ -872,9 +872,8 @@ let table_record = fun (file_start : Pos) => {
     offset <- u32be,
     /// Length of this table.
     length <- u32be,
-    // TODO: links
-    // /// The computed position of this table.
-    // link <- link file_start offset (font_table table_id length)
+    /// The computed position of this table.
+    link <- link32 file_start offset (font_table table_id)
 };
 
 /// # Table Directory

--- a/tests/succeed/format-repr/primitives.fathom
+++ b/tests/succeed/format-repr/primitives.fathom
@@ -19,14 +19,15 @@ let test_f32le_repr : Repr f32le -> F32 = fun x => x;
 let test_f64be_repr : Repr f64be -> F64 = fun x => x;
 let test_f64le_repr : Repr f64le -> F64 = fun x => x;
 
-let test_array8 : fun (n : U8) -> fun (f : Format) -> Repr (array8 n f) -> Array8 n (Repr f) =
-    fun n => fun f => fun array => array;
-let test_array16 : fun (n : U16) -> fun (f : Format) -> Repr (array16 n f) -> Array16 n (Repr f) =
-    fun n => fun f => fun array => array;
-let test_array32 : fun (n : U32) -> fun (f : Format) -> Repr (array32 n f) -> Array32 n (Repr f) =
-    fun n => fun f => fun array => array;
-let test_array64 : fun (n : U64) -> fun (f : Format) -> Repr (array64 n f) -> Array64 n (Repr f) =
-    fun len => fun f => fun array => array;
+let test_array8 : fun n -> fun f -> Repr (array8 n f) -> Array8 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array16 : fun n -> fun f -> Repr (array16 n f) -> Array16 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array32 : fun n -> fun f -> Repr (array32 n f) -> Array32 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array64 : fun n -> fun f -> Repr (array64 n f) -> Array64 n (Repr f) = fun _ => fun _ => fun x => x;
+
+let test_link8 : fun pos -> fun offset -> fun f -> Repr (link8 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
+let test_link16 : fun pos -> fun offset -> fun f -> Repr (link16 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
+let test_link32 : fun pos -> fun offset -> fun f -> Repr (link32 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
+let test_link64 : fun pos -> fun offset -> fun f -> Repr (link64 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
 
 let test_stream_pos : Repr stream_pos -> Pos = fun x => x;
 

--- a/tests/succeed/primitives.fathom
+++ b/tests/succeed/primitives.fathom
@@ -15,6 +15,7 @@ let test_Array16 : U16 -> Type -> Type = Array16;
 let test_Array32 : U32 -> Type -> Type = Array32;
 let test_Array64 : U64 -> Type -> Type = Array64;
 let test_Pos : Type = Pos;
+let test_Ref : Type -> Type = Ref;
 
 let test_U8_literal : U8 = 1;
 let test_U16_literal : U16 = 1;
@@ -52,6 +53,10 @@ let test_array8 : U8 -> Format -> Format = array8;
 let test_array16 : U16 -> Format -> Format = array16;
 let test_array32 : U32 -> Format -> Format = array32;
 let test_array64 : U64 -> Format -> Format = array64;
+let test_link8 : Pos -> U8 -> Format -> Format = link8;
+let test_link16 : Pos -> U16 -> Format -> Format = link16;
+let test_link32 : Pos -> U32 -> Format -> Format = link32;
+let test_link64 : Pos -> U64 -> Format -> Format = link64;
 let test_stream_pos : Format = stream_pos;
 let test_repr : Format -> Type = Repr;
 


### PR DESCRIPTION
The link formats could be simplified to a single `link` format if we allowed for limited arithmetic on positions. For now I just have a bunch of link formats that take a position and an offset:

- `Ref : Type -> Type`
- `link8 : Pos -> U8 -> Format -> Format`
- `link16 : Pos -> U16 -> Format -> Format`
- `link32 : Pos -> U32 -> Format -> Format`
- `link64 : Pos -> U64 -> Format -> Format`

Todo:

- [x] integration tests
- [x] check the open type format works with the new links
- [x] write reference documentation