### PR TITLE
Wire up error recovery in the parser.

### DIFF
--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -9,9 +9,7 @@ use crate::source::{ByteRange, FileId};
 use crate::{StringId, StringInterner};
 
 lalrpop_mod!(grammar, "/surface/grammar.rs");
-// FIXME: This lexer module should be private! LALRPOP's exports are somewhat broken, however.
-//        See: https://github.com/lalrpop/lalrpop/pull/584#issuecomment-856731852
-pub(crate) mod lexer;
+mod lexer;
 pub mod pretty;
 
 pub mod distillation;

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -3,10 +3,14 @@ use std::cell::RefCell;
 
 use crate::{StringId, StringInterner};
 use crate::source::ByteRange;
-use crate::surface::{Pattern, Term};
+use crate::surface::{Term, ParseMessage, Pattern};
 use crate::surface::lexer::{Error as LexerError, Token};
 
-grammar<'arena, 'source>(interner: &RefCell<StringInterner>, scope: &'arena Scope<'arena>);
+grammar<'arena, 'source>(
+    interner: &RefCell<StringInterner>,
+    scope: &'arena Scope<'arena>,
+    messages: &mut Vec<ParseMessage>,
+);
 
 extern {
     type Location = usize;
@@ -154,6 +158,10 @@ AtomicTerm: Term<'arena, ByteRange> = {
     },
     <start: @L> "[" <exprs: Seq<Term, ",">> "]" <end: @R> => {
         Term::ArrayLiteral(ByteRange::new(start, end), exprs)
+    },
+    <start: @L> <error: !> <end: @R> => {
+        messages.push(ParseMessage::from(error));
+        Term::ReportedError(ByteRange::new(start, end))
     },
 };
 

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -71,6 +71,12 @@ pub enum Error {
 }
 
 impl Error {
+    pub fn range(&self) -> ByteRange {
+        match self {
+            Error::UnexpectedCharacter { range } => *range,
+        }
+    }
+
     pub fn to_diagnostic(&self, file_id: FileId) -> Diagnostic<FileId> {
         match self {
             Error::UnexpectedCharacter { range } => Diagnostic::error()

--- a/tests/fail/parse/error-recovery.fathom
+++ b/tests/fail/parse/error-recovery.fathom
@@ -1,0 +1,5 @@
+//~ exit-code = 1
+
+let x : Type = {;
+
+x : Type -> Type

--- a/tests/fail/parse/error-recovery.snap
+++ b/tests/fail/parse/error-recovery.snap
@@ -1,0 +1,17 @@
+stdout = ''
+stderr = '''
+error: unexpected token ;
+  ┌─ tests/fail/parse/error-recovery.fathom:3:17
+  │
+3 │ let x : Type = {;
+  │                 ^ unexpected token
+  │
+  = expected "name" or "}"
+
+error: type mismatch
+  ┌─ tests/fail/parse/error-recovery.fathom:5:1
+  │
+5 │ x : Type -> Type
+  │ ^
+
+'''


### PR DESCRIPTION
This allows for further parsing to take place after a syntax error is encountered. For more information check out the [LALRPOP book's chapter on error recovery](https://lalrpop.github.io/lalrpop/tutorial/008_error_recovery.html).