### PR TITLE
Simplify link formats with position addition operations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-    "recommendations": [
-        "cab404.vscode-direnv",
-        "jnoortheen.nix-ide",
-        "matklad.rust-analyzer",
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "nixEnvSelector.nixFile": "${workspaceRoot}/shell.nix",
-    "[nix]": {
-        "editor.formatOnSave": true,
-    },
-}

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -45,6 +45,8 @@ elaboration, and core language is forthcoming.
   - [Array types](#array-types)
   - [Array literals](#array-literals)
 - [Positions](#positions)
+  - [Position types](#position-types)
+  - [Position operations](#position-operations)
 - [References](#references)
 - [Void](#void)
 
@@ -349,27 +351,19 @@ of the host array types.
 ### Link formats
 
 Link formats allow for references to other parts of a binary stream to be
-registered during parsing. They take a base [position](#positions), an offset
-from that position, and a format to expect at that position.
+registered during parsing. They take a base [position](#positions) and a format
+to expect at that position:
 
-There is a different link type for each unsigned integer offset:
-
-- `link8 : Pos -> U8 -> Format -> Format`
-- `link16 : Pos -> U16 -> Format -> Format`
-- `link32 : Pos -> U32 -> Format -> Format`
-- `link64 : Pos -> U64 -> Format -> Format`
+- `link : Pos -> Format -> Format`
 
 #### Representation of link formats
 
 Links formats are [represented](#format-representations) as typed
 [references](#references) to other parts of the binary stream.
 
-| format                       | `Repr` format               |
-| ---------------------------- | --------------------------- |
-| `link8 pos offset format`    | `Ref (Repr format)`         |
-| `link16 pos offset format`   | `Ref (Repr format)`         |
-| `link32 pos offset format`   | `Ref (Repr format)`         |
-| `link64 pos offset format`   | `Ref (Repr format)`         |
+| format               | `Repr` format               |
+| -------------------- | --------------------------- |
+| `link pos format`    | `Ref (Repr format)`         |
 
 ### Stream position formats
 
@@ -670,12 +664,26 @@ brackets. For example:
 
 ## Positions
 
-Stream positions are represented as an abstract datatype:
+Position types represent locations in the binary stream, relative to the
+beginning of the binary stream.
+
+### Position types
+
+Stream positions are formed with the primitive:
 
 - `Pos : Type`
 
 Positions are usually encountered as a result of parsing a [stream position
 format](#stream-position-formats).
+
+### Position operations
+
+A number of operations are defined for positions:
+
+- `pos_add_u8 : Pos -> U8 -> Pos`
+- `pos_add_u16 : Pos -> U16 -> Pos`
+- `pos_add_u32 : Pos -> U32 -> Pos`
+- `pos_add_u64 : Pos -> U64 -> Pos`
 
 ## References
 

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -265,17 +265,8 @@ def_prims! {
     /// A format which returns the current position in the input stream.
     FormatStreamPos => "stream_pos",
     /// A format that links to another location in the binary data stream,
-    /// relative to a base position and a unsigned 8-bit offset.
-    FormatLink8 => "link8",
-    /// A format that links to another location in the binary data stream,
-    /// relative to a base position and a unsigned 16-bit offset.
-    FormatLink16 => "link16",
-    /// A format that links to another location in the binary data stream,
-    /// relative to a base position and a unsigned 32-bit offset.
-    FormatLink32 => "link32",
-    /// A format that links to another location in the binary data stream,
-    /// relative to a base position and a unsigned 64-bit offset.
-    FormatLink64 => "link64",
+    /// relative to a base position.
+    FormatLink => "link",
     /// Format representations.
     FormatRepr => "Repr",
 
@@ -349,6 +340,11 @@ def_prims! {
     S64Sub => "s64_sub",
     S64Mul => "s64_mul",
     S64Div => "s64_div",
+
+    PosAddU8 => "pos_add_u8",
+    PosAddU16 => "pos_add_u16",
+    PosAddU32 => "pos_add_u32",
+    PosAddU64 => "pos_add_u64",
 }
 
 /// Constants

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -30,11 +30,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
         }
     }
 
-    fn elim_context(&self) -> semantics::ElimContext<'arena, '_> {
+    fn elim_context(&self) -> semantics::ElimContext<'arena, 'env> {
         semantics::ElimContext::new(self.flexible_exprs)
     }
 
-    fn conversion_context(&self) -> semantics::ConversionContext<'arena, '_> {
+    fn conversion_context(&self) -> semantics::ConversionContext<'arena, 'env> {
         semantics::ConversionContext::new(EnvLen::new(), self.flexible_exprs)
     }
 

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -428,6 +428,11 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
         Prim::S64Mul => const_step!([x: S64, y: S64] => Const::S64(i64::checked_mul(*x, *y)?)),
         Prim::S64Div => const_step!([x: S64, y: S64] => Const::S64(i64::checked_div(*x, *y)?)),
 
+        Prim::PosAddU8 => const_step!([x: Pos, y: U8] => Const::Pos(u64::checked_add(*x, u64::from(*y))?)),
+        Prim::PosAddU16 => const_step!([x: Pos, y: U16] => Const::Pos(u64::checked_add(*x, u64::from(*y))?)),
+        Prim::PosAddU32 => const_step!([x: Pos, y: U32] => Const::Pos(u64::checked_add(*x, u64::from(*y))?)),
+        Prim::PosAddU64 => const_step!([x: Pos, y: U64] => Const::Pos(u64::checked_add(*x, *y)?)),
+
         _ => None,
     }
 }
@@ -650,16 +655,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
                     (Prim::FormatArray64, [Elim::Fun(len), Elim::Fun(elem)]) => Arc::new(
                         Value::prim(Prim::Array64Type, [len.clone(), self.apply_repr(elem)]),
                     ),
-                    (Prim::FormatLink8, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
-                        Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
-                    }
-                    (Prim::FormatLink16, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
-                        Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
-                    }
-                    (Prim::FormatLink32, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
-                        Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
-                    }
-                    (Prim::FormatLink64, [Elim::Fun(_), Elim::Fun(_), Elim::Fun(elem)]) => {
+                    (Prim::FormatLink, [Elim::Fun(_), Elim::Fun(elem)]) => {
                         Arc::new(Value::prim(Prim::RefType, [self.apply_repr(elem)]))
                     }
                     (Prim::FormatStreamPos, []) => Arc::new(Value::prim(Prim::PosType, [])),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -74,13 +74,6 @@ impl<'arena> RigidEnv<'arena> {
 
             Arc::new(Value::FunType(None, index_type, close(&FORMAT_FUN)))
         };
-        let format_link = |offset_type: Prim| {
-            let pos_type = Arc::new(Value::prim(PosType, []));
-            let offset_type = scope.to_scope(Term::Prim(offset_type));
-            let output_type = close(scope.to_scope(Term::FunType(None, offset_type, &FORMAT_FUN)));
-
-            Arc::new(Value::FunType(None, pos_type, output_type))
-        };
 
         let unary_op = |input: Prim, output: Prim| {
             Arc::new(Value::FunType(
@@ -159,10 +152,7 @@ impl<'arena> RigidEnv<'arena> {
         define_prim(FormatArray16, format_array(U16Type));
         define_prim(FormatArray32, format_array(U32Type));
         define_prim(FormatArray64, format_array(U64Type));
-        define_prim(FormatLink8, format_link(U8Type));
-        define_prim(FormatLink16, format_link(U16Type));
-        define_prim(FormatLink32, format_link(U32Type));
-        define_prim(FormatLink64, format_link(U64Type));
+        define_prim(FormatLink, binary_op(PosType, FormatType, FormatType));
         define_prim(FormatStreamPos, format_type());
         define_prim(
             FormatRepr,
@@ -236,6 +226,11 @@ impl<'arena> RigidEnv<'arena> {
         define_prim(S64Sub, binary_op(S64Type, S64Type, S64Type));
         define_prim(S64Mul, binary_op(S64Type, S64Type, S64Type));
         define_prim(S64Div, binary_op(S64Type, S64Type, S64Type));
+
+        define_prim(PosAddU8, binary_op(PosType, U8Type, PosType));
+        define_prim(PosAddU16, binary_op(PosType, U16Type, PosType));
+        define_prim(PosAddU32, binary_op(PosType, U32Type, PosType));
+        define_prim(PosAddU64, binary_op(PosType, U64Type, PosType));
 
         env
     }

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -103,7 +103,7 @@ let offset16 = fun (base : Pos) => fun (format : Format) => {
     offset <- u16be,
     link <- match offset {
         0 => empty,
-        _ => link16 base offset format, // TODO: Use an option type?
+        _ => link (pos_add_u16 base offset) format, // TODO: Use an option type?
     },
 };
 
@@ -116,7 +116,7 @@ let offset32 = fun (base : Pos) => fun (format : Format) => {
     offset <- u32be,
     link <- match offset {
         0 => empty,
-        _ => link32 base offset format, // TODO: Use an option type?
+        _ => link (pos_add_u32 base offset) format, // TODO: Use an option type?
     },
 };
 
@@ -1197,7 +1197,7 @@ let table_record = fun (file_start : Pos) => {
     /// Length of this table.
     length <- u32be,
     /// The computed position of this table.
-    link <- link32 file_start offset (font_table table_id)
+    link <- link (pos_add_u32 file_start offset) (font_table table_id)
 };
 
 /// # Table Directory

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -14,14 +14,14 @@ let offset16 : _ = fun base => fun format => {
     offset <- u16be,
     link <- match offset {
         0 => empty,
-        _ => link16 base offset format,
+        _ => link (pos_add_u16 base offset) format,
     },
 };
 let offset32 : _ = fun base => fun format => {
     offset <- u32be,
     link <- match offset {
         0 => empty,
-        _ => link32 base offset format,
+        _ => link (pos_add_u32 base offset) format,
     },
 };
 let version16dot16 : _ = u32be;
@@ -289,7 +289,7 @@ let table_record : _ = fun file_start => {
     checksum <- u32be,
     offset <- u32be,
     length <- u32be,
-    link <- link32 file_start offset (font_table table_id),
+    link <- link (pos_add_u32 file_start offset) (font_table table_id),
 };
 let table_directory : _ = fun file_start => {
     sfnt_version <- u32be,

--- a/tests/succeed/format-repr/primitives.fathom
+++ b/tests/succeed/format-repr/primitives.fathom
@@ -24,11 +24,7 @@ let test_array16 : fun n -> fun f -> Repr (array16 n f) -> Array16 n (Repr f) = 
 let test_array32 : fun n -> fun f -> Repr (array32 n f) -> Array32 n (Repr f) = fun _ => fun _ => fun x => x;
 let test_array64 : fun n -> fun f -> Repr (array64 n f) -> Array64 n (Repr f) = fun _ => fun _ => fun x => x;
 
-let test_link8 : fun pos -> fun offset -> fun f -> Repr (link8 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
-let test_link16 : fun pos -> fun offset -> fun f -> Repr (link16 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
-let test_link32 : fun pos -> fun offset -> fun f -> Repr (link32 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
-let test_link64 : fun pos -> fun offset -> fun f -> Repr (link64 pos offset f) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
-
+let test_link : fun pos -> fun f -> Repr (link pos f) -> Ref (Repr f) = fun _ => fun _ => fun x => x;
 let test_stream_pos : Repr stream_pos -> Pos = fun x => x;
 
 Type

--- a/tests/succeed/format-repr/primitives.snap
+++ b/tests/succeed/format-repr/primitives.snap
@@ -27,14 +27,8 @@ let test_array32 : fun (n : U32) -> fun (f : Format) -> fun (_ :
 Array32 n (Repr f)) -> Array32 n (Repr f) = fun _ => fun _ => fun x => x;
 let test_array64 : fun (n : U64) -> fun (f : Format) -> fun (_ :
 Array64 n (Repr f)) -> Array64 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_link8 : fun (pos : Pos) -> fun (offset : U8) -> fun (f : Format) ->
-fun (_ : Ref (Repr f)) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
-let test_link16 : fun (pos : Pos) -> fun (offset : U16) -> fun (f : Format) ->
-fun (_ : Ref (Repr f)) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
-let test_link32 : fun (pos : Pos) -> fun (offset : U32) -> fun (f : Format) ->
-fun (_ : Ref (Repr f)) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
-let test_link64 : fun (pos : Pos) -> fun (offset : U64) -> fun (f : Format) ->
-fun (_ : Ref (Repr f)) -> Ref (Repr f) = fun _ => fun _ => fun _ => fun x => x;
+let test_link : fun (pos : Pos) -> fun (f : Format) -> fun (_ : Ref (Repr f)) ->
+Ref (Repr f) = fun _ => fun _ => fun x => x;
 let test_stream_pos : fun (_ : Pos) -> Pos = fun x => x;
 Type : Type
 '''

--- a/tests/succeed/primitives.fathom
+++ b/tests/succeed/primitives.fathom
@@ -53,10 +53,7 @@ let _ = array8 : U8 -> Format -> Format;
 let _ = array16 : U16 -> Format -> Format;
 let _ = array32 : U32 -> Format -> Format;
 let _ = array64 : U64 -> Format -> Format;
-let _ = link8 : Pos -> U8 -> Format -> Format;
-let _ = link16 : Pos -> U16 -> Format -> Format;
-let _ = link32 : Pos -> U32 -> Format -> Format;
-let _ = link64 : Pos -> U64 -> Format -> Format;
+let _ = link : Pos -> Format -> Format;
 let _ = stream_pos : Format;
 let _ = Repr : Format -> Type;
 
@@ -127,5 +124,10 @@ let _ = s64_add : S64 -> S64 -> S64;
 let _ = s64_sub : S64 -> S64 -> S64;
 let _ = s64_mul : S64 -> S64 -> S64;
 let _ = s64_div : S64 -> S64 -> S64;
+
+let _ = pos_add_u8 : Pos -> U8 -> Pos;
+let _ = pos_add_u16 : Pos -> U16 -> Pos;
+let _ = pos_add_u32 : Pos -> U32 -> Pos;
+let _ = pos_add_u64 : Pos -> U64 -> Pos;
 
 Type

--- a/tests/succeed/primitives.snap
+++ b/tests/succeed/primitives.snap
@@ -51,10 +51,7 @@ let _ : _ = array8;
 let _ : _ = array16;
 let _ : _ = array32;
 let _ : _ = array64;
-let _ : _ = link8;
-let _ : _ = link16;
-let _ : _ = link32;
-let _ : _ = link64;
+let _ : _ = link;
 let _ : _ = stream_pos;
 let _ : _ = Repr;
 let _ : _ = u8_add;
@@ -117,6 +114,10 @@ let _ : _ = s64_add;
 let _ : _ = s64_sub;
 let _ : _ = s64_mul;
 let _ : _ = s64_div;
+let _ : _ = pos_add_u8;
+let _ : _ = pos_add_u16;
+let _ : _ = pos_add_u32;
+let _ : _ = pos_add_u64;
 Type : Type
 '''
 stderr = ''


### PR DESCRIPTION
This implements a number of primitives for adding unsigned numbers to positions:

- `pos_add_u8 : Pos -> U8 -> Pos`
- `pos_add_u16 : Pos -> U16 -> Pos`
- `pos_add_u32 : Pos -> U32 -> Pos`
- `pos_add_u64 : Pos -> U64 -> Pos`

This means that we can simplify link formats down to a single primitive:

- `link : Pos -> Format -> Format`

At the moment these operations will get 'stuck' during evaluation if they overflow, which will ultimately lead to a parse error. We might need to consider a different approach in the future but I think this is fine for now.