### PR TITLE
Allow different formats at the same ref position

### DIFF
--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -269,7 +269,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
     /// Pretty prints a delimited sequence of documents with a trailing
     /// separator if it is formatted over multiple lines.
-    fn sequence(
+    pub fn sequence(
         &'arena self,
         start_delim: DocBuilder<'arena, Self>,
         docs: impl ExactSizeIterator<Item = DocBuilder<'arena, Self>> + Clone,


### PR DESCRIPTION
This allows multiple linked formats to occupy the same position in the binary file.

Currently this just renders the different formats as a list corresponding to each position in the CLI. In the future I'd want to explore a different way of displaying these - perhaps something like `pos : Repr format = ...` or `pos : format = ...` (if we add format -> repr coercions) - but this would require glued evaluation of [top-level items](https://github.com/yeslogic/fathom/issues/318) to avoid swamping users with massive format descriptions.