### PR TITLE
Implement top level items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,32 +143,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -299,7 +308,7 @@ name = "fathom"
 version = "0.1.0"
 dependencies = [
  "atty",
- "clap 3.0.10",
+ "clap 3.2.5",
  "codespan-reporting",
  "diff",
  "fxhash",
@@ -607,18 +616,15 @@ checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1001,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +194,42 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concolor"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -289,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +349,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -325,7 +382,20 @@ dependencies = [
  "string-interner",
  "termsize",
  "toml",
+ "trycmd",
  "walkdir",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -359,6 +429,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
@@ -415,6 +491,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
 ]
 
 [[package]]
@@ -599,6 +691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +717,16 @@ name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+
+[[package]]
+name = "os_pipe"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c92f2b54f081d635c77e7120862d48db8e91f7f21cef23ab1b4fe9971c59f55"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -807,6 +915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rpds"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +980,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+
+[[package]]
 name = "siphasher"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1002,32 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "snapbox"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767a1d5da232b6959cd1bd5c9e8db8a7cce09c3038e89deedb49a549a2aefd93"
+dependencies = [
+ "concolor",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "normalize-line-endings",
+ "os_pipe",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "wait-timeout",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01dea7e04cbb27ef4c86e9922184608185f7cd95c1763bc30d727cda4a5e930"
 
 [[package]]
 name = "static_assertions"
@@ -949,6 +1104,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1039,6 +1208,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "serde",
+]
+
+[[package]]
+name = "trycmd"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4185126cc904642173a54c185083f410c86d1202ada6761aacf7c40829f13"
+dependencies = [
+ "glob",
+ "humantime",
+ "humantime-serde",
+ "rayon",
+ "serde",
+ "shlex",
+ "snapbox",
+ "toml_edit",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1276,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -1139,3 +1345,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/README.md
+++ b/README.md
@@ -16,19 +16,17 @@ A language for specifying data-dependent binary formats.
 ## Example
 
 ```fathom
-let pixel = {
+def pixel = {
     red <- u8,
     green <- u8,
     blue <- u8,
 };
 
-let image = {
+def main = {
     width <- u16le,
     height <- u16le,
     pixels <- array16 (u16_mul width height) pixel,
 };
-
-image
 ```
 
 More examples can be found in the [formats](./formats) directory.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -86,13 +86,6 @@ def point : Format = {
 };
 ```
 
-Definitions with `_` in place of the name are still type checked, but cannot be
-used in other parts of the Fathom module:
-
-```fathom
-def _ = u32be;
-```
-
 ## Structure
 
 This section descibes basic structural parts of Fathom.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -8,6 +8,8 @@ elaboration, and core language is forthcoming.
 
 ## Contents
 
+- [Modules](#items)
+  - [Definitions](#definitions)
 - [Structure](#structure)
   - [Names](#names)
   - [Let expressions](#let-expressions)
@@ -59,6 +61,37 @@ elaboration, and core language is forthcoming.
   - [Position operations](#position-operations)
 - [References](#references)
 - [Void](#void)
+
+## Modules
+
+Fathom modules are made up of multiple top-level items
+
+### Definitions
+
+Top-level definitions are preceded by the `def` keyword:
+
+```fathom
+def point = {
+  x <- u32be,
+  y <- u32be,
+};
+```
+
+Definitions can optionally have a type annotation given to them:
+
+```fathom
+def point : Format = {
+  x <- u32be,
+  y <- u32be,
+};
+```
+
+Definitions with `_` in place of the name are still type checked, but cannot be
+used in other parts of the Fathom module:
+
+```fathom
+def _ = u32be;
+```
 
 ## Structure
 

--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -40,4 +40,5 @@ itertools = "0.10.1"
 libtest-mimic = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
+trycmd = "0.13.4"
 walkdir = "2.3.2"

--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -18,7 +18,7 @@ harness = false
 
 [dependencies]
 atty = "0.2.14"
-clap = { version = "3.0.10", features = ["derive"] }
+clap = { version = "3.2.5", features = ["derive"] }
 codespan-reporting = "0.11.1"
 fxhash = "0.2"
 itertools = "0.10"

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -6,6 +6,24 @@ use crate::StringId;
 pub mod binary;
 pub mod semantics;
 
+/// Modules
+pub struct Module<'arena> {
+    pub items: &'arena [Item<'arena>],
+}
+
+/// Top-level items
+pub enum Item<'arena> {
+    /// Top-level definitions
+    Definition {
+        /// The label that identifies this definition
+        label: StringId,
+        /// The type of the defined expression
+        r#type: &'arena Term<'arena>,
+        /// The defined expression
+        expr: &'arena Term<'arena>,
+    },
+}
+
 /// Information about how entries were bound in the rigid environment. This is
 /// used when inserting [flexible variables][Term::FlexibleInsertion] during
 /// elaboration.
@@ -22,6 +40,10 @@ pub enum EntryInfo {
 /// Core language terms.
 #[derive(Debug, Clone)]
 pub enum Term<'arena> {
+    /// Item variable occurrences.
+    ///
+    /// These refer to [items][Item] bound at the top-level of a [module][Module].
+    ItemVar(GlobalVar),
     /// Rigid variable occurrences.
     ///
     /// These correspond to variables that were most likely bound as a result of

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -162,7 +162,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
 
         let diagnostics = {
             let elab_messages = context.drain_messages();
-            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner, file_id)))
+            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner)))
         };
 
         if !(self.emit_diagnostics(diagnostics) || self.allow_errors) {
@@ -189,7 +189,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
 
         let diagnostics = {
             let elab_messages = context.drain_messages();
-            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner, file_id)))
+            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner)))
         };
 
         if !(self.emit_diagnostics(diagnostics) || self.allow_errors) {
@@ -215,7 +215,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
 
         let diagnostics = {
             let elab_messages = context.drain_messages();
-            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner, file_id)))
+            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner)))
         };
 
         if !(self.emit_diagnostics(diagnostics) || self.allow_errors) {
@@ -246,7 +246,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
 
         let diagnostics = {
             let elab_messages = context.drain_messages();
-            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner, file_id)))
+            parse_diagnostics.chain(elab_messages.map(|m| m.to_diagnostic(&self.interner)))
         };
 
         if !(self.emit_diagnostics(diagnostics) || self.allow_errors) {
@@ -308,8 +308,9 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         impl Iterator<Item = Diagnostic<FileId>>,
     ) {
         let source = self.files.get(file_id).unwrap().source();
-        let (term, messages) = surface::Term::parse(&self.interner, &self.surface_scope, source);
-        let diagnostics = messages.into_iter().map(move |m| m.to_diagnostic(file_id));
+        let (term, messages) =
+            surface::Term::parse(&self.interner, &self.surface_scope, file_id, source);
+        let diagnostics = messages.into_iter().map(move |m| m.to_diagnostic());
 
         (term, diagnostics)
     }

--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -255,6 +255,17 @@ impl<Entry> SliceEnv<Entry> {
     }
 }
 
+impl<Entry: PartialEq> SliceEnv<Entry> {
+    pub fn elem_global(&self, entry: &Entry) -> Option<GlobalVar> {
+        Iterator::zip(global_vars(), self.iter()).find_map(|(var, e)| (entry == e).then(|| var))
+    }
+
+    pub fn elem_local(&self, entry: &Entry) -> Option<LocalVar> {
+        Iterator::zip(local_vars(), self.iter().rev())
+            .find_map(|(var, e)| (entry == e).then(|| var))
+    }
+}
+
 /// A persistent environment with structural sharing.
 #[derive(Clone)]
 pub struct SharedEnv<Entry> {

--- a/fathom/src/main.rs
+++ b/fathom/src/main.rs
@@ -4,48 +4,94 @@ use std::path::PathBuf;
 /// A language for declaratively specifying binary data formats
 #[derive(Parser)]
 #[clap(author, version, about)]
-enum Options {
-    /// Elaborate a term, printing the elaborated term and type
+enum Cli {
+    /// Elaborate a Fathom module or term, printing the result to stdout
     Elab {
-        /// Path to a file containing the surface term
-        #[clap(long = "term", name = "FILE", default_value = "-")]
-        term_file: PathOrStdin,
+        /// Path to a module to elaborate
+        #[clap(
+            long = "module",
+            name = "MODULE_FILE",
+            group = "input",
+            required_unless_present = "input",
+            display_order = 0
+        )]
+        module_file: Option<PathOrStdin>,
+        /// Path to a term to elaborate
+        #[clap(
+            long = "term",
+            name = "TERM_FILE",
+            group = "input",
+            required_unless_present = "input",
+            display_order = 1
+        )]
+        term_file: Option<PathOrStdin>,
         /// Continue even if errors were encountered
         #[clap(long = "allow-errors")]
         allow_errors: bool,
     },
-    /// Elaborate a term, printing its normal form and type
+    /// Normalise a Fathom term, printing its normal form and type
     Norm {
-        /// Path to a file containing the surface term
-        #[clap(long = "term", name = "FILE", default_value = "-")]
+        /// Path to a term to normalise
+        #[clap(long = "term", name = "TERM_FILE", display_order = 0)]
         term_file: PathOrStdin,
         /// Continue even if errors were encountered
         #[clap(long = "allow-errors")]
         allow_errors: bool,
     },
-    /// Elaborate a term, printing its type
-    Type {
-        /// Path to a file containing the surface term
-        #[clap(long = "term", name = "FILE", default_value = "-")]
-        term_file: PathOrStdin,
-        /// Continue even if errors were encountered
-        #[clap(long = "allow-errors")]
-        allow_errors: bool,
-    },
-    /// Manipulate binary data
+    /// Manipulate binary data based on a Fathom format
+    #[clap(after_help = DATA_COMMAND_AFTER_HELP)]
+    #[clap(after_long_help = DATA_COMMAND_AFTER_LONG_HELP)]
     Data {
-        /// Path to a file containing the surface term
-        #[clap(long = "format", name = "FILE")]
-        format_file: PathOrStdin,
+        /// Path to a module to load when reading
+        #[clap(long = "module", name = "MODULE_FILE", display_order = 0)]
+        module_file: Option<PathOrStdin>,
+        /// Format used when reading the binary data
+        ///
+        /// The term provided by `FORMAT` must be of type `Format`.
+        ///
+        /// Required unless `--module` is present.
+        #[clap(
+            long = "format",
+            name = "FORMAT",
+            default_value = "main",
+            required_unless_present = "MODULE_FILE",
+            display_order = 1
+        )]
+        format: String,
+        /// Path to the binary data to read from
+        #[clap(name = "BINARY_FILE")]
+        binary_file: PathOrStdin,
         /// Continue even if errors were encountered
         #[clap(long = "allow-errors")]
         allow_errors: bool,
-        /// The binary file to read
-        #[clap(name = "BINARY")]
-        binary_path: PathBuf, // TODO: parse multiple binary files?
     },
 }
 
+const DATA_COMMAND_AFTER_HELP: &str = "\
+Examples:
+
+  $ fathom data --format '{ magic <- u32be where u32_eq magic \"icns\" }' AppIcon.icns
+  $ fathom data --module formats/opentype.fathom Monaco.ttf
+  $ fathom data --module formats/icns.fathom --format header AppIcon.icns
+";
+
+const DATA_COMMAND_AFTER_LONG_HELP: &str = "\
+Binary data can be read using a term supplied by the `--format` option:
+
+  $ fathom data --format '{ magic <- u32be where u32_eq magic \"icns\" }' AppIcon.icns
+
+Alternatively data can be read using a module:
+
+  $ fathom data --module formats/opentype.fathom Monaco.ttf
+  $ fathom data --module formats/stl-binary.fathom cube.stl
+
+When a module is specified the binary data is read assuming that it contains a
+`main` definition, but this can be overridden using the `--format` option:
+
+  $ fathom data --module formats/icns.fathom --format header AppIcon.icns
+";
+
+#[derive(Clone, Debug)]
 enum PathOrStdin {
     StdIn,
     Path(PathBuf),
@@ -62,11 +108,22 @@ impl std::str::FromStr for PathOrStdin {
     }
 }
 
-fn read_source(driver: &mut fathom::Driver, file: PathOrStdin) -> fathom::source::FileId {
-    match file {
-        PathOrStdin::StdIn => driver.read_source("<stdin>", std::io::stdin()),
-        PathOrStdin::Path(path) => driver.read_source_path(&path),
-    }
+fn unwrap_or_exit<T>(option: Option<T>) -> T {
+    option.unwrap_or_else(|| std::process::exit(fathom::Status::Error.exit_code()))
+}
+
+fn load_file_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> fathom::source::FileId {
+    unwrap_or_exit(match file {
+        PathOrStdin::StdIn => driver.load_source("<stdin>".to_owned(), std::io::stdin()),
+        PathOrStdin::Path(path) => driver.load_source_path(&path),
+    })
+}
+
+fn read_bytes_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> Vec<u8> {
+    unwrap_or_exit(match file {
+        PathOrStdin::StdIn => driver.read_bytes("<stdio>".to_owned(), std::io::stdin()),
+        PathOrStdin::Path(path) => driver.read_bytes_path(&path),
+    })
 }
 
 const MAX_PRETTY_WIDTH: usize = 80;
@@ -77,8 +134,9 @@ fn get_pretty_width() -> usize {
 }
 
 fn main() -> ! {
-    match Options::parse() {
-        Options::Elab {
+    match Cli::parse() {
+        Cli::Elab {
+            module_file,
             term_file,
             allow_errors,
         } => {
@@ -87,12 +145,23 @@ fn main() -> ! {
             driver.set_allow_errors(allow_errors);
             driver.set_emit_width(get_pretty_width());
 
-            let file_id = read_source(&mut driver, term_file);
-            let status = driver.elaborate(file_id);
+            let status = match (module_file, term_file) {
+                (Some(module_file), None) => {
+                    let file_id = load_file_or_exit(&mut driver, module_file);
+                    driver.elaborate_and_emit_module(file_id)
+                }
+                (None, Some(term_file)) => {
+                    let file_id = load_file_or_exit(&mut driver, term_file);
+                    driver.elaborate_and_emit_term(file_id)
+                }
+                (Some(_), Some(_)) | (None, None) => {
+                    unreachable!(r#"guarded by `required_unless_present = "input"`"#)
+                }
+            };
 
             std::process::exit(status.exit_code());
         }
-        Options::Norm {
+        Cli::Norm {
             term_file,
             allow_errors,
         } => {
@@ -101,13 +170,15 @@ fn main() -> ! {
             driver.set_allow_errors(allow_errors);
             driver.set_emit_width(get_pretty_width());
 
-            let file_id = read_source(&mut driver, term_file);
-            let status = driver.normalise(file_id);
+            let file_id = load_file_or_exit(&mut driver, term_file);
+            let status = driver.normalise_and_emit_term(file_id);
 
             std::process::exit(status.exit_code());
         }
-        Options::Type {
-            term_file,
+        Cli::Data {
+            module_file,
+            format,
+            binary_file,
             allow_errors,
         } => {
             let mut driver = fathom::Driver::new();
@@ -115,32 +186,11 @@ fn main() -> ! {
             driver.set_allow_errors(allow_errors);
             driver.set_emit_width(get_pretty_width());
 
-            let file_id = read_source(&mut driver, term_file);
-            let status = driver.r#type(file_id);
+            let module_file_id = module_file.map(|input| load_file_or_exit(&mut driver, input));
+            let format_file_id = driver.load_source_string("<FORMAT>".to_owned(), format);
 
-            std::process::exit(status.exit_code());
-        }
-        Options::Data {
-            format_file,
-            allow_errors,
-            binary_path,
-        } => {
-            use std::io::Read;
-
-            let mut driver = fathom::Driver::new();
-            driver.install_panic_hook();
-            driver.set_allow_errors(allow_errors);
-            driver.set_emit_width(get_pretty_width());
-
-            let file_id = read_source(&mut driver, format_file);
-
-            // TODO: report errors
-            let mut file = std::fs::File::open(binary_path).unwrap();
-            let mut data = Vec::new();
-            file.read_to_end(&mut data).unwrap();
-            let buffer = fathom::core::binary::Buffer::from(data.as_slice());
-
-            let status = driver.read_format(file_id, buffer);
+            let data = read_bytes_or_exit(&mut driver, binary_file);
+            let status = driver.read_and_emit_format(module_file_id, format_file_id, &data);
 
             std::process::exit(status.exit_code());
         }

--- a/fathom/src/main.rs
+++ b/fathom/src/main.rs
@@ -1,71 +1,47 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-/// CLI for the programming language prototype.
+/// A language for declaratively specifying binary data formats
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-#[clap(after_help = r#"EXAMPLES:
-
-Using arguments
-
-    fathom elab --term=examples/prelude.txt
-    fathom norm --term=examples/prelude.txt
-
-Using pipes and redirects
-
-    echo "fun (A : Type) -> A -> A" | fathom elab
-    cat examples/prelude.txt | fathom elab
-    fathom elab < examples/prelude.txt
-
-Using heredocs
-
-    fathom elab <<< "fun (A : Type) -> A -> A"
-
-    fathom norm <<EOF
-        let id : fun (A : Type) -> A -> A
-          = fun A => fun a => a;
-
-        id Type Type
-    EOF
-"#)]
+#[clap(author, version, about)]
 enum Options {
     /// Elaborate a term, printing the elaborated term and type
     Elab {
         /// Path to a file containing the surface term
-        #[clap(long = "term", name = "FILE", default_value = "-", parse(from_str))]
+        #[clap(long = "term", name = "FILE", default_value = "-")]
         term_file: PathOrStdin,
-        /// Continue even if errors were encountered.
+        /// Continue even if errors were encountered
         #[clap(long = "allow-errors")]
         allow_errors: bool,
     },
     /// Elaborate a term, printing its normal form and type
     Norm {
         /// Path to a file containing the surface term
-        #[clap(long = "term", name = "FILE", default_value = "-", parse(from_str))]
+        #[clap(long = "term", name = "FILE", default_value = "-")]
         term_file: PathOrStdin,
-        /// Continue even if errors were encountered.
+        /// Continue even if errors were encountered
         #[clap(long = "allow-errors")]
         allow_errors: bool,
     },
     /// Elaborate a term, printing its type
     Type {
         /// Path to a file containing the surface term
-        #[clap(long = "term", name = "FILE", default_value = "-", parse(from_str))]
+        #[clap(long = "term", name = "FILE", default_value = "-")]
         term_file: PathOrStdin,
-        /// Continue even if errors were encountered. v
+        /// Continue even if errors were encountered
         #[clap(long = "allow-errors")]
         allow_errors: bool,
     },
     /// Manipulate binary data
     Data {
         /// Path to a file containing the surface term
-        #[clap(long = "format", name = "FILE", parse(from_str))]
+        #[clap(long = "format", name = "FILE")]
         format_file: PathOrStdin,
         /// Continue even if errors were encountered
         #[clap(long = "allow-errors")]
         allow_errors: bool,
         /// The binary file to read
-        #[clap(name = "BINARY", parse(from_str))]
+        #[clap(name = "BINARY")]
         binary_path: PathBuf, // TODO: parse multiple binary files?
     },
 }
@@ -75,11 +51,13 @@ enum PathOrStdin {
     Path(PathBuf),
 }
 
-impl From<&str> for PathOrStdin {
-    fn from(src: &str) -> PathOrStdin {
+impl std::str::FromStr for PathOrStdin {
+    type Err = &'static str; // Unused, but satisfies `clap`. Could be `!` in the future.
+
+    fn from_str(src: &str) -> Result<PathOrStdin, &'static str> {
         match src {
-            "-" => PathOrStdin::StdIn,
-            _ => PathOrStdin::Path(PathBuf::from(src)),
+            "-" => Ok(PathOrStdin::StdIn),
+            _ => Ok(PathOrStdin::Path(PathBuf::from(src))),
         }
     }
 }

--- a/fathom/src/main.rs
+++ b/fathom/src/main.rs
@@ -98,9 +98,9 @@ enum PathOrStdin {
 }
 
 impl std::str::FromStr for PathOrStdin {
-    type Err = &'static str; // Unused, but satisfies `clap`. Could be `!` in the future.
+    type Err = std::convert::Infallible;
 
-    fn from_str(src: &str) -> Result<PathOrStdin, &'static str> {
+    fn from_str(src: &str) -> Result<PathOrStdin, std::convert::Infallible> {
         match src {
             "-" => Ok(PathOrStdin::StdIn),
             _ => Ok(PathOrStdin::Path(PathBuf::from(src))),

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -9,13 +9,22 @@ pub type BytePos = usize;
 /// Byte ranges in source files.
 #[derive(Debug, Copy, Clone)]
 pub struct ByteRange {
+    file_id: FileId,
     start: BytePos,
     end: BytePos,
 }
 
 impl ByteRange {
-    pub const fn new(start: BytePos, end: BytePos) -> ByteRange {
-        ByteRange { start, end }
+    pub const fn new(file_id: FileId, start: BytePos, end: BytePos) -> ByteRange {
+        ByteRange {
+            file_id,
+            start,
+            end,
+        }
+    }
+
+    pub fn file_id(&self) -> FileId {
+        self.file_id
     }
 
     pub const fn start(&self) -> BytePos {

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -50,7 +50,7 @@ pub enum Item<'arena, Range> {
     /// Top-level definitions
     Definition {
         /// The label that identifies this definition
-        label: (Range, Option<StringId>),
+        label: (Range, StringId),
         /// An optional type annotation for the defined expression
         // FIXME: raw identifiers in LALRPOP grammars https://github.com/lalrpop/lalrpop/issues/613
         type_: Option<&'arena Term<'arena, Range>>,

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -106,7 +106,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 self.push_item(*label);
 
                 Item::Definition {
-                    label: ((), Some(*label)),
+                    label: ((), *label),
                     type_: Some(r#type),
                     expr,
                 }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -813,7 +813,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let ch_end = ch_start + ch.len_utf8();
 
                 self.push_message(Message::NonAsciiStringLiteral {
-                    invalid_range: ByteRange::new(ch_start, ch_end),
+                    invalid_range: ByteRange::new(range.file_id(), ch_start, ch_end),
                 });
                 data = None;
             }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -984,7 +984,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
     pub fn elab_module(&mut self, surface_module: &Module<'_, ByteRange>) -> core::Module<'arena> {
         let universe = Arc::new(Value::Universe);
         let num_items = (surface_module.items.iter())
-            .filter(|item| matches!(item, Item::Definition { label, .. } if label.1.is_some()))
+            .filter(|item| matches!(item, Item::Definition { .. }))
             .count();
         let mut items = SliceVec::new(self.scope, num_items);
 
@@ -999,18 +999,14 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     let r#type = self.quote_context(self.scope).quote(&type_value);
                     let expr_value = self.eval_context().eval(&expr);
 
-                    if let Some(label) = *label {
-                        self.item_env.push_definition(label, type_value, expr_value);
+                    self.item_env
+                        .push_definition(*label, type_value, expr_value);
 
-                        let r#type = self.scope.to_scope(r#type);
-                        let expr = self.scope.to_scope(expr);
-
-                        items.push(core::Item::Definition {
-                            label,
-                            r#type: self.scope.to_scope(r#type),
-                            expr: self.scope.to_scope(expr),
-                        })
-                    }
+                    items.push(core::Item::Definition {
+                        label: *label,
+                        r#type: self.scope.to_scope(r#type),
+                        expr: self.scope.to_scope(expr),
+                    });
                 }
                 Item::Definition {
                     label: (_, label),
@@ -1022,15 +1018,14 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     let expr = self.check(expr, &type_value);
                     let expr_value = self.eval_context().eval(&expr);
 
-                    if let Some(label) = *label {
-                        self.item_env.push_definition(label, type_value, expr_value);
+                    self.item_env
+                        .push_definition(*label, type_value, expr_value);
 
-                        items.push(core::Item::Definition {
-                            label,
-                            r#type: self.scope.to_scope(r#type),
-                            expr: self.scope.to_scope(expr),
-                        })
-                    }
+                    items.push(core::Item::Definition {
+                        label: *label,
+                        r#type: self.scope.to_scope(r#type),
+                        expr: self.scope.to_scope(expr),
+                    });
                 }
                 Item::ReportedError(_) => {}
             }

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 
 use crate::{StringId, StringInterner};
 use crate::source::{ByteRange, FileId};
-use crate::surface::{ExprField, FormatField, ParseMessage, Pattern, Term, TypeField};
+use crate::surface::{ExprField, FormatField, Item, Module, ParseMessage, Pattern, Term, TypeField};
 use crate::surface::lexer::{Error as LexerError, Token};
 
 grammar<'arena, 'source>(
@@ -23,6 +23,7 @@ extern {
         "string literal" => Token::StringLiteral(<&'source str>),
         "number literal" => Token::NumberLiteral(<&'source str>),
 
+        "def" => Token::KeywordDef,
         "fun" => Token::KeywordFun,
         "let" => Token::KeywordLet,
         "match" => Token::KeywordMatch,
@@ -51,6 +52,26 @@ extern {
         ")" => Token::CloseParen,
     }
 }
+
+pub Module: Module<'arena, ByteRange> = {
+    <items: Item*> => Module {
+        items: scope.to_scope_from_iter(items.into_iter()),
+    },
+};
+
+Item: Item<'arena, ByteRange> = {
+    <start: @L> "def" <label: ItemName> <type_: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
+        Item::Definition {
+            label,
+            type_: type_.map(|type_| scope.to_scope(type_) as &_),
+            expr: scope.to_scope(expr),
+        }
+    },
+    <start: @L> <error: !> <end: @R> => {
+        messages.push(ParseMessage::from_lalrpop_recovery(file_id, error));
+        Item::ReportedError(ByteRange::new(file_id, start, end))
+    },
+};
 
 Pattern: Pattern<ByteRange> = {
     <start: @L> <name: Name> <end: @R> => Pattern::Name(ByteRange::new(file_id, start, end), name),
@@ -194,6 +215,11 @@ ExprField: ExprField<'arena, ByteRange> = {
 #[inline] Hole: StringId = { <"hole"> => interner.borrow_mut().get_or_intern(<>) };
 #[inline] StringLiteral: StringId = { <"string literal"> => interner.borrow_mut().get_or_intern(<>) };
 #[inline] NumberLiteral: StringId = { <"number literal"> => interner.borrow_mut().get_or_intern(<>) };
+
+ItemName: (ByteRange, Option<StringId>) = {
+    <start: @L> "_" <end: @R> => (ByteRange::new(file_id, start, end), None),
+    <start: @L> <name: Name> <end: @R> => (ByteRange::new(file_id, start, end), Some(name)),
+};
 
 #[inline]
 RangedName: (ByteRange, StringId) = {

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -60,7 +60,7 @@ pub Module: Module<'arena, ByteRange> = {
 };
 
 Item: Item<'arena, ByteRange> = {
-    <start: @L> "def" <label: ItemName> <type_: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
+    <start: @L> "def" <label: RangedName> <type_: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
         Item::Definition {
             label,
             type_: type_.map(|type_| scope.to_scope(type_) as &_),
@@ -215,11 +215,6 @@ ExprField: ExprField<'arena, ByteRange> = {
 #[inline] Hole: StringId = { <"hole"> => interner.borrow_mut().get_or_intern(<>) };
 #[inline] StringLiteral: StringId = { <"string literal"> => interner.borrow_mut().get_or_intern(<>) };
 #[inline] NumberLiteral: StringId = { <"number literal"> => interner.borrow_mut().get_or_intern(<>) };
-
-ItemName: (ByteRange, Option<StringId>) = {
-    <start: @L> "_" <end: @R> => (ByteRange::new(file_id, start, end), None),
-    <start: @L> <name: Name> <end: @R> => (ByteRange::new(file_id, start, end), Some(name)),
-};
 
 #[inline]
 RangedName: (ByteRange, StringId) = {

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -2,7 +2,7 @@ use scoped_arena::Scope;
 use std::cell::RefCell;
 
 use crate::{StringId, StringInterner};
-use crate::source::ByteRange;
+use crate::source::{ByteRange, FileId};
 use crate::surface::{ExprField, FormatField, ParseMessage, Pattern, Term, TypeField};
 use crate::surface::lexer::{Error as LexerError, Token};
 
@@ -10,6 +10,7 @@ grammar<'arena, 'source>(
     interner: &RefCell<StringInterner>,
     scope: &'arena Scope<'arena>,
     messages: &mut Vec<ParseMessage>,
+    file_id: FileId,
 );
 
 extern {
@@ -52,12 +53,12 @@ extern {
 }
 
 Pattern: Pattern<ByteRange> = {
-    <start: @L> <name: Name> <end: @R> => Pattern::Name(ByteRange::new(start, end), name),
-    <start: @L> "_" <end: @R> => Pattern::Placeholder(ByteRange::new(start, end)),
-    <start: @L> <string: StringLiteral> <end: @R> => Pattern::StringLiteral(ByteRange::new(start, end), string),
-    <start: @L> <number: NumberLiteral> <end: @R> => Pattern::NumberLiteral(ByteRange::new(start, end), number),
-    <start: @L> "true" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(start, end), true),
-    <start: @L> "false" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(start, end), false),
+    <start: @L> <name: Name> <end: @R> => Pattern::Name(ByteRange::new(file_id, start, end), name),
+    <start: @L> "_" <end: @R> => Pattern::Placeholder(ByteRange::new(file_id, start, end)),
+    <start: @L> <string: StringLiteral> <end: @R> => Pattern::StringLiteral(ByteRange::new(file_id, start, end), string),
+    <start: @L> <number: NumberLiteral> <end: @R> => Pattern::NumberLiteral(ByteRange::new(file_id, start, end), number),
+    <start: @L> "true" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(file_id, start, end), true),
+    <start: @L> "false" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(file_id, start, end), false),
 };
 
 AnnPattern: (Pattern<ByteRange>, Option<&'arena Term<'arena, ByteRange>>) = {
@@ -70,7 +71,7 @@ pub Term: Term<'arena, ByteRange> = {
     // FIXME: LALRPOP does not accept raw identifiers (see: https://github.com/lalrpop/lalrpop/issues/613)
     <start: @L> <expr: LetTerm> ":" <type_: LetTerm> <end: @R> => {
         Term::Ann(
-            ByteRange::new(start, end),
+            ByteRange::new(file_id, start, end),
             scope.to_scope(expr),
             scope.to_scope(type_),
         )
@@ -81,7 +82,7 @@ LetTerm: Term<'arena, ByteRange> = {
     FunTerm,
     <start: @L> "let" <def_pattern: Pattern> <def_type: (":" <LetTerm>)?> "=" <def_expr: Term> ";" <body_expr: LetTerm> <end: @R> => {
         Term::Let(
-            ByteRange::new(start, end),
+            ByteRange::new(file_id, start, end),
             def_pattern,
             def_type.map(|def_type| scope.to_scope(def_type) as &_),
             scope.to_scope(def_expr),
@@ -94,7 +95,7 @@ FunTerm: Term<'arena, ByteRange> = {
     AppTerm,
     <start: @L> <input_type: AppTerm> "->"  <output_type: FunTerm> <end: @R> => {
         Term::Arrow(
-            ByteRange::new(start, end),
+            ByteRange::new(file_id, start, end),
             scope.to_scope(input_type),
             scope.to_scope(output_type),
         )
@@ -102,7 +103,7 @@ FunTerm: Term<'arena, ByteRange> = {
     <start: @L> "fun" <input_param: AnnPattern> "->"  <output_type: FunTerm> <end: @R> => {
         let (input_param, input_type) = input_param;
         Term::FunType(
-            ByteRange::new(start, end),
+            ByteRange::new(file_id, start, end),
             input_param,
             input_type,
             scope.to_scope(output_type),
@@ -111,7 +112,7 @@ FunTerm: Term<'arena, ByteRange> = {
     <start: @L> "fun" <input_param: AnnPattern> "=>" <output_type: LetTerm> <end: @R> => {
         let (input_param, input_type) = input_param;
         Term::FunLiteral(
-            ByteRange::new(start, end),
+            ByteRange::new(file_id, start, end),
             input_param,
             input_type,
             scope.to_scope(output_type),
@@ -123,7 +124,7 @@ AppTerm: Term<'arena, ByteRange> = {
     AtomicTerm,
     <start: @L> <head_expr: AppTerm> <input_expr: AtomicTerm> <end: @R> => {
         Term::App(
-            ByteRange::new(start, end),
+            ByteRange::new(file_id, start, end),
             scope.to_scope(head_expr),
             scope.to_scope(input_expr),
         )
@@ -133,42 +134,42 @@ AppTerm: Term<'arena, ByteRange> = {
 AtomicTerm: Term<'arena, ByteRange> = {
     "(" <term: Term> ")" => term,
 
-    <start: @L> <name: Name> <end: @R> => Term::Name(ByteRange::new(start, end), name),
-    <start: @L> "_" <end: @R> => Term::Placeholder(ByteRange::new(start, end)),
-    <start: @L> <name: Hole> <end: @R> => Term::Hole(ByteRange::new(start, end), name),
+    <start: @L> <name: Name> <end: @R> => Term::Name(ByteRange::new(file_id, start, end), name),
+    <start: @L> "_" <end: @R> => Term::Placeholder(ByteRange::new(file_id, start, end)),
+    <start: @L> <name: Hole> <end: @R> => Term::Hole(ByteRange::new(file_id, start, end), name),
     <start: @L> "match" <scrutinee: AtomicTerm> "{"  <equations: Seq<(<Pattern> "=>" <Term>), ",">> "}" <end: @R> => {
-        Term::Match(ByteRange::new(start, end), scope.to_scope(scrutinee), equations)
+        Term::Match(ByteRange::new(file_id, start, end), scope.to_scope(scrutinee), equations)
     },
-    <start: @L> "Type" <end: @R> => Term::Universe(ByteRange::new(start, end)),
-    <start: @L> <string: StringLiteral> <end: @R> => Term::StringLiteral(ByteRange::new(start, end), string),
-    <start: @L> <number: NumberLiteral> <end: @R> => Term::NumberLiteral(ByteRange::new(start, end), number),
-    <start: @L> "true" <end: @R> => Term::BooleanLiteral(ByteRange::new(start, end), true),
-    <start: @L> "false" <end: @R> => Term::BooleanLiteral(ByteRange::new(start, end), false),
-    <start: @L> "{" "}" <end: @R> => Term::UnitLiteral(ByteRange::new(start, end)),
+    <start: @L> "Type" <end: @R> => Term::Universe(ByteRange::new(file_id, start, end)),
+    <start: @L> <string: StringLiteral> <end: @R> => Term::StringLiteral(ByteRange::new(file_id, start, end), string),
+    <start: @L> <number: NumberLiteral> <end: @R> => Term::NumberLiteral(ByteRange::new(file_id, start, end), number),
+    <start: @L> "true" <end: @R> => Term::BooleanLiteral(ByteRange::new(file_id, start, end), true),
+    <start: @L> "false" <end: @R> => Term::BooleanLiteral(ByteRange::new(file_id, start, end), false),
+    <start: @L> "{" "}" <end: @R> => Term::UnitLiteral(ByteRange::new(file_id, start, end)),
     <start: @L> "{" <fields: NonEmptySeq<TypeField, ",">> "}" <end: @R> => {
-        Term::RecordType(ByteRange::new(start, end), fields)
+        Term::RecordType(ByteRange::new(file_id, start, end), fields)
     },
     <start: @L> "{" <fields: NonEmptySeq<ExprField, ",">> "}" <end: @R> => {
-        Term::RecordLiteral(ByteRange::new(start, end), fields)
+        Term::RecordLiteral(ByteRange::new(file_id, start, end), fields)
     },
     <start: @L> "{" <fields: NonEmptySeq<FormatField, ",">> "}" <end: @R> => {
-        Term::FormatRecord(ByteRange::new(start, end), fields)
+        Term::FormatRecord(ByteRange::new(file_id, start, end), fields)
     },
     <start: @L> "{" <name: RangedName> "<-" <format:Term> "|" <cond:Term> "}" <end: @R> => {
-        Term::FormatCond(ByteRange::new(start, end), name, scope.to_scope(format), scope.to_scope(cond))
+        Term::FormatCond(ByteRange::new(file_id, start, end), name, scope.to_scope(format), scope.to_scope(cond))
     },
     <start: @L> "overlap" "{" <fields: NonEmptySeq<FormatField, ",">> "}" <end: @R> => {
-        Term::FormatOverlap(ByteRange::new(start, end), fields)
+        Term::FormatOverlap(ByteRange::new(file_id, start, end), fields)
     },
     <start: @L> <head_expr: AtomicTerm> "." <label: RangedName> <end: @R> => {
-        Term::Proj(ByteRange::new(start, end), scope.to_scope(head_expr), label)
+        Term::Proj(ByteRange::new(file_id, start, end), scope.to_scope(head_expr), label)
     },
     <start: @L> "[" <exprs: Seq<Term, ",">> "]" <end: @R> => {
-        Term::ArrayLiteral(ByteRange::new(start, end), exprs)
+        Term::ArrayLiteral(ByteRange::new(file_id, start, end), exprs)
     },
     <start: @L> <error: !> <end: @R> => {
-        messages.push(ParseMessage::from(error));
-        Term::ReportedError(ByteRange::new(start, end))
+        messages.push(ParseMessage::from_lalrpop_recovery(file_id, error));
+        Term::ReportedError(ByteRange::new(file_id, start, end))
     },
 };
 
@@ -196,7 +197,7 @@ ExprField: ExprField<'arena, ByteRange> = {
 
 #[inline]
 RangedName: (ByteRange, StringId) = {
-    <start: @L> <name: Name> <end: @R> => (ByteRange::new(start, end), name),
+    <start: @L> <name: Name> <end: @R> => (ByteRange::new(file_id, start, end), name),
 };
 
 Seq<Elem, Sep>: &'arena [Elem] = {

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -14,6 +14,10 @@ pub enum Token<'source> {
     #[regex(r"[+-]?[0-9][a-zA-Z0-9_]*")]
     NumberLiteral(&'source str),
 
+    #[token("def")]
+    KeywordDef,
+    #[token("false")]
+    KeywordFalse,
     #[token("fun")]
     KeywordFun,
     #[token("let")]
@@ -26,8 +30,6 @@ pub enum Token<'source> {
     KeywordType,
     #[token("true")]
     KeywordTrue,
-    #[token("false")]
-    KeywordFalse,
     #[token("where")]
     KeywordWhere,
 
@@ -115,12 +117,13 @@ impl<'source> Token<'source> {
             Token::Hole(_) => "hole",
             Token::StringLiteral(_) => "string literal",
             Token::NumberLiteral(_) => "number literal",
-            Token::KeywordTrue => "true",
+            Token::KeywordDef => "def",
             Token::KeywordFalse => "false",
             Token::KeywordFun => "fun",
             Token::KeywordLet => "let",
             Token::KeywordMatch => "match",
             Token::KeywordOverlap => "overlap",
+            Token::KeywordTrue => "true",
             Token::KeywordType => "Type",
             Token::KeywordWhere => "where",
             Token::Colon => ":",

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -46,19 +46,15 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
     fn item<Range>(&'arena self, item: &Item<'_, Range>) -> DocBuilder<'arena, Self> {
         match item {
-            Item::Definition { label, type_, expr } => {
-                let name = match label.1 {
-                    None => self.text("_"),
-                    Some(name) => self.string_id(name),
-                };
-
-                self.concat([
+            Item::Definition { label, type_, expr } => self
+                .concat([
                     self.text("def"),
                     self.space(),
                     match type_ {
-                        None => name,
+                        None => self.string_id(label.1),
                         Some(r#type) => self.concat([
-                            self.concat([name, self.space(), self.text(":")]).group(),
+                            self.concat([self.string_id(label.1), self.space(), self.text(":")])
+                                .group(),
                             self.softline(),
                             self.term_prec(Prec::Top, &r#type),
                         ]),
@@ -69,8 +65,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                     self.term_prec(Prec::Let, expr),
                     self.text(";"),
                 ])
-                .group()
-            }
+                .group(),
             Item::ReportedError(_) => self.text("#error"),
         }
     }

--- a/fathom/tests/cli_tests.rs
+++ b/fathom/tests/cli_tests.rs
@@ -1,0 +1,7 @@
+/// Command line integration tests, run with the [trycmd] crate.
+
+#[test]
+fn cli_tests() {
+    std::env::set_current_dir("..").unwrap();
+    trycmd::TestCases::new().case("tests/cmd/*.md");
+}

--- a/formats/edid.fathom
+++ b/formats/edid.fathom
@@ -14,7 +14,7 @@
 
 // TODO: Versions 1.0-1.4
 
-let header = {
+def header = {
     magic <- u64le where u64_eq magic 0x00ffffffffffff00,
     manufacturer_id <- u16le,                // TODO: bit patterns
     product_code <- u16le,
@@ -25,7 +25,7 @@ let header = {
     edid_version_minor <- u8,
 };
 
-let display_parameters = {
+def display_parameters = {
     video_input_parameters <- u8,            // TODO: bit patterns
     screen_size_h <- u8,
     screen_size_v <- u8,
@@ -33,7 +33,7 @@ let display_parameters = {
     supported_features <- u8,                // TODO: bit patterns
 };
 
-let chromacity_coordinates = {
+def chromacity_coordinates = {
     red_green_lsb <- u8,                     // TODO: bit patterns
     blue_white_lsb <- u8,                    // TODO: bit patterns
     red_x_msb <- u8,
@@ -46,20 +46,18 @@ let chromacity_coordinates = {
     white_y_msb <- u8,
 };
 
-let established_timing = {
+def established_timing = {
     mode_bitmap <- array8 3 u8,             // TODO: bit patterns
 };
 
-let standard_timing_information : Format = {
+def standard_timing_information : Format = {
     // TODO: Standard timing information
 };
 
-let main = {
+def main = {
     header <- header,
     display_parameters <- display_parameters,
     chromacity_coordinates <- chromacity_coordinates,
     established_timing <- established_timing,
     standard_timing_information <- standard_timing_information,
 };
-
-main

--- a/formats/edid.snap
+++ b/formats/edid.snap
@@ -1,5 +1,5 @@
 stdout = '''
-let header : _ = {
+def header : Format = {
     magic <- u64le where u64_eq magic 0xffffffffffff00,
     manufacturer_id <- u16le,
     product_code <- u16le,
@@ -9,14 +9,14 @@ let header : _ = {
     edid_version_major <- u8,
     edid_version_minor <- u8,
 };
-let display_parameters : _ = {
+def display_parameters : Format = {
     video_input_parameters <- u8,
     screen_size_h <- u8,
     screen_size_v <- u8,
     gamma_mod <- u8,
     supported_features <- u8,
 };
-let chromacity_coordinates : _ = {
+def chromacity_coordinates : Format = {
     red_green_lsb <- u8,
     blue_white_lsb <- u8,
     red_x_msb <- u8,
@@ -28,15 +28,14 @@ let chromacity_coordinates : _ = {
     white_x_msb <- u8,
     white_y_msb <- u8,
 };
-let established_timing : _ = { mode_bitmap <- array8 3 u8 };
-let standard_timing_information : Format = {};
-let main : _ = {
+def established_timing : Format = { mode_bitmap <- array8 3 u8 };
+def standard_timing_information : Format = {};
+def main : Format = {
     header <- header,
     display_parameters <- display_parameters,
     chromacity_coordinates <- chromacity_coordinates,
     established_timing <- established_timing,
     standard_timing_information <- standard_timing_information,
 };
-main : Format
 '''
 stderr = ''

--- a/formats/gif.fathom
+++ b/formats/gif.fathom
@@ -11,7 +11,7 @@
 /// ## References
 ///
 /// - [GIF89a Specification: Section 18](https://www.w3.org/Graphics/GIF/spec-gif89a.txt)
-let logical_screen_descriptor = {
+def logical_screen_descriptor = {
     image_width <- u16le,
     image_height <- u16le,
     flags <- u8,
@@ -28,7 +28,7 @@ let logical_screen_descriptor = {
 /// ## References
 ///
 /// - [GIF89a Specification: Section 17](https://www.w3.org/Graphics/GIF/spec-gif89a.txt)
-let header = {
+def header = {
     magic <- array8 3 u8,   // TODO: where magic == ascii "GIF"`,
     version <- array8 3 u8,
 };
@@ -38,7 +38,7 @@ let header = {
 /// ## References
 ///
 /// - [GIF89a Specification: Section 19](https://www.w3.org/Graphics/GIF/spec-gif89a.txt)
-let color_table_entry = {
+def color_table_entry = {
     red <- u8,
     green <- u8,
     blue <- u8,
@@ -49,15 +49,13 @@ let color_table_entry = {
 /// ## References
 ///
 /// - [GIF89a Specification: Section 19](https://www.w3.org/Graphics/GIF/spec-gif89a.txt)
-let global_color_table = fun (len : U16) => {
+def global_color_table = fun (len : U16) => {
     entries <- array16 len color_table_entry,
 };
 
-let main = {
+def main = {
     header <- header,
     screen <- logical_screen_descriptor,
     // global_color_table <- global_color_table screen.color_table_size,    // TODO: if `screen.has_color_table,`
     // blocks <- array 0 block,                                             // TODO: repeat while not EOF or BlockTerminator
 };
-
-main

--- a/formats/gif.snap
+++ b/formats/gif.snap
@@ -1,17 +1,16 @@
 stdout = '''
-let logical_screen_descriptor : _ = {
+def logical_screen_descriptor : Format = {
     image_width <- u16le,
     image_height <- u16le,
     flags <- u8,
     bg_color_index <- u8,
     pixel_aspect_ratio <- u8,
 };
-let header : _ = { magic <- array8 3 u8, version <- array8 3 u8 };
-let color_table_entry : _ = { red <- u8, green <- u8, blue <- u8 };
-let global_color_table : _ = fun len => {
+def header : Format = { magic <- array8 3 u8, version <- array8 3 u8 };
+def color_table_entry : Format = { red <- u8, green <- u8, blue <- u8 };
+def global_color_table : fun (len : U16) -> Format = fun len => {
     entries <- array16 len color_table_entry,
 };
-let main : _ = { header <- header, screen <- logical_screen_descriptor };
-main : Format
+def main : Format = { header <- header, screen <- logical_screen_descriptor };
 '''
 stderr = ''

--- a/formats/icns.fathom
+++ b/formats/icns.fathom
@@ -4,21 +4,19 @@
 //!
 //! - [Wikipedia](https://en.wikipedia.org/wiki/Apple_Icon_Image_format)
 
-let header = {
+def header = {
     magic <- u32be where u32_eq magic "icns",
     file_length <- u32be,
 };
 
-let icon_data = {
+def icon_data = {
     icon_type <- u32be,             // TODO: bit patterns
     icon_data_length <- u32be,
     // TODO: decode data based on `icon_type`
     data <- limit32 icon_data_length (repeat_until_end u8),
 };
 
-let main = {
+def main = {
     header <- header,
     icons <- repeat_until_end icon_data,
 };
-
-main

--- a/formats/icns.snap
+++ b/formats/icns.snap
@@ -1,14 +1,13 @@
 stdout = '''
-let header : _ = {
+def header : Format = {
     magic <- u32be where u32_eq magic "icns",
     file_length <- u32be,
 };
-let icon_data : _ = {
+def icon_data : Format = {
     icon_type <- u32be,
     icon_data_length <- u32be,
     data <- limit32 icon_data_length (repeat_until_end u8),
 };
-let main : _ = { header <- header, icons <- repeat_until_end icon_data };
-main : Format
+def main : Format = { header <- header, icons <- repeat_until_end icon_data };
 '''
 stderr = ''

--- a/formats/ideas/ico.fathom
+++ b/formats/ideas/ico.fathom
@@ -7,12 +7,12 @@
 //! - [Wikipedia](https://en.wikipedia.org/wiki/ICO_(file_format))
 //! - [Wikidata](https://www.wikidata.org/wiki/Q729366)
 
-let reserved : fun (f : Format) -> Repr f -> Format =
+def reserved : fun (f : Format) -> Repr f -> Format =
     fun f => fun default =>
         let data <- f;
         return data;
 
-let image = {
+def image = {
     width <- u8 if 0 then 256,
     height <- u8 if 0 then 256,
     num_colors <- u8,
@@ -23,7 +23,7 @@ let image = {
     image_offset <- u32le,
 };
 
-let ico = {
+def main = {
     // NOTE: Could be useful to have invertible patterns here?
     magic <- array8 4 u8 match {
         [0, 0, 1, 0] => icon,   // TODO
@@ -32,5 +32,3 @@ let ico = {
     num_images <- u16le,
     images <- repeat num_images image,
 };
-
-ico

--- a/formats/ideas/opentype/morx.fathom
+++ b/formats/ideas/opentype/morx.fathom
@@ -6,7 +6,7 @@
 //!
 //! [Apple Developer Documentation](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html)
 
-let table_header = {
+def table_header = {
     /// Version number of the extended glyph metamorphosis table (either 2 or 3)
     version <- u16be,
     unused <- u16be, // TODO: reserved, set to 0
@@ -14,7 +14,7 @@ let table_header = {
     num_chains <- u32be,
 };
 
-let chain_header = {
+def chain_header = {
     /// The default specification for subtables.
     default_flags <- u32be,
     /// Total byte count, including this header; must be a multiple of 4.
@@ -25,7 +25,7 @@ let chain_header = {
     num_subtables <- u32be,
 };
 
-let feature_table = {
+def feature_table = {
     /// The type of feature.
     feature_type <- uint16,
     /// The feature's setting (aka selector)
@@ -36,7 +36,7 @@ let feature_table = {
     disable_flags <- uint32,
 };
 
-let subtable_glyph_coverage_table = {
+def subtable_glyph_coverage_table = {
     /// Array of offsets from the beginning of the subtable glyph coverage table
     /// to the glyph coverage bitfield for a given subtable; there is one offset
     /// for each subtable in the chain
@@ -45,7 +45,7 @@ let subtable_glyph_coverage_table = {
     coverage_bitfields <- array _ u8, // TODO: array length?
 };
 
-let subtable_header = {
+def subtable_header = {
     /// Total subtable length, including this header.
     length <- u32be,
     /// Coverage flags and subtable type.
@@ -56,17 +56,15 @@ let subtable_header = {
     sub_feature_flags <- u32be,
 };
 
-let subtable = {
+def subtable = {
     header <- subtable_header,
     ... // TODO: ...
 };
 
 // TODO: ...
 
-let morx = {
+def morx = {
     header <- table_header,
     chains <- ..., // TODO
     subtable_glyph_coverage_array <- array _ _ if table_header.version >= 3,
 };
-
-morx

--- a/formats/image.fathom
+++ b/formats/image.fathom
@@ -1,6 +1,6 @@
 //! A simple image data format.
 
-let pixel = {
+def pixel = {
     /// Red value.
     red <- s32be,
     /// Green value.
@@ -9,7 +9,7 @@ let pixel = {
     blue <- s32be,
 };
 
-let main = {
+def main = {
     /// The width of the image, in pixels.
     width <- u32be,
     /// The height of the image, in pixels.
@@ -17,5 +17,3 @@ let main = {
     /// The pixel data.
     pixels <- array32 (u32_mul width height) pixel, // TODO: binary operators
 };
-
-main

--- a/formats/image.snap
+++ b/formats/image.snap
@@ -1,10 +1,9 @@
 stdout = '''
-let pixel : _ = { red <- s32be, green <- s32be, blue <- s32be };
-let main : _ = {
+def pixel : Format = { red <- s32be, green <- s32be, blue <- s32be };
+def main : Format = {
     width <- u32be,
     height <- u32be,
     pixels <- array32 (u32_mul width height) pixel,
 };
-main : Format
 '''
 stderr = ''

--- a/formats/object-id.fathom
+++ b/formats/object-id.fathom
@@ -5,9 +5,9 @@
 //! - [Mongo Reference](https://docs.mongodb.com/manual/reference/bson-types/#objectid)
 
 // TODO: make this a primitive
-let u24be = array8 3 u8;
+def u24be = array8 3 u8;
 
-{
+def main = {
     /// 4-byte timestamp value representing the creation time of the ObjectId,
     /// measured in seconds since the Unix epoch.
     timestamp <- u32be,
@@ -16,4 +16,4 @@ let u24be = array8 3 u8;
     random <- array8 5 u8,
     /// Incrementing counter, initialized to a random value.
     counter <- u24be,
-}
+};

--- a/formats/object-id.snap
+++ b/formats/object-id.snap
@@ -1,5 +1,9 @@
 stdout = '''
-let u24be : _ = array8 3 u8;
-{ timestamp <- u32be, random <- array8 5 u8, counter <- u24be } : Format
+def u24be : Format = array8 3 u8;
+def main : Format = {
+    timestamp <- u32be,
+    random <- array8 5 u8,
+    counter <- u24be,
+};
 '''
 stderr = ''

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -9,11 +9,11 @@
 // -----------------------------------------------------------------------------
 
 /// Reserved formats
-let reserved = fun (format : Format) => fun (default : Repr format) =>
+def reserved = fun (format : Format) => fun (default : Repr format) =>
     format; // TODO: set to `default` during serialisation
 
 /// Deprecated formats
-let deprecated = fun (format : Format) => fun (default : Repr format) =>
+def deprecated = fun (format : Format) => fun (default : Repr format) =>
     format; // TODO: set to `default` during serialisation
 
 
@@ -35,42 +35,42 @@ let deprecated = fun (format : Format) => fun (default : Repr format) =>
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Fixed](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_Fixed)
-let fixed : Format = u32be;
+def fixed : Format = u32be;
 
 /// Signed, 16-bit integer that describes a quantity in font design units.
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: FWORD](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_FWORD)
-let fword : Format = s16be;
+def fword : Format = s16be;
 
 /// Unsigned, 16-bit integer that describes a quantity in font design units.
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: UFWORD](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_UFWORD)
-let ufword : Format = u16be;
+def ufword : Format = u16be;
 
 /// Signed 16-bit fixed number with the low 14 bits of fraction (2.14).
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: F2DOT14](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_F2DOT14)
-let f2dot14 : Format = s16be;
+def f2dot14 : Format = s16be;
 
 /// Unsigned 24-bit integer
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: uint24](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_uint24)
-let u24be : Format = array8 3 u8;
+def u24be : Format = array8 3 u8;
 
 /// Date represented in number of seconds since 12:00 midnight, January 1, 1904.
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LONGDATETIME](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_LONGDATETIME)
-let long_date_time : Format = s64be;
+def long_date_time : Format = s64be;
 
 /// Array of four `U8`s used to identify a table, design-variation axis, script,
 /// language system, feature, or baseline.
@@ -81,7 +81,7 @@ let long_date_time : Format = s64be;
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Tag](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_Tag)
-let tag : Format =
+def tag : Format =
     // TODO: constrain array elements to the range 0x20 to 0x7E.
     // TODO: pattern matching on arrays
     // array8 4 u8;
@@ -92,17 +92,17 @@ let tag : Format =
 /// This is a placeholder for a table that has an unknown identifier (due to the
 /// file conforming to a newer version of the specification), or for a table has
 /// not yet been implemented.
-let unknown_table : Format = {};
+def unknown_table : Format = {};
 
 /// A format that consumes no input.
-let empty : Format = {};
+def empty : Format = {};
 
 /// 16-bit offset to a `format`, relative to some `base` position.
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Offset16](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_Offset16)
-let offset16 = fun (base : Pos) => fun (format : Format) => {
+def offset16 = fun (base : Pos) => fun (format : Format) => {
     offset <- u16be,
     link <- match offset {
         0 => empty,
@@ -115,7 +115,7 @@ let offset16 = fun (base : Pos) => fun (format : Format) => {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Offset32](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_Offset32)
-let offset32 = fun (base : Pos) => fun (format : Format) => {
+def offset32 = fun (base : Pos) => fun (format : Format) => {
     offset <- u32be,
     link <- match offset {
         0 => empty,
@@ -131,7 +131,7 @@ let offset32 = fun (base : Pos) => fun (format : Format) => {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Version16Dot16](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#dt_Version16Dot16)
-let version16dot16 = u32be;
+def version16dot16 = u32be;
 
 
 // -----------------------------------------------------------------------------
@@ -157,13 +157,13 @@ let version16dot16 = u32be;
 /// - [Microsoft's OpenType Spec: Platform, encoding and language](https://docs.microsoft.com/en-us/typography/opentype/spec/name#platform-encoding-and-language)
 /// - [Apple's TrueType Reference Manual: The `'cmap'` encoding subtables](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
 /// - [Apple's TrueType Reference Manual: The platform identifier](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6name.html)
-let platform_id =
+def platform_id =
     u16be;
 
 /// # Platform-specific encoding identifiers
 ///
 // TODO: document encoding IDs
-let encoding_id = fun (platform : Repr platform_id) =>
+def encoding_id = fun (platform : Repr platform_id) =>
     u16be;
 
 /// # Language identifiers
@@ -177,10 +177,10 @@ let encoding_id = fun (platform : Repr platform_id) =>
 /// - [Apple's TrueType Reference Manual: The `'cmap'` table and language codes](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
 ///
 // TODO: add more details to docs
-let language_id =
+def language_id =
     u16be;
 
-let language_id32 =
+def language_id32 =
     u32be;
 
 
@@ -204,7 +204,7 @@ let language_id32 =
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
-let class_def_format_1 = {
+def class_def_format_1 = {
     /// First glyph ID of the class_value_array
     start_glyph_id <- u16be,
     /// Size of the class_value_array
@@ -218,7 +218,7 @@ let class_def_format_1 = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
-let class_def_format_2 = (
+def class_def_format_2 = (
     /// ClassRangeRecord
     let class_range_record = {
         /// First glyph ID in the range
@@ -242,7 +242,7 @@ let class_def_format_2 = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
-let class_def = {
+def class_def = {
     /// Format identifier
     class_format <- u16be,
     /// Format specific data
@@ -258,7 +258,7 @@ let class_def = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
-let coverage_format_1 = {
+def coverage_format_1 = {
     /// Number of glyphs in the glyph array
     glyph_count <- u16be,
     /// Array of glyph IDs — in numerical order
@@ -270,7 +270,7 @@ let coverage_format_1 = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
-let coverage_format_2 = (
+def coverage_format_2 = (
     /// RangeRecord
     let range_record = {
         /// First glyph ID in the range
@@ -294,7 +294,7 @@ let coverage_format_2 = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverageTbl)
-let coverage_table = {
+def coverage_table = {
     /// Format identifier
     coverage_format <- u16be,
     /// Format specific data
@@ -310,7 +310,7 @@ let coverage_table = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)
-let sequence_lookup_record = {
+def sequence_lookup_record = {
     /// Index (zero-based) into the input glyph sequence
     sequence_index <- u16be,
     /// Index (zero-based) into the LookupList
@@ -343,7 +343,7 @@ let sequence_lookup_record = {
 ///
 /// - [Microsoft's OpenType Spec: Device and VariationIndex Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 ///
-let device_table = (
+def device_table = (
     // quotient = numerator / denominator # int division
     // if quotient * denominator < numerator:
     //     quotient + 1
@@ -387,7 +387,7 @@ let device_table = (
 );
 
 /// VariationIndex table
-let variation_index_table = {
+def variation_index_table = {
     /// A delta-set outer index — used to select an item variation data subtable within the item
     /// variation store.
     delta_set_outer_index <- u16be,
@@ -396,7 +396,7 @@ let variation_index_table = {
     delta_set_inner_index <- u16be,
 };
 
-let device_or_variation_index_table = overlap {
+def device_or_variation_index_table = overlap {
     // Initial pass to figure out the table format
     init <- {
         _skipped <- array8 4 u8,
@@ -419,7 +419,7 @@ let device_or_variation_index_table = overlap {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
-let lang_sys = {
+def lang_sys = {
     /// = NULL (reserved for an offset to a reordering table)
     lookup_order_offset <- u16be,
     /// Index of a feature required for this language system; if no required features = 0xFFFF
@@ -437,7 +437,7 @@ let lang_sys = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Script Table and Language System Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
-let lang_sys_record = fun (script_start : Pos) => {
+def lang_sys_record = fun (script_start : Pos) => {
     /// 4-byte LangSysTag identifier
     lang_sys_tag <- tag,
     /// Offset to LangSys table, from beginning of Script table
@@ -449,7 +449,7 @@ let lang_sys_record = fun (script_start : Pos) => {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Script Table and Language System Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
-let script_table = {
+def script_table = {
     /// The start of the script table
     table_start <- stream_pos,
     /// Offset to default LangSys table, from beginning of Script table — may be NULL
@@ -465,7 +465,7 @@ let script_table = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Script List Table and Script Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
-let script_list = (
+def script_list = (
     /// ScriptRecord
     let script_record = fun (script_list_start : Pos) => {
         /// 4-byte script tag identifier
@@ -489,7 +489,7 @@ let script_list = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
-let feature_table = {
+def feature_table = {
     /// The start of the feature table
     table_start <- stream_pos,
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and
@@ -506,7 +506,7 @@ let feature_table = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
-let feature_list = (
+def feature_list = (
     let feature_record = fun (feature_list_start : Pos) => {
         /// 4-byte feature identification tag
         feature_tag <- tag,
@@ -530,7 +530,7 @@ let feature_list = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
-let sequence_context_format1 = (
+def sequence_context_format1 = (
     /// SequenceRule table
     let sequence_rule = {
         /// Number of glyphs in the input glyph sequence
@@ -571,7 +571,7 @@ let sequence_context_format1 = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
-let sequence_context_format2 = (
+def sequence_context_format2 = (
     /// ClassSequenceRule table
     let class_sequence_rule = {
         /// Number of glyphs to be matched
@@ -616,7 +616,7 @@ let sequence_context_format2 = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-3-coverage-based-glyph-contexts)
-let sequence_context_format3 = {
+def sequence_context_format3 = {
     /// The start of the table
     table_start <- stream_pos,
     /// Number of glyphs in the input sequence
@@ -629,7 +629,7 @@ let sequence_context_format3 = {
     seq_lookup_records <- array16 seq_lookup_count sequence_lookup_record,
 };
 
-let sequence_context = {
+def sequence_context = {
     /// Format identifier
     format <- u16be,
     /// Format specific substitutions
@@ -646,7 +646,7 @@ let sequence_context = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
-let chained_sequence_context_format_1 = (
+def chained_sequence_context_format_1 = (
     let chained_sequence_rule = {
         /// Number of glyphs in the backtrack sequence
         backtrack_glyph_count <- u16be,
@@ -694,7 +694,7 @@ let chained_sequence_context_format_1 = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
-let chained_sequence_context_format_2 = (
+def chained_sequence_context_format_2 = (
     /// ChainedClassSequenceRule table
     let chained_class_sequence_rule = {
         /// Number of glyphs in the backtrack sequence
@@ -753,7 +753,7 @@ let chained_sequence_context_format_2 = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Chained Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-3-coverage-based-glyph-contexts)
-let chained_sequence_context_format_3 = {
+def chained_sequence_context_format_3 = {
     /// The start of the table
     table_start <- stream_pos,
     /// Number of glyphs in the backtrack sequence
@@ -774,7 +774,7 @@ let chained_sequence_context_format_3 = {
     seq_lookup_records <- array16 seq_lookup_count sequence_lookup_record,
 };
 
-let chained_sequence_context = {
+def chained_sequence_context = {
     /// Format identifier
     format <- u16be,
     /// Format specific substitutions
@@ -793,7 +793,7 @@ let chained_sequence_context = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-1-single-substitution-subtable)
-let single_substitution = {
+def single_substitution = {
     /// The start of the sub-table
     table_start <- stream_pos,
     /// Format identifier
@@ -823,7 +823,7 @@ let single_substitution = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-2-multiple-substitution-subtable)
-let multiple_substitution = (
+def multiple_substitution = (
     let sequence_table = {
         /// Number of glyph IDs in the substitute_glyph_ids array. This must always be greater than
         /// 0.
@@ -857,7 +857,7 @@ let multiple_substitution = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-3-alternate-substitution-subtable)
-let alternate_substitution = (
+def alternate_substitution = (
     /// AlternateSet table
     let alternate_set = {
         /// Number of glyph IDs in the alternate_glyph_ids array
@@ -891,7 +891,7 @@ let alternate_substitution = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 4](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-4-ligature-substitution-subtable)
-let ligature_substitution = (
+def ligature_substitution = (
     /// Ligature table: Glyph components for one ligature
     let ligature_table = {
         /// glyph ID of ligature to substitute
@@ -946,21 +946,21 @@ let ligature_substitution = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 5](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-5-contextual-substitution-subtable)
-let contextual_substitution = sequence_context;
+def contextual_substitution = sequence_context;
 
 /// # LookupType 6: Chained Contexts Substitution Subtable
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 6](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-6-chained-contexts-substitution-subtable)
-let chained_contexts_substitution = chained_sequence_context;
+def chained_contexts_substitution = chained_sequence_context;
 
 /// # LookupType 8: Reverse Chaining Contextual Single Substitution Subtable
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 8](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-8-reverse-chaining-contextual-single-substitution-subtable)
-let reverse_chaining_contextual_single_substitution = (
+def reverse_chaining_contextual_single_substitution = (
     /// ReverseChainSingleSubstFormat1 Subtable
     let reverse_chain_single_subst_format1 = {
         /// The start of the table
@@ -997,7 +997,7 @@ let reverse_chaining_contextual_single_substitution = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 7](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-7-extension-substitution)
-let extension_substitution = (
+def extension_substitution = (
     /// ExtensionSubstFormat1 subtable
     let extension_subst_format1 = {
         /// The start of the table
@@ -1081,7 +1081,7 @@ let extension_substitution = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Value Record](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#value-record)
-let value_record = fun (table_start : Pos) => fun (flags : U16) => (
+def value_record = fun (table_start : Pos) => fun (flags : U16) => (
     let X_PLACEMENT : U16 = 0x0001;
     let Y_PLACEMENT : U16 = 0x0002;
     let X_ADVANCE : U16 = 0x0004;
@@ -1130,7 +1130,7 @@ let value_record = fun (table_start : Pos) => fun (flags : U16) => (
 );
 
 /// A value record that is `empty` if flags is 0
-let optional_value_record = fun (table_start : Pos) => fun (flags : U16) => match (u16_eq flags 0) {
+def optional_value_record = fun (table_start : Pos) => fun (flags : U16) => match (u16_eq flags 0) {
     true => empty,
     false => value_record table_start flags
 };
@@ -1140,7 +1140,7 @@ let optional_value_record = fun (table_start : Pos) => fun (flags : U16) => matc
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Anchor Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-tables)
-let anchor_table = {
+def anchor_table = {
     /// The start of the table
     table_start <- stream_pos,
     /// Format identifier
@@ -1184,7 +1184,7 @@ let anchor_table = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
-let mark_array_table = (
+def mark_array_table = (
     /// MarkRecord
     let mark_record = fun (table_start : Pos) => {
         /// Class defined for the associated mark.
@@ -1210,7 +1210,7 @@ let mark_array_table = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable)
-let single_adjustment = (
+def single_adjustment = (
     /// Single Adjustment Positioning Format 1: Single Positioning Value
     let single_pos_format1 = fun (table_start : Pos) => {
         /// Offset to Coverage table, from beginning of SinglePos subtable.
@@ -1254,7 +1254,7 @@ let single_adjustment = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-2-pair-adjustment-positioning-subtable)
-let pair_adjustment = (
+def pair_adjustment = (
     /// PairValueRecord
     let pair_value_record = fun (table_start : Pos) => fun (value_format1 : U16) => fun (value_format2 : U16) => {
         /// Glyph ID of second glyph in the pair (first glyph is listed in the Coverage table).
@@ -1349,7 +1349,7 @@ let pair_adjustment = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-3-cursive-attachment-positioning-subtable)
-let cursive_attachment = (
+def cursive_attachment = (
     /// EntryExitRecord
     let entry_exit_record = fun (table_start : Pos) => {
         /// Offset to entry Anchor table, from beginning of CursivePos subtable (may be NULL).
@@ -1389,7 +1389,7 @@ let cursive_attachment = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 4](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable)
-let mark_to_base_attachment = (
+def mark_to_base_attachment = (
     /// BaseRecord
     let base_record = fun (table_start : Pos) => fun (mark_class_count : U16) => {
         /// Array of offsets (one per mark class) to Anchor tables. Offsets are from beginning of
@@ -1439,7 +1439,7 @@ let mark_to_base_attachment = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 5](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-5-mark-to-ligature-attachment-positioning-subtable)
-let mark_to_ligature_attachment = (
+def mark_to_ligature_attachment = (
     let component_record = fun (table_start : Pos) => fun (mark_class_count : U16) => {
         /// Array of offsets (one per class) to Anchor tables. Offsets are from beginning of
         /// LigatureAttach table, ordered by class (offsets may be NULL).
@@ -1498,28 +1498,28 @@ let mark_to_ligature_attachment = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 6](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-6-mark-to-mark-attachment-positioning-subtable)
-let mark_to_mark_attachment = mark_to_base_attachment;
+def mark_to_mark_attachment = mark_to_base_attachment;
 
 /// # GPOS Lookup Type 7: Contextual Positioning Subtables
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 7](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-7-contextual-positioning-subtables)
-let contextual_positioning = sequence_context;
+def contextual_positioning = sequence_context;
 
 /// # GPOS Lookup Type 8: Chained Contexts Positioning Subtable
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GPOS Lookup Type 8](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-8-chained-contexts-positioning-subtable)
-let chained_contexts_positioning = chained_sequence_context;
+def chained_contexts_positioning = chained_sequence_context;
 
 /// # LookupType 9: Extension Positioning
 ///
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: LookupType 9](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning)
-let extension_positioning = (
+def extension_positioning = (
     /// ExtensionPosFormat1 subtable
     let extension_pos_format1 = {
         /// The start of the table
@@ -1563,7 +1563,7 @@ let extension_positioning = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
-let lookup_table = fun (tag : U32) => (
+def lookup_table = fun (tag : U32) => (
     let USE_MARK_FILTERING_SET : U16 = 0x0010;
 
     let lookup_subtable = fun (tag : U32) => fun (lookup_type : U16) =>
@@ -1619,7 +1619,7 @@ let lookup_table = fun (tag : U32) => (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
-let lookup_list = fun (tag : U32) => {
+def lookup_list = fun (tag : U32) => {
     /// The start of the lookup list table
     table_start <- stream_pos,
     /// Number of lookups in this table
@@ -1652,15 +1652,15 @@ let lookup_list = fun (tag : U32) => {
 /// - [Apple's TrueType Reference Manual: : The `'cmap'` table and language codes](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
 ///
 // TODO: add more details to docs
-let cmap_language_id = fun (platform : Repr platform_id) =>
+def cmap_language_id = fun (platform : Repr platform_id) =>
     language_id;
 
 // cmap sub-table format 8 has a 32-bit language code
-let cmap_language_id32 = fun (platform : Repr platform_id) =>
+def cmap_language_id32 = fun (platform : Repr platform_id) =>
     language_id32;
 
 /// A small glyph ID, limited to a glyph set of 256 glyphs.
-let small_glyph_id = u8;
+def small_glyph_id = u8;
 
 /// # SequentialMapGroup Record
 ///
@@ -1673,7 +1673,7 @@ let small_glyph_id = u8;
 ///
 /// - [Microsoft's OpenType Spec: cmap sub-table format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 8](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let sequential_map_group = {
+def sequential_map_group = {
     /// First character code in this group; note that if this group is for one or more 16-bit
     /// character codes (which is determined from the is32 array), this 32-bit value will have the
     /// high 16-bits set to zero
@@ -1696,7 +1696,7 @@ let sequential_map_group = {
 ///
 /// - [Microsoft's OpenType Spec: cmap sub-table format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 13](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let constant_map_group = sequential_map_group;
+def constant_map_group = sequential_map_group;
 
 /// # UnicodeRange Record
 ///
@@ -1706,7 +1706,7 @@ let constant_map_group = sequential_map_group;
 ///
 /// - [Microsoft's OpenType Spec: cmap sub-table format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 14](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let unicode_range = {
+def unicode_range = {
     /// First value in this range
     start_unicode_value <- u24be,
     /// Number of additional values in this range
@@ -1721,7 +1721,7 @@ let unicode_range = {
 ///
 /// - [Microsoft's OpenType Spec: cmap sub-table format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 14](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let default_uvs_table = {
+def default_uvs_table = {
     /// Number of Unicode character ranges.
     num_unicode_value_ranges <- u32be,
     /// Array of UnicodeRange records.
@@ -1737,7 +1737,7 @@ let default_uvs_table = {
 ///
 /// - [Microsoft's OpenType Spec: cmap sub-table format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 14](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let uvs_mapping = {
+def uvs_mapping = {
     /// Base Unicode value of the UVS
     unicode_value <- u24be,
     /// Glyph ID of the UVS
@@ -1752,7 +1752,7 @@ let uvs_mapping = {
 ///
 /// - [Microsoft's OpenType Spec: cmap sub-table format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 14](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let non_default_uvs_table = {
+def non_default_uvs_table = {
     /// Number of UVS Mappings that follow
     num_uvs_mappings <- u32be,
     /// Array of UVSMapping records.
@@ -1768,7 +1768,7 @@ let non_default_uvs_table = {
 ///
 /// - [Microsoft's OpenType Spec: cmap sub-table format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 14](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let variation_selector = fun (table_start : Pos) => {
+def variation_selector = fun (table_start : Pos) => {
     /// Variation selector
     var_selector <- u24be,
     /// Offset from the start of the format 14 subtable to Default UVS Table. May be 0.
@@ -1790,7 +1790,7 @@ let variation_selector = fun (table_start : Pos) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 0: Byte encoding table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 0](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format0 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format0 = fun (platform : Repr platform_id) => {
     /// The length of the subtable in bytes
     length <- u16be,
     /// The language ID of the subtable
@@ -1811,7 +1811,7 @@ let cmap_subtable_format0 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 2: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 2](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format2 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format2 = fun (platform : Repr platform_id) => {
     /// The length of the subtable in bytes
     length <- u16be,
     /// The language ID of the subtable
@@ -1835,7 +1835,7 @@ let cmap_subtable_format2 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 4: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 4](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format4 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format4 = fun (platform : Repr platform_id) => {
     /// The length of the subtable in bytes
     length <- u16be,
     /// The language ID of the subtable
@@ -1876,7 +1876,7 @@ let cmap_subtable_format4 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 6: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 6](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format6 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format6 = fun (platform : Repr platform_id) => {
     /// The length of the subtable in bytes
     length <- u16be,
     /// The language ID of the subtable
@@ -1900,7 +1900,7 @@ let cmap_subtable_format6 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 8: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 8](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format8 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format8 = fun (platform : Repr platform_id) => {
     /// Set to 0.
     _reserved <- reserved u16be 0,
     /// The length of the subtable in bytes (including the header)
@@ -1926,7 +1926,7 @@ let cmap_subtable_format8 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 10: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 10](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format10 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format10 = fun (platform : Repr platform_id) => {
     /// Set to 0.
     _reserved <- reserved u16be 0,
     /// The length of the subtable in bytes (including the header)
@@ -1950,7 +1950,7 @@ let cmap_subtable_format10 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 12: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 12](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format12 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format12 = fun (platform : Repr platform_id) => {
     /// Set to 0.
     _reserved <- reserved u16be 0,
     /// The length of the subtable in bytes (including the header)
@@ -1974,7 +1974,7 @@ let cmap_subtable_format12 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 13: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 13](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format13 = fun (platform : Repr platform_id) => {
+def cmap_subtable_format13 = fun (platform : Repr platform_id) => {
     /// Set to 0.
     _reserved <- reserved u16be 0,
     /// The length of the subtable in bytes (including the header)
@@ -1999,7 +1999,7 @@ let cmap_subtable_format13 = fun (platform : Repr platform_id) => {
 ///
 /// - [Microsoft's OpenType Spec: Format 14: Segment mapping to delta values](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
 /// - [Apple's TrueType Reference Manual: `'cmap'` format 14](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_subtable_format14 = fun (platform : Repr platform_id) => fun (table_start : Pos) => {
+def cmap_subtable_format14 = fun (platform : Repr platform_id) => fun (table_start : Pos) => {
     /// The length of the subtable in bytes (including the header)
     length <- u32be,
     /// Number of variation Selector Records
@@ -2009,7 +2009,7 @@ let cmap_subtable_format14 = fun (platform : Repr platform_id) => fun (table_sta
 };
 
 /// # Character Mapping subtable
-let cmap_subtable = fun (platform : Repr platform_id) => {
+def cmap_subtable = fun (platform : Repr platform_id) => {
     /// The start of the character mapping sub-table
     table_start <- stream_pos,
     /// Format number of the subtable
@@ -2034,7 +2034,7 @@ let cmap_subtable = fun (platform : Repr platform_id) => {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Encoding records and encodings](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#encoding-records-and-encodings)
-let encoding_record = fun (table_start : Pos) => {
+def encoding_record = fun (table_start : Pos) => {
     /// Platform identifier
     platform <- platform_id,
     /// Platform-specific encoding identifier
@@ -2049,7 +2049,7 @@ let encoding_record = fun (table_start : Pos) => {
 ///
 /// - [Microsoft's OpenType Spec: 'cmap' Header](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#cmap-header)
 /// - [Apple's TrueType Reference Manual: The `'cmap'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html)
-let cmap_table = {
+def cmap_table = {
     /// The start of the character mapping table
     table_start <- stream_pos,
     /// The version of the character
@@ -2078,7 +2078,7 @@ let cmap_table = {
 ///
 /// - [Microsoft's OpenType Spec: head — Font Header Table](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
 /// - [Apple's TrueType Reference Manual: The `'head'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6head.html)
-let head_table = {
+def head_table = {
     /// Major version number of the font header table.
     major_version <- u16be where u16_eq major_version 1,
     /// Minor version number of the font header table.
@@ -2180,7 +2180,7 @@ let head_table = {
 ///
 /// - [Microsoft's OpenType Spec: hhea — Horizontal Header Table](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea)
 /// - [Apple's TrueType Reference Manual: The `'hhea'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hhea.html)
-let hhea_table = {
+def hhea_table = {
     /// Major version number of the horizontal header table.
     major_version <- u16be where u16_eq major_version 1,
     /// Minor version number of the horizontal header table.
@@ -2234,7 +2234,7 @@ let hhea_table = {
 // - [Apple's TrueType Reference Manual: The `'hmtx'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hmtx.html)
 
 /// Horizontal metrics that provide an `advance_width`.
-let long_horizontal_metric = {
+def long_horizontal_metric = {
     /// Advance width, in font design units.
     advance_width <- u16be,
     /// Glyph left side bearing, in font design units.
@@ -2247,7 +2247,7 @@ let long_horizontal_metric = {
 ///
 /// - [Microsoft's OpenType Spec: hmtx — Horizontal Metrics Table](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx)
 /// - [Apple's TrueType Reference Manual: The `'hmtx'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hmtx.html)
-let htmx_table = fun (number_of_long_horizontal_metrics : U16) => fun (num_glyphs : U16) => {
+def htmx_table = fun (number_of_long_horizontal_metrics : U16) => fun (num_glyphs : U16) => {
     /// Long horizontal metrics, indexed by the glyph ID.
     h_metrics <- array16 number_of_long_horizontal_metrics long_horizontal_metric,
     /// Left side bearings for glyph IDs greater than or equal to the
@@ -2268,7 +2268,7 @@ let htmx_table = fun (number_of_long_horizontal_metrics : U16) => fun (num_glyph
 // - [Apple's TrueType Reference Manual: The `'maxp'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6maxp.html)
 
 /// Fields specific to maxp version 1.0
-let maxp_version_1 = {
+def maxp_version_1 = {
     /// Maximum points in non-composite glyphs.
     max_points <- u16be,
     /// Maximum contours in non-composite glyphs.
@@ -2317,7 +2317,7 @@ let maxp_version_1 = {
 ///
 /// - [Microsoft's OpenType Spec: maxp — Maximum Profile](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp)
 /// - [Apple's TrueType Reference Manual: The `'maxp'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6maxp.html)
-let maxp_table = {
+def maxp_table = {
     /// The version of the table
     version <- version16dot16,
     /// The number of glyphs in the font.
@@ -2353,7 +2353,7 @@ let maxp_table = {
 ///
 /// - [Microsoft's OpenType Spec: Name records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
 /// - [Apple's TrueType Reference Manual: The `'name'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6name.html)
-let name_record = fun (storage_start : Pos) => {
+def name_record = fun (storage_start : Pos) => {
     /// Platform identifier
     platform <- platform_id,
     /// Platform-specific encoding identifier
@@ -2387,8 +2387,8 @@ let name_record = fun (storage_start : Pos) => {
     /// | `20`          | PostScript font name                  |
     /// | `21`          | WWS family name                       |
     /// | `22`          | WWS subfamily name                    |
-    /// | `23`          | light background palette              |
-    /// | `24`          | dark background palette               |
+    /// | `23`          | light background padefte              |
+    /// | `24`          | dark background padefte               |
     /// | `25`          | variations PostScript name prefix     |
     /// | `26..<256`    | reserved                              |
     /// | `256..<32768` | font-specific names                   |
@@ -2405,14 +2405,14 @@ let name_record = fun (storage_start : Pos) => {
 ///
 /// - [Microsoft's OpenType Spec: Naming table header](https://docs.microsoft.com/en-us/typography/opentype/spec/name#naming-table-header)
 /// - [Apple's TrueType Reference Manual: The `'name'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6name.html)
-let lang_tag_record = fun (storage_start : Pos) => {
+def lang_tag_record = fun (storage_start : Pos) => {
     /// Language tag string length
     length <- u16be,
     /// Offset to the language tag string data
     offset <- offset16 storage_start (array16 length u8),
 };
 
-let name_version_1 = fun (storage_start : Pos) => {
+def name_version_1 = fun (storage_start : Pos) => {
     /// The number of language tags to expect
     lang_tag_count <- u16be,
     /// The array of language tag records
@@ -2425,7 +2425,7 @@ let name_version_1 = fun (storage_start : Pos) => {
 ///
 /// - [Microsoft's OpenType Spec: Naming table header](https://docs.microsoft.com/en-us/typography/opentype/spec/name#naming-table-header)
 /// - [Apple's TrueType Reference Manual: The `'name'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6name.html)
-let name_table = {
+def name_table = {
     /// The start of the naming table
     table_start <- stream_pos,
 
@@ -2452,7 +2452,7 @@ let name_table = {
 ///
 /// - [Microsoft's OpenType Spec: `loca` table](https://docs.microsoft.com/en-us/typography/opentype/spec/loca)
 /// - [Apple's TrueType Reference Manual: The `'loca'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6loca.html)
-let loca_table = fun (num_glyphs : U16) => fun (index_to_loc_format : S16) => {
+def loca_table = fun (num_glyphs : U16) => fun (index_to_loc_format : S16) => {
     offsets <- match index_to_loc_format {
         // short offsets
         0 => array16 (u16_add num_glyphs 1) u16be, // TODO Offset16
@@ -2468,7 +2468,7 @@ let loca_table = fun (num_glyphs : U16) => fun (index_to_loc_format : S16) => {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Headers](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
 /// - [Apple's TrueType Reference Manual: The `'loca'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html)
-let glyph_header = {
+def glyph_header = {
     /// If the number of contours is greater than or equal to zero, this is a simple glyph. If
     /// negative, this is a composite glyph — the value -1 should be used for composite glyphs.
     number_of_contours <- s16be,
@@ -2488,7 +2488,7 @@ let glyph_header = {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Headers](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#simple-glyph-description)
 /// - [Apple's TrueType Reference Manual: The `'loca'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html)
-let simple_glyph = fun (number_of_contours : U16) => {
+def simple_glyph = fun (number_of_contours : U16) => {
     /// Array of point indices for the last point of each contour, in increasing numeric order.
     end_pts_of_contours <- array16 number_of_contours u16be,
     /// Total number of bytes for instructions. If instructionLength is zero, no instructions are
@@ -2506,10 +2506,10 @@ let simple_glyph = fun (number_of_contours : U16) => {
     // or int16 <- uint8,
 };
 
-let args_are_signed = fun (flags : U16) =>
+def args_are_signed = fun (flags : U16) =>
     (u16_neq (u16_and flags 0x0002) 0);
 
-let arg_format = fun (flags : U16) =>
+def arg_format = fun (flags : U16) =>
     match (u16_neq (u16_and flags 0x0001) 0) {
         // If the bit is set the arguments are 16-bit
         true => match (args_are_signed flags) {
@@ -2529,7 +2529,7 @@ let arg_format = fun (flags : U16) =>
 ///
 /// - [Microsoft's OpenType Spec: Glyph Headers](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#composite-glyph-description)
 /// - [Apple's TrueType Reference Manual: The `'loca'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html)
-let composite_glyph = {
+def composite_glyph = {
     /// component flag
     flags <- u16be,
     /// glyph index of component
@@ -2541,7 +2541,7 @@ let composite_glyph = {
 };
 
 /// # TrueType glyph
-let glyph = {
+def glyph = {
     header <- glyph_header,
     data <- match (s16_lt header.number_of_contours 0) {
         true => composite_glyph,
@@ -2555,7 +2555,7 @@ let glyph = {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Data](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf)
 /// - [Apple's TrueType Reference Manual: The `'glyf'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html)
-let glyf_table = fun (num_glyphs : U16) => {
+def glyf_table = fun (num_glyphs : U16) => {
     glyphs <- array16 num_glyphs glyph,
 };
 
@@ -2567,7 +2567,7 @@ let glyf_table = fun (num_glyphs : U16) => {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Data](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#version-0)
 /// - [Apple's TrueType Reference Manual: The `'OS/2'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6OS2.html)
-let os2_version_0 = {
+def os2_version_0 = {
     s_typo_ascender <- s16be,
     s_typo_descender <- s16be,
     s_typo_line_gap <- s16be,
@@ -2581,7 +2581,7 @@ let os2_version_0 = {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Data](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#version-1)
 /// - [Apple's TrueType Reference Manual: The `'OS/2'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6OS2.html)
-let os2_version_1 = {
+def os2_version_1 = {
     version_0 <- os2_version_0,
     ul_code_page_range1 <- u32be,
     ul_code_page_range2 <- u32be,
@@ -2593,7 +2593,7 @@ let os2_version_1 = {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Data](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#version-2)
 /// - [Apple's TrueType Reference Manual: The `'OS/2'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6OS2.html)
-let os2_version_2_3_4 = {
+def os2_version_2_3_4 = {
     version_1 <- os2_version_1,
     sx_height <- s16be,
     s_cap_height <- s16be,
@@ -2608,7 +2608,7 @@ let os2_version_2_3_4 = {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Data](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#version-0)
 /// - [Apple's TrueType Reference Manual: The `'OS/2'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6OS2.html)
-let os2_version_5 = {
+def os2_version_5 = {
     parent <- os2_version_2_3_4,
     usLowerOpticalPointSize <- u16be,
     usUpperOpticalPointSize <- u16be,
@@ -2620,7 +2620,7 @@ let os2_version_5 = {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Data](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
 /// - [Apple's TrueType Reference Manual: The `'OS/2'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6OS2.html)
-let os2_table = fun (table_length : U32) => {
+def os2_table = fun (table_length : U32) => {
     version <- u16be,
     x_avg_char_width <- s16be,
     us_weight_class <- u16be,
@@ -2677,7 +2677,7 @@ let os2_table = fun (table_length : U32) => {
 ///
 /// - [Microsoft's OpenType Spec: Glyph Data](https://docs.microsoft.com/en-us/typography/opentype/spec/post)
 /// - [Apple's TrueType Reference Manual: The `'post'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6post.html)
-let post_table = {
+def post_table = {
     /// 0x00010000 for version 1.0 0x00020000 for version 2.0
     /// 0x00025000 for version 2.5 (deprecated) 0x00030000 for version 3.0
     version <- version16dot16,
@@ -2747,7 +2747,7 @@ let post_table = {
 //
 // - [Microsoft's OpenType Spec: BASE — Baseline Table](https://docs.microsoft.com/en-us/typography/opentype/spec/base)
 
-let base_table = unknown_table;
+def base_table = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -2761,7 +2761,7 @@ let base_table = unknown_table;
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Attachment Point List table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#attachment-point-list-table)
-let attach_list = (
+def attach_list = (
     /// AttachPoint table
     let attach_point_table = {
         /// Number of attachment points on this glyph
@@ -2788,7 +2788,7 @@ let attach_list = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Caret Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caret-value-tables)
-let caret_value = (
+def caret_value = (
     /// # Caret Value Format 1
     ///
     /// ## References
@@ -2841,7 +2841,7 @@ let caret_value = (
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Ligature Glyph Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-glyph-table)
-let lig_glyph = {
+def lig_glyph = {
     /// The start of the LigGlyph table
     table_start <- stream_pos,
     /// Number of CaretValue tables for this ligature (components - 1)
@@ -2856,7 +2856,7 @@ let lig_glyph = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Ligature Caret List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table)
-let lig_caret_list = {
+def lig_caret_list = {
     /// The start of the LigCaretList table
     table_start <- stream_pos,
     /// Offset to Coverage table - from beginning of LigCaretList table
@@ -2873,7 +2873,7 @@ let lig_caret_list = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Mark Glyph Sets Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#mark-glyph-sets-table)
-let mark_glyph_sets = {
+def mark_glyph_sets = {
     /// The start of the MarkGlyphSets table
     table_start <- stream_pos,
     /// Format identifier == 1
@@ -2890,7 +2890,7 @@ let mark_glyph_sets = {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: Glyph Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef)
-let gdef_table = (
+def gdef_table = (
     let gdef_header_version_1_2 = fun (gdef_start : Pos) => {
         /// Offset to the table of mark glyph set definitions, from beginning of GDEF header (may be
         /// NULL)
@@ -2937,7 +2937,7 @@ let gdef_table = (
 // -----------------------------------------------------------------------------
 
 /// Shared structure of GSUB and GPOS tables
-let layout_table = fun (tag : U32) => {
+def layout_table = fun (tag : U32) => {
     /// The start of the table
     table_start <- stream_pos,
     /// Major version of the table
@@ -2957,7 +2957,7 @@ let layout_table = fun (tag : U32) => {
 //
 // - [Microsoft's OpenType Spec: GPOS — Glyph Positioning Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos)
 
-let gpos_table = layout_table "GPOS";
+def gpos_table = layout_table "GPOS";
 
 
 // -----------------------------------------------------------------------------
@@ -2967,7 +2967,7 @@ let gpos_table = layout_table "GPOS";
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: GSUB — Glyph Substitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub)
-let gsub_table = layout_table "GSUB";
+def gsub_table = layout_table "GSUB";
 
 
 // -----------------------------------------------------------------------------
@@ -2976,7 +2976,7 @@ let gsub_table = layout_table "GSUB";
 //
 // - [Microsoft's OpenType Spec: JSTF — Justification Table](https://docs.microsoft.com/en-us/typography/opentype/spec/jstf)
 
-let jstf_table = unknown_table;
+def jstf_table = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -2985,7 +2985,7 @@ let jstf_table = unknown_table;
 //
 // - [Microsoft's OpenType Spec: MATH - The Mathematical Typesetting Table](https://docs.microsoft.com/en-us/typography/opentype/spec/math)
 
-let math_table = unknown_table;
+def math_table = unknown_table;
 
 
 // -----------------------------------------------------------------------------
@@ -3013,7 +3013,7 @@ let math_table = unknown_table;
 ///
 /// - [Microsoft's OpenType Spec: Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 /// - [Apple's TrueType Reference Manual: The Font Directory](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html#Directory)
-let table_record = {
+def table_record = {
     /// Table identifier.
     table_id <- tag,
     /// CheckSum for this table.
@@ -3029,7 +3029,7 @@ let table_record = {
 };
 
 /// Find a table record using the given `table_id`.
-let find_table =
+def find_table =
     fun (num_tables : U16) =>
     fun (table_records : Array16 num_tables (Repr table_record)) =>
     fun (table_id : Repr tag) =>
@@ -3042,7 +3042,7 @@ let find_table =
             table_records;
 
 /// Create a link to the given `table_format`.
-let link_table =
+def link_table =
     fun (file_start : Pos) =>
     fun (table_record : Repr table_record) =>
     fun (table_format : Format) =>
@@ -3058,7 +3058,7 @@ let link_table =
 ///
 /// - [Microsoft's OpenType Spec: Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 /// - [Apple's TrueType Reference Manual: The Font Directory](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html#Directory)
-let table_directory = fun (file_start : Pos) => {
+def table_directory = fun (file_start : Pos) => {
     /// Version of the font.
     ///
     /// | Value         | Meaning                                   |
@@ -3230,7 +3230,7 @@ let table_directory = fun (file_start : Pos) => {
 /// ## References
 ///
 /// - [Microsoft's OpenType Spec: TTC Header](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
-let ttc_header = fun (start : Pos) => (
+def ttc_header = fun (start : Pos) => (
     /// TTC Header Version 1.0
     let ttc_header1 = fun (start : Pos) => {
         /// Number of fonts in TTC
@@ -3279,7 +3279,7 @@ let ttc_header = fun (start : Pos) => (
 ///
 /// - [Microsoft's OpenType Spec: Organization of an OpenType Font](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#organization-of-an-opentype-font)
 /// - [Apple's TrueType Reference Manual: TrueType Font files](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html#Overview)
-let main = {
+def main = {
     /// The start of the font file.
     start <- stream_pos,
     /// The directory of tables in the font.
@@ -3296,8 +3296,3 @@ let main = {
         },
     },
 };
-
-
-// -----------------------------------------------------------------------------
-
-main

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -1,40 +1,44 @@
 stdout = '''
-let reserved : _ = fun format => fun default => format;
-let deprecated : _ = fun format => fun default => format;
-let fixed : Format = u32be;
-let fword : Format = s16be;
-let ufword : Format = u16be;
-let f2dot14 : Format = s16be;
-let u24be : Format = array8 3 u8;
-let long_date_time : Format = s64be;
-let tag : Format = u32be;
-let unknown_table : Format = {};
-let empty : Format = {};
-let offset16 : _ = fun base => fun format => {
+def reserved : fun (format : Format) -> fun (default : Repr format) -> Format =
+fun format => fun default => format;
+def deprecated : fun (format : Format) -> fun (default : Repr format) ->
+Format = fun format => fun default => format;
+def fixed : Format = u32be;
+def fword : Format = s16be;
+def ufword : Format = u16be;
+def f2dot14 : Format = s16be;
+def u24be : Format = array8 3 u8;
+def long_date_time : Format = s64be;
+def tag : Format = u32be;
+def unknown_table : Format = {};
+def empty : Format = {};
+def offset16 : fun (base : Pos) -> fun (format : Format) -> Format =
+fun base => fun format => {
     offset <- u16be,
     link <- match offset {
         0 => empty,
         _ => link (pos_add_u16 base offset) format,
     },
 };
-let offset32 : _ = fun base => fun format => {
+def offset32 : fun (base : Pos) -> fun (format : Format) -> Format =
+fun base => fun format => {
     offset <- u32be,
     link <- match offset {
         0 => empty,
         _ => link (pos_add_u32 base offset) format,
     },
 };
-let version16dot16 : _ = u32be;
-let platform_id : _ = u16be;
-let encoding_id : _ = fun platform => u16be;
-let language_id : _ = u16be;
-let language_id32 : _ = u32be;
-let class_def_format_1 : _ = {
+def version16dot16 : Format = u32be;
+def platform_id : Format = u16be;
+def encoding_id : fun (platform : U16) -> Format = fun platform => u16be;
+def language_id : Format = u16be;
+def language_id32 : Format = u32be;
+def class_def_format_1 : Format = {
     start_glyph_id <- u16be,
     glyph_count <- u16be,
     class_value_array <- array16 glyph_count u16be,
 };
-let class_def_format_2 : _ = let class_range_record : _ = {
+def class_def_format_2 : Format = let class_range_record : _ = {
     start_glyph_id <- u16be,
     end_glyph_id <- u16be,
     class <- u16be,
@@ -43,7 +47,7 @@ let class_def_format_2 : _ = let class_range_record : _ = {
     class_range_count <- u16be,
     class_range_records <- array16 class_range_count class_range_record,
 };
-let class_def : _ = {
+def class_def : Format = {
     class_format <- u16be,
     data <- match class_format {
         1 => class_def_format_1,
@@ -51,17 +55,17 @@ let class_def : _ = {
         _ => unknown_table,
     },
 };
-let coverage_format_1 : _ = {
+def coverage_format_1 : Format = {
     glyph_count <- u16be,
     glyph_array <- array16 glyph_count u16be,
 };
-let coverage_format_2 : _ = let range_record : _ = {
+def coverage_format_2 : Format = let range_record : _ = {
     start_glyph_id <- u16be,
     end_glyph_id <- u16be,
     start_coverage_index <- u16be,
 };
 { range_count <- u16be, range_records <- array16 range_count range_record };
-let coverage_table : _ = {
+def coverage_table : Format = {
     coverage_format <- u16be,
     data <- match coverage_format {
         1 => coverage_format_1,
@@ -69,11 +73,11 @@ let coverage_table : _ = {
         _ => unknown_table,
     },
 };
-let sequence_lookup_record : _ = {
+def sequence_lookup_record : Format = {
     sequence_index <- u16be,
     lookup_list_index <- u16be,
 };
-let device_table : _ = let u16_div_ceil : _ =
+def device_table : Format = let u16_div_ceil : _ =
 fun numerator => fun denominator => let quotient : _ numerator denominator =
 u16_div numerator denominator;
 match (u16_lt (u16_mul quotient denominator) numerator) {
@@ -95,11 +99,11 @@ let num_sizes : _ = fun start => fun end => u16_add (u16_sub end start) 1;
     delta_bits delta_format (num_sizes start_size end_size);
     array16 (u16_div_ceil delta_bits 16) u16be,
 };
-let variation_index_table : _ = {
+def variation_index_table : Format = {
     delta_set_outer_index <- u16be,
     delta_set_inner_index <- u16be,
 };
-let device_or_variation_index_table : _ = overlap {
+def device_or_variation_index_table : Format = overlap {
     init <- { _skipped <- array8 4 u8, table_format <- u16be },
     table <- match init.table_format {
         0x1 => device_table,
@@ -109,23 +113,23 @@ let device_or_variation_index_table : _ = overlap {
         _ => unknown_table,
     },
 };
-let lang_sys : _ = {
+def lang_sys : Format = {
     lookup_order_offset <- u16be,
     required_feature_index <- u16be,
     feature_index_count <- u16be,
     feature_indices <- array16 feature_index_count u16be,
 };
-let lang_sys_record : _ = fun script_start => {
+def lang_sys_record : fun (script_start : Pos) -> Format = fun script_start => {
     lang_sys_tag <- tag,
     lang_sys <- offset16 script_start lang_sys,
 };
-let script_table : _ = {
+def script_table : Format = {
     table_start <- stream_pos,
     default_lang_sys <- offset16 table_start lang_sys,
     lang_sys_count <- u16be,
     lang_sys_records <- array16 lang_sys_count (lang_sys_record table_start),
 };
-let script_list : _ = let script_record : _ = fun script_list_start => {
+def script_list : Format = let script_record : _ = fun script_list_start => {
     script_tag <- tag,
     script <- offset16 script_list_start script_table,
 };
@@ -134,13 +138,13 @@ let script_list : _ = let script_record : _ = fun script_list_start => {
     script_count <- u16be,
     script_records <- array16 script_count (script_record table_start),
 };
-let feature_table : _ = {
+def feature_table : Format = {
     table_start <- stream_pos,
     feature_params <- u16be,
     lookup_index_count <- u16be,
     lookup_list_indices <- array16 lookup_index_count u16be,
 };
-let feature_list : _ = let feature_record : _ = fun feature_list_start => {
+def feature_list : Format = let feature_record : _ = fun feature_list_start => {
     feature_tag <- tag,
     feature <- offset16 feature_list_start feature_table,
 };
@@ -149,7 +153,7 @@ let feature_list : _ = let feature_record : _ = fun feature_list_start => {
     feature_count <- u16be,
     feature_records <- array16 feature_count (feature_record table_start),
 };
-let sequence_context_format1 : _ = let sequence_rule : _ = {
+def sequence_context_format1 : Format = let sequence_rule : _ = {
     glyph_count <- u16be,
     seq_lookup_count <- u16be,
     input_sequence <- array16 (u16_sub glyph_count 1) u16be,
@@ -166,7 +170,7 @@ let sequence_rule_set : _ = {
     seq_rule_set_count <- u16be,
     seq_rule_sets <- array16 seq_rule_set_count (offset16 table_start sequence_rule_set),
 };
-let sequence_context_format2 : _ = let class_sequence_rule : _ = {
+def sequence_context_format2 : Format = let class_sequence_rule : _ = {
     glyph_count <- u16be,
     seq_lookup_count <- u16be,
     input_sequence <- array16 (u16_sub glyph_count 1) u16be,
@@ -184,14 +188,14 @@ let class_sequence_rule_set : _ = {
     class_seq_rule_set_count <- u16be,
     class_seq_rule_sets <- array16 class_seq_rule_set_count (offset16 table_start class_sequence_rule_set),
 };
-let sequence_context_format3 : _ = {
+def sequence_context_format3 : Format = {
     table_start <- stream_pos,
     glyph_count <- u16be,
     seq_lookup_count <- u16be,
     coverage_tables <- array16 glyph_count (offset16 table_start coverage_table),
     seq_lookup_records <- array16 seq_lookup_count sequence_lookup_record,
 };
-let sequence_context : _ = {
+def sequence_context : Format = {
     format <- u16be,
     subst <- match format {
         1 => sequence_context_format1,
@@ -200,7 +204,8 @@ let sequence_context : _ = {
         _ => unknown_table,
     },
 };
-let chained_sequence_context_format_1 : _ = let chained_sequence_rule : _ = {
+def chained_sequence_context_format_1 : Format = let chained_sequence_rule : _ =
+{
     backtrack_glyph_count <- u16be,
     backtrack_sequence <- array16 backtrack_glyph_count u16be,
     input_glyph_count <- u16be,
@@ -221,8 +226,8 @@ let chained_sequence_rule_set : _ = {
     chained_seq_rule_set_count <- u16be,
     chained_seq_rule_sets <- array16 chained_seq_rule_set_count (offset16 table_start chained_sequence_rule_set),
 };
-let chained_sequence_context_format_2 : _ = let chained_class_sequence_rule :
-_ = {
+def chained_sequence_context_format_2 : Format =
+let chained_class_sequence_rule : _ = {
     backtrack_glyph_count <- u16be,
     backtrack_sequence <- array16 backtrack_glyph_count u16be,
     input_glyph_count <- u16be,
@@ -246,7 +251,7 @@ let chained_class_sequence_rule_set : _ = {
     chained_class_seq_rule_set_count <- u16be,
     chained_class_seq_rule_sets <- array16 chained_class_seq_rule_set_count (offset16 table_start chained_class_sequence_rule_set),
 };
-let chained_sequence_context_format_3 : _ = {
+def chained_sequence_context_format_3 : Format = {
     table_start <- stream_pos,
     backtrack_glyph_count <- u16be,
     backtrack_coverages <- array16 backtrack_glyph_count (offset16 table_start coverage_table),
@@ -257,7 +262,7 @@ let chained_sequence_context_format_3 : _ = {
     seq_lookup_count <- u16be,
     seq_lookup_records <- array16 seq_lookup_count sequence_lookup_record,
 };
-let chained_sequence_context : _ = {
+def chained_sequence_context : Format = {
     format <- u16be,
     subst <- match format {
         1 => sequence_context_format1,
@@ -266,7 +271,7 @@ let chained_sequence_context : _ = {
         _ => unknown_table,
     },
 };
-let single_substitution : _ = {
+def single_substitution : Format = {
     table_start <- stream_pos,
     subst_format <- u16be,
     subst <- match subst_format {
@@ -282,7 +287,7 @@ let single_substitution : _ = {
         _ => unknown_table,
     },
 };
-let multiple_substitution : _ = let sequence_table : _ = {
+def multiple_substitution : Format = let sequence_table : _ = {
     glyph_count <- u16be,
     substitute_glyph_ids <- array16 glyph_count u16be,
 };
@@ -298,7 +303,7 @@ let multiple_substitution : _ = let sequence_table : _ = {
         _ => unknown_table,
     },
 };
-let alternate_substitution : _ = let alternate_set : _ = {
+def alternate_substitution : Format = let alternate_set : _ = {
     glyph_count <- u16be,
     alternate_glyph_ids <- array16 glyph_count u16be,
 };
@@ -314,7 +319,7 @@ let alternate_substitution : _ = let alternate_set : _ = {
         _ => unknown_table,
     },
 };
-let ligature_substitution : _ = let ligature_table : _ = {
+def ligature_substitution : Format = let ligature_table : _ = {
     ligature_glyph <- u16be,
     component_count <- u16be,
     component_glyph_ids <- array16 (u16_sub component_count 1) u16be,
@@ -336,9 +341,9 @@ let ligature_set : _ = {
         _ => unknown_table,
     },
 };
-let contextual_substitution : _ = sequence_context;
-let chained_contexts_substitution : _ = chained_sequence_context;
-let reverse_chaining_contextual_single_substitution : _ =
+def contextual_substitution : Format = sequence_context;
+def chained_contexts_substitution : Format = chained_sequence_context;
+def reverse_chaining_contextual_single_substitution : Format =
 let reverse_chain_single_subst_format1 : _ = {
     table_start <- stream_pos,
     coverage <- offset16 table_start coverage_table,
@@ -356,7 +361,7 @@ let reverse_chain_single_subst_format1 : _ = {
         _ => unknown_table,
     },
 };
-let extension_substitution : _ = let extension_subst_format1 : _ = {
+def extension_substitution : Format = let extension_subst_format1 : _ = {
     table_start <- stream_pos,
     extension_lookup_type <- u16be,
     extension_subtable <- match extension_lookup_type {
@@ -378,8 +383,8 @@ let extension_substitution : _ = let extension_subst_format1 : _ = {
         _ => unknown_table,
     },
 };
-let value_record : _ = fun table_start => fun flags => let X_PLACEMENT : U16 =
-0x1;
+def value_record : fun (table_start : Pos) -> fun (flags : U16) -> Format =
+fun table_start => fun flags => let X_PLACEMENT : U16 = 0x1;
 let Y_PLACEMENT : U16 = 0x2;
 let X_ADVANCE : U16 = 0x4;
 let Y_ADVANCE : U16 = 0x8;
@@ -402,12 +407,12 @@ fun field => fun format => match (u16_neq (u16_and flags field) 0) {
     x_adv_device_offset <- optional_field X_ADVANCE_DEVICE (offset16 table_start device_or_variation_index_table),
     y_adv_device_offset <- optional_field Y_ADVANCE_DEVICE (offset16 table_start device_or_variation_index_table),
 };
-let optional_value_record : _ =
-fun table_start => fun flags => match (u16_eq flags 0) {
+def optional_value_record : fun (table_start : Pos) -> fun (flags : U16) ->
+Format = fun table_start => fun flags => match (u16_eq flags 0) {
     false => value_record table_start flags,
     true => empty,
 };
-let anchor_table : _ = {
+def anchor_table : Format = {
     table_start <- stream_pos,
     anchor_format <- u16be,
     table <- match anchor_format {
@@ -426,7 +431,7 @@ let anchor_table : _ = {
         _ => unknown_table,
     },
 };
-let mark_array_table : _ = let mark_record : _ = fun table_start => {
+def mark_array_table : Format = let mark_record : _ = fun table_start => {
     mark_class <- u16be,
     mark_anchor_offset <- offset16 table_start anchor_table,
 };
@@ -435,7 +440,8 @@ let mark_array_table : _ = let mark_record : _ = fun table_start => {
     mark_count <- u16be,
     mark_records <- array16 mark_count (mark_record table_start),
 };
-let single_adjustment : _ = let single_pos_format1 : _ = fun table_start => {
+def single_adjustment : Format = let single_pos_format1 : _ =
+fun table_start => {
     coverage_offset <- offset16 table_start coverage_table,
     value_format <- u16be,
     value_record <- value_record table_start value_format,
@@ -455,7 +461,7 @@ let single_pos_format2 : _ = fun table_start => {
         _ => unknown_table,
     },
 };
-let pair_adjustment : _ = let pair_value_record : _ =
+def pair_adjustment : Format = let pair_value_record : _ =
 fun table_start => fun value_format1 => fun value_format2 => {
     second_glyph <- u16be,
     value_record1 <- optional_value_record table_start value_format1,
@@ -501,7 +507,8 @@ let pair_pos_format2 : _ = fun pair_pos_start => {
         _ => unknown_table,
     },
 };
-let cursive_attachment : _ = let entry_exit_record : _ = fun table_start => {
+def cursive_attachment : Format = let entry_exit_record : _ =
+fun table_start => {
     entry_anchor <- offset16 table_start anchor_table,
     exit_anchor <- offset16 table_start anchor_table,
 };
@@ -518,7 +525,7 @@ let cursive_pos_format1 : _ = fun table_start => {
         _ => unknown_table,
     },
 };
-let mark_to_base_attachment : _ = let base_record : _ =
+def mark_to_base_attachment : Format = let base_record : _ =
 fun table_start => fun mark_class_count => {
     base_anchors <- array16 mark_class_count (offset16 table_start anchor_table),
 };
@@ -541,7 +548,7 @@ let mark_base_pos_format1 : _ = fun table_start => {
         _ => unknown_table,
     },
 };
-let mark_to_ligature_attachment : _ = let component_record : _ =
+def mark_to_ligature_attachment : Format = let component_record : _ =
 fun table_start => fun mark_class_count => {
     ligature_anchors <- array16 mark_class_count (offset16 table_start anchor_table),
 };
@@ -568,10 +575,10 @@ let mark_lig_pos_format1 : _ = fun table_start => {
         _ => unknown_table,
     },
 };
-let mark_to_mark_attachment : _ = mark_to_base_attachment;
-let contextual_positioning : _ = sequence_context;
-let chained_contexts_positioning : _ = chained_sequence_context;
-let extension_positioning : _ = let extension_pos_format1 : _ = {
+def mark_to_mark_attachment : Format = mark_to_base_attachment;
+def contextual_positioning : Format = sequence_context;
+def chained_contexts_positioning : Format = chained_sequence_context;
+def extension_positioning : Format = let extension_pos_format1 : _ = {
     table_start <- stream_pos,
     extension_lookup_type <- u16be,
     extension_subtable <- match extension_lookup_type {
@@ -593,7 +600,8 @@ let extension_positioning : _ = let extension_pos_format1 : _ = {
         _ => unknown_table,
     },
 };
-let lookup_table : _ = fun tag => let USE_MARK_FILTERING_SET : U16 = 0x10;
+def lookup_table : fun (tag : U32) -> Format =
+fun tag => let USE_MARK_FILTERING_SET : U16 = 0x10;
 let lookup_subtable : _ tag = fun tag => fun lookup_type => match tag {
     "GPOS" => match lookup_type {
         1 => single_adjustment,
@@ -631,49 +639,52 @@ let lookup_subtable : _ tag = fun tag => fun lookup_type => match tag {
         true => u16be,
     },
 };
-let lookup_list : _ = fun tag => {
+def lookup_list : fun (tag : U32) -> Format = fun tag => {
     table_start <- stream_pos,
     lookup_count <- u16be,
     lookups <- array16 lookup_count (offset16 table_start (lookup_table tag)),
 };
-let cmap_language_id : _ = fun platform => language_id;
-let cmap_language_id32 : _ = fun platform => language_id32;
-let small_glyph_id : _ = u8;
-let sequential_map_group : _ = {
+def cmap_language_id : fun (platform : U16) -> Format =
+fun platform => language_id;
+def cmap_language_id32 : fun (platform : U16) -> Format =
+fun platform => language_id32;
+def small_glyph_id : Format = u8;
+def sequential_map_group : Format = {
     start_char_code <- u32be,
     end_char_code <- u32be,
     start_glyph_id <- u32be,
 };
-let constant_map_group : _ = sequential_map_group;
-let unicode_range : _ = {
+def constant_map_group : Format = sequential_map_group;
+def unicode_range : Format = {
     start_unicode_value <- u24be,
     additional_count <- u8,
 };
-let default_uvs_table : _ = {
+def default_uvs_table : Format = {
     num_unicode_value_ranges <- u32be,
     ranges <- array32 num_unicode_value_ranges unicode_range,
 };
-let uvs_mapping : _ = { unicode_value <- u24be, glyph_id <- u16be };
-let non_default_uvs_table : _ = {
+def uvs_mapping : Format = { unicode_value <- u24be, glyph_id <- u16be };
+def non_default_uvs_table : Format = {
     num_uvs_mappings <- u32be,
     uvs_mappings <- array32 num_uvs_mappings uvs_mapping,
 };
-let variation_selector : _ = fun table_start => {
+def variation_selector : fun (table_start : Pos) -> Format =
+fun table_start => {
     var_selector <- u24be,
     default_uvs_offset <- offset32 table_start default_uvs_table,
     non_default_uvs_offset <- offset32 table_start non_default_uvs_table,
 };
-let cmap_subtable_format0 : _ = fun platform => {
+def cmap_subtable_format0 : fun (platform : U16) -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     glyph_id_array <- array16 256 small_glyph_id,
 };
-let cmap_subtable_format2 : _ = fun platform => {
+def cmap_subtable_format2 : fun (platform : U16) -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     sub_header_keys <- array16 256 u16be,
 };
-let cmap_subtable_format4 : _ = fun platform => {
+def cmap_subtable_format4 : fun (platform : U16) -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     seg_count_x2 <- u16be,
@@ -687,14 +698,14 @@ let cmap_subtable_format4 : _ = fun platform => {
     id_delta <- array16 seg_count s16be,
     id_range_offsets <- array16 seg_count u16be,
 };
-let cmap_subtable_format6 : _ = fun platform => {
+def cmap_subtable_format6 : fun (platform : U16) -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     first_code <- u16be,
     entry_count <- u16be,
     glyph_id_array <- array16 entry_count u16be,
 };
-let cmap_subtable_format8 : _ = fun platform => {
+def cmap_subtable_format8 : fun (platform : U16) -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
@@ -702,7 +713,7 @@ let cmap_subtable_format8 : _ = fun platform => {
     num_groups <- u32be,
     groups <- array32 num_groups sequential_map_group,
 };
-let cmap_subtable_format10 : _ = fun platform => {
+def cmap_subtable_format10 : fun (platform : U16) -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
@@ -710,26 +721,27 @@ let cmap_subtable_format10 : _ = fun platform => {
     num_chars <- u32be,
     glyph_id_array <- array32 num_chars u16be,
 };
-let cmap_subtable_format12 : _ = fun platform => {
+def cmap_subtable_format12 : fun (platform : U16) -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
     num_groups <- u32be,
     groups <- array32 num_groups sequential_map_group,
 };
-let cmap_subtable_format13 : _ = fun platform => {
+def cmap_subtable_format13 : fun (platform : U16) -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
     num_groups <- u32be,
     groups <- array32 num_groups constant_map_group,
 };
-let cmap_subtable_format14 : _ = fun platform => fun table_start => {
+def cmap_subtable_format14 : fun (platform : U16) -> fun (table_start : Pos) ->
+Format = fun platform => fun table_start => {
     length <- u32be,
     num_var_selector_records <- u32be,
     var_selector <- array32 num_var_selector_records (variation_selector table_start),
 };
-let cmap_subtable : _ = fun platform => {
+def cmap_subtable : fun (platform : U16) -> Format = fun platform => {
     table_start <- stream_pos,
     format <- u16be,
     data <- match format {
@@ -745,18 +757,18 @@ let cmap_subtable : _ = fun platform => {
         _ => unknown_table,
     },
 };
-let encoding_record : _ = fun table_start => {
+def encoding_record : fun (table_start : Pos) -> Format = fun table_start => {
     platform <- platform_id,
     encoding <- encoding_id platform,
     subtable_offset <- offset32 table_start (cmap_subtable platform),
 };
-let cmap_table : _ = {
+def cmap_table : Format = {
     table_start <- stream_pos,
     version <- u16be,
     num_tables <- u16be,
     encoding_records <- array16 num_tables (encoding_record table_start),
 };
-let head_table : _ = {
+def head_table : Format = {
     major_version <- u16be where u16_eq major_version 1,
     minor_version <- u16be,
     font_revision <- fixed,
@@ -778,7 +790,7 @@ let head_table : _ = {
     index_to_loc_format <- s16be,
     glyph_data_format <- s16be,
 };
-let hhea_table : _ = {
+def hhea_table : Format = {
     major_version <- u16be where u16_eq major_version 1,
     minor_version <- u16be,
     ascent <- fword,
@@ -797,16 +809,17 @@ let hhea_table : _ = {
     metric_data_format <- s16be,
     number_of_long_horizontal_metrics <- u16be,
 };
-let long_horizontal_metric : _ = {
+def long_horizontal_metric : Format = {
     advance_width <- u16be,
     left_side_bearing <- s16be,
 };
-let htmx_table : _ =
+def htmx_table : fun (number_of_long_horizontal_metrics : U16) ->
+fun (num_glyphs : U16) -> Format =
 fun number_of_long_horizontal_metrics => fun num_glyphs => {
     h_metrics <- array16 number_of_long_horizontal_metrics long_horizontal_metric,
     left_side_bearings <- array16 (u16_sub num_glyphs number_of_long_horizontal_metrics) s16be,
 };
-let maxp_version_1 : _ = {
+def maxp_version_1 : Format = {
     max_points <- u16be,
     max_contours <- u16be,
     max_composite_points <- u16be,
@@ -821,12 +834,12 @@ let maxp_version_1 : _ = {
     max_component_elements <- u16be,
     max_component_depth <- u16be where u16_lte max_component_depth 16,
 };
-let maxp_table : _ = {
+def maxp_table : Format = {
     version <- version16dot16,
     num_glyphs <- u16be,
     data <- match version { 0x10000 => maxp_version_1, _ => unknown_table },
 };
-let name_record : _ = fun storage_start => {
+def name_record : fun (storage_start : Pos) -> Format = fun storage_start => {
     platform <- platform_id,
     encoding <- encoding_id platform,
     language <- language_id,
@@ -834,15 +847,17 @@ let name_record : _ = fun storage_start => {
     length <- u16be,
     offset <- offset16 storage_start (array16 length u8),
 };
-let lang_tag_record : _ = fun storage_start => {
+def lang_tag_record : fun (storage_start : Pos) -> Format =
+fun storage_start => {
     length <- u16be,
     offset <- offset16 storage_start (array16 length u8),
 };
-let name_version_1 : _ = fun storage_start => {
+def name_version_1 : fun (storage_start : Pos) -> Format =
+fun storage_start => {
     lang_tag_count <- u16be,
     lang_tag_records <- array16 lang_tag_count (lang_tag_record storage_start),
 };
-let name_table : _ = {
+def name_table : Format = {
     table_start <- stream_pos,
     version <- u16be,
     name_count <- u16be,
@@ -854,57 +869,63 @@ let name_table : _ = {
         _ => unknown_table,
     },
 };
-let loca_table : _ = fun num_glyphs => fun index_to_loc_format => {
+def loca_table : fun (num_glyphs : U16) -> fun (index_to_loc_format : S16) ->
+Format = fun num_glyphs => fun index_to_loc_format => {
     offsets <- match index_to_loc_format {
         0 => array16 (u16_add num_glyphs 1) u16be,
         1 => array16 (u16_add num_glyphs 1) u32be,
         _ => unknown_table,
     },
 };
-let glyph_header : _ = {
+def glyph_header : Format = {
     number_of_contours <- s16be,
     x_min <- s16be,
     y_min <- s16be,
     x_max <- s16be,
     y_max <- s16be,
 };
-let simple_glyph : _ = fun number_of_contours => {
+def simple_glyph : fun (number_of_contours : U16) -> Format =
+fun number_of_contours => {
     end_pts_of_contours <- array16 number_of_contours u16be,
     instruction_length <- u16be,
     instructions <- array16 instruction_length u8,
 };
-let args_are_signed : _ = fun flags => u16_neq (u16_and flags 0x2) 0;
-let arg_format : _ = fun flags => match (u16_neq (u16_and flags 0x1) 0) {
+def args_are_signed : fun (flags : U16) -> Bool =
+fun flags => u16_neq (u16_and flags 0x2) 0;
+def arg_format : fun (flags : U16) -> Format =
+fun flags => match (u16_neq (u16_and flags 0x1) 0) {
     false => match (args_are_signed flags) { false => u8, true => s8 },
     true => match (args_are_signed flags) { false => u16be, true => s16be },
 };
-let composite_glyph : _ = {
+def composite_glyph : Format = {
     flags <- u16be,
     glyphIndex <- u16be,
     argument1 <- arg_format flags,
     argument2 <- arg_format flags,
 };
-let glyph : _ = {
+def glyph : Format = {
     header <- glyph_header,
     data <- match (s16_lt header.number_of_contours 0) {
         false => simple_glyph (s16_unsigned_abs header.number_of_contours),
         true => composite_glyph,
     },
 };
-let glyf_table : _ = fun num_glyphs => { glyphs <- array16 num_glyphs glyph };
-let os2_version_0 : _ = {
+def glyf_table : fun (num_glyphs : U16) -> Format = fun num_glyphs => {
+    glyphs <- array16 num_glyphs glyph,
+};
+def os2_version_0 : Format = {
     s_typo_ascender <- s16be,
     s_typo_descender <- s16be,
     s_typo_line_gap <- s16be,
     us_win_ascent <- u16be,
     usWinDescent <- u16be,
 };
-let os2_version_1 : _ = {
+def os2_version_1 : Format = {
     version_0 <- os2_version_0,
     ul_code_page_range1 <- u32be,
     ul_code_page_range2 <- u32be,
 };
-let os2_version_2_3_4 : _ = {
+def os2_version_2_3_4 : Format = {
     version_1 <- os2_version_1,
     sx_height <- s16be,
     s_cap_height <- s16be,
@@ -912,12 +933,12 @@ let os2_version_2_3_4 : _ = {
     us_break_char <- u16be,
     us_max_context <- u16be,
 };
-let os2_version_5 : _ = {
+def os2_version_5 : Format = {
     parent <- os2_version_2_3_4,
     usLowerOpticalPointSize <- u16be,
     usUpperOpticalPointSize <- u16be,
 };
-let os2_table : _ = fun table_length => {
+def os2_table : fun (table_length : U32) -> Format = fun table_length => {
     version <- u16be,
     x_avg_char_width <- s16be,
     us_weight_class <- u16be,
@@ -956,7 +977,7 @@ let os2_table : _ = fun table_length => {
         _ => os2_version_5,
     },
 };
-let post_table : _ = {
+def post_table : Format = {
     version <- version16dot16,
     italic_angle <- fixed,
     underline_position <- fword,
@@ -978,8 +999,8 @@ let post_table : _ = {
         _ => {},
     },
 };
-let base_table : _ = unknown_table;
-let attach_list : _ = let attach_point_table : _ = {
+def base_table : Format = unknown_table;
+def attach_list : Format = let attach_point_table : _ = {
     point_count <- u16be,
     point_indices <- array16 point_count u16be,
 };
@@ -989,7 +1010,9 @@ let attach_list : _ = let attach_point_table : _ = {
     glyph_count <- u16be,
     attach_point_offsets <- array16 glyph_count (offset16 table_start attach_point_table),
 };
-let caret_value : _ = let caret_value_format_1 : _ = { coordinate <- s16be };
+def caret_value : Format = let caret_value_format_1 : _ = {
+    coordinate <- s16be,
+};
 let caret_value_format_2 : _ = { caret_value_point_index <- u16be };
 let caret_value_format_3 : _ = fun table_start => {
     coordinate <- s16be,
@@ -1005,24 +1028,24 @@ let caret_value_format_3 : _ = fun table_start => {
         _ => unknown_table,
     },
 };
-let lig_glyph : _ = {
+def lig_glyph : Format = {
     table_start <- stream_pos,
     caret_count <- u16be,
     caret_values <- array16 caret_count (offset16 table_start caret_value),
 };
-let lig_caret_list : _ = {
+def lig_caret_list : Format = {
     table_start <- stream_pos,
     coverage <- offset16 table_start coverage_table,
     lig_glyph_count <- u16be,
     lig_glyph_offsets <- array16 lig_glyph_count (offset16 table_start lig_glyph),
 };
-let mark_glyph_sets : _ = {
+def mark_glyph_sets : Format = {
     table_start <- stream_pos,
     format <- u16be,
     mark_glyph_set_count <- u16be,
     coverage <- array16 mark_glyph_set_count (offset32 table_start coverage_table),
 };
-let gdef_table : _ = let gdef_header_version_1_2 : _ = fun gdef_start => {
+def gdef_table : Format = let gdef_header_version_1_2 : _ = fun gdef_start => {
     mark_glyph_sets_def <- offset16 gdef_start mark_glyph_sets,
 };
 let gdef_header_version_1_3 : _ = fun gdef_start => { item_var_store <- u32be };
@@ -1042,7 +1065,7 @@ let gdef_header_version_1_3 : _ = fun gdef_start => { item_var_store <- u32be };
         _ => gdef_header_version_1_3 table_start,
     },
 };
-let layout_table : _ = fun tag => {
+def layout_table : fun (tag : U32) -> Format = fun tag => {
     table_start <- stream_pos,
     major_version <- u16be where u16_eq major_version 1,
     minor_version <- u16be,
@@ -1050,21 +1073,37 @@ let layout_table : _ = fun tag => {
     feature_list <- offset16 table_start feature_list,
     lookup_list <- offset16 table_start (lookup_list tag),
 };
-let gpos_table : _ = layout_table "GPOS";
-let gsub_table : _ = layout_table "GSUB";
-let jstf_table : _ = unknown_table;
-let math_table : _ = unknown_table;
-let table_record : _ = {
+def gpos_table : Format = layout_table "GPOS";
+def gsub_table : Format = layout_table "GSUB";
+def jstf_table : Format = unknown_table;
+def math_table : Format = unknown_table;
+def table_record : Format = {
     table_id <- tag,
     checksum <- u32be,
     offset <- u32be,
     length <- u32be,
 };
-let find_table : _ =
+def find_table : fun (num_tables : U16) -> fun (table_records :
+Array16 num_tables {
+    table_id : U32,
+    checksum : U32,
+    offset : U32,
+    length : U32,
+}) -> fun (table_id : U32) -> Option {
+    table_id : U32,
+    checksum : U32,
+    offset : U32,
+    length : U32,
+} =
 fun num_tables => fun table_records => fun table_id => array16_find (_ num_tables table_records table_id) (Repr table_record) (fun table_record => u32_eq table_record.table_id table_id) table_records;
-let link_table : _ =
+def link_table : fun (file_start : Pos) -> fun (table_record : {
+    table_id : U32,
+    checksum : U32,
+    offset : U32,
+    length : U32,
+}) -> fun (table_format : Format) -> Format =
 fun file_start => fun table_record => fun table_format => link (pos_add_u32 file_start table_record.offset) (limit32 table_record.length table_format);
-let table_directory : _ = fun file_start => {
+def table_directory : fun (file_start : Pos) -> Format = fun file_start => {
     sfnt_version <- u32be where bool_or (u32_eq sfnt_version 0x10000) (u32_eq sfnt_version "OTTO"),
     num_tables <- u16be,
     search_range <- u16be,
@@ -1150,7 +1189,8 @@ let table_directory : _ = fun file_start => {
         vmtx <- optional_table "vmtx" unknown_table,
     },
 };
-let ttc_header : _ = fun start => let ttc_header1 : _ start = fun start => {
+def ttc_header : fun (start : Pos) -> Format = fun start => let ttc_header1 :
+_ start = fun start => {
     num_fonts <- u32be,
     table_directories <- array32 num_fonts (offset32 start (table_directory start)),
 };
@@ -1171,7 +1211,7 @@ let ttc_header2 : _ start = fun start => {
         _ => unknown_table,
     },
 };
-let main : _ = {
+def main : Format = {
     start <- stream_pos,
     font <- overlap {
         magic <- u32be,
@@ -1183,6 +1223,5 @@ let main : _ = {
         },
     },
 };
-main : Format
 '''
 stderr = ''

--- a/formats/stl-binary.fathom
+++ b/formats/stl-binary.fathom
@@ -13,22 +13,20 @@
 // - SolidView
 // - Materialise Magics
 
-let vec3d = {
+def vec3d = {
     x <- f32le,
     y <- f32le,
     z <- f32le,
 };
 
-let triangle = {
+def triangle = {
     normal <- vec3d,
     vertices <- array8 3 vec3d,
     attribute_byte_count <- u16le,
 };
 
-let main = {
+def main = {
     header <- array8 80 u8,
     triangle_count <- u32le,
     triangles <- array32 triangle_count triangle,
 };
-
-main

--- a/formats/stl-binary.snap
+++ b/formats/stl-binary.snap
@@ -1,15 +1,14 @@
 stdout = '''
-let vec3d : _ = { x <- f32le, y <- f32le, z <- f32le };
-let triangle : _ = {
+def vec3d : Format = { x <- f32le, y <- f32le, z <- f32le };
+def triangle : Format = {
     normal <- vec3d,
     vertices <- array8 3 vec3d,
     attribute_byte_count <- u16le,
 };
-let main : _ = {
+def main : Format = {
     header <- array8 80 u8,
     triangle_count <- u32le,
     triangles <- array32 triangle_count triangle,
 };
-main : Format
 '''
 stderr = ''

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,7 @@
-# End-to-end tests
+# Integration tests
 
-The test runner for these tests can be found at [../fathom/tests/source_tests.rs](../fathom/tests/source_tests.rs).
+The harnesses for each subdirectory can be found at:
+
+- [cmd](./cmd) → [../fathom/tests/cli_tests.rs](../fathom/tests/cli_tests.rs)
+- [fail](./fail) → [../fathom/tests/source_tests.rs](../fathom/tests/source_tests.rs)
+- [succeed](./succeed) → [../fathom/tests/source_tests.rs](../fathom/tests/source_tests.rs)

--- a/tests/cmd/README.md
+++ b/tests/cmd/README.md
@@ -1,0 +1,13 @@
+# Command line snapshot tests
+
+These snapshot tests leverage [trycmd][trycmd-crate] test harness. More
+information on writing and running these tests can be found by reading the
+[trycmd docs][trycmd-docs]. If test snapshots need to be updated, rerunning the
+tests with `TRYCMD=overwrite` will regenerate them:
+
+```sh
+TRYCMD=overwrite cargo test cli_tests
+```
+
+[trycmd-crate]: https://crates.io/crates/trycmd
+[trycmd-docs]: https://docs.rs/trycmd/latest/trycmd

--- a/tests/cmd/fathom-data.md
+++ b/tests/cmd/fathom-data.md
@@ -1,0 +1,287 @@
+# `fathom data`
+
+## Help information
+
+Short help can be printed with `-h`
+
+```console
+$ fathom data -h
+fathom-data 
+Manipulate binary data based on a Fathom format
+
+USAGE:
+    fathom data [OPTIONS] <BINARY_FILE>
+
+ARGS:
+    <BINARY_FILE>    Path to the binary data to read from
+
+OPTIONS:
+        --module <MODULE_FILE>    Path to a module to load when reading
+        --format <FORMAT>         Format used when reading the binary data [default: main]
+        --allow-errors            Continue even if errors were encountered
+    -h, --help                    Print help information
+
+Examples:
+
+  $ fathom data --format '{ magic <- u32be where u32_eq magic "icns" }' AppIcon.icns
+  $ fathom data --module formats/opentype.fathom Monaco.ttf
+  $ fathom data --module formats/icns.fathom --format header AppIcon.icns
+
+```
+
+Long help can be printed with `--help`
+
+```console
+$ fathom data --help
+fathom-data 
+Manipulate binary data based on a Fathom format
+
+USAGE:
+    fathom data [OPTIONS] <BINARY_FILE>
+
+ARGS:
+    <BINARY_FILE>
+            Path to the binary data to read from
+
+OPTIONS:
+        --module <MODULE_FILE>
+            Path to a module to load when reading
+
+        --format <FORMAT>
+            Format used when reading the binary data
+            
+            The term provided by `FORMAT` must be of type `Format`.
+            
+            Required unless `--module` is present.
+            
+            [default: main]
+
+        --allow-errors
+            Continue even if errors were encountered
+
+    -h, --help
+            Print help information
+
+Binary data can be read using a term supplied by the `--format` option:
+
+  $ fathom data --format '{ magic <- u32be where u32_eq magic "icns" }' AppIcon.icns
+
+Alternatively data can be read using a module:
+
+  $ fathom data --module formats/opentype.fathom Monaco.ttf
+  $ fathom data --module formats/stl-binary.fathom cube.stl
+
+When a module is specified the binary data is read assuming that it contains a
+`main` definition, but this can be overridden using the `--format` option:
+
+  $ fathom data --module formats/icns.fathom --format header AppIcon.icns
+
+```
+
+## Usage examples
+
+### Reading data with adhoc formats
+
+Binary data can be read using `--format`
+
+```console
+$ fathom data --format "{ magic <- u64le where u64_eq magic 0x00ffffffffffff00 }"
+>             formats/data/edid/dell-P2415Q.edid
+0 = [ { magic = 72057594037927680 } ]
+
+```
+
+### Reading data with a module
+
+Binary data can be read using a module supplied with `--module`
+
+```console
+$ fathom data --module formats/edid.fathom formats/data/edid/dell-P2415Q.edid
+0 = [
+    {
+        header = {
+            magic = 72057594037927680,
+            manufacturer_id = 44048,
+            product_code = 41150,
+            serial = 810372684,
+            manufacturer_week = 10,
+            manufacturer_year_mod = 29,
+            edid_version_major = 1,
+            edid_version_minor = 4,
+        },
+        display_parameters = {
+            video_input_parameters = 165,
+            screen_size_h = 53,
+            screen_size_v = 30,
+            gamma_mod = 120,
+            supported_features = 58,
+        },
+        chromacity_coordinates = {
+            red_green_lsb = 226,
+            blue_white_lsb = 69,
+            red_x_msb = 168,
+            red_y_msb = 85,
+            green_x_msb = 77,
+            green_y_msb = 163,
+            blue_x_msb = 38,
+            blue_y_msb = 11,
+            white_x_msb = 80,
+            white_y_msb = 84,
+        },
+        established_timing = { mode_bitmap = [ 165, 75, 0 ] },
+        standard_timing_information = {},
+    },
+]
+
+```
+
+### Overriding the default entrypoint
+
+An explicit entrypoint can be supplied with `--format`
+
+```console
+$ fathom data --module formats/edid.fathom --format header
+>             formats/data/edid/dell-P2415Q.edid
+0 = [
+    {
+        magic = 72057594037927680,
+        manufacturer_id = 44048,
+        product_code = 41150,
+        serial = 810372684,
+        manufacturer_week = 10,
+        manufacturer_year_mod = 29,
+        edid_version_major = 1,
+        edid_version_minor = 4,
+    },
+]
+
+```
+
+Offsets can be used to more look more deeply into binary files
+
+```console
+$ fathom data --module formats/opentype.fathom
+>             --format "{ start <- stream_pos, link <- link (pos_add_u32 start 4396) (cmap_subtable 3) }"
+>             formats/data/opentype/aots/cmap0_font1.otf
+0 = [ { start = 0, link = 4396 } ]
+4396 = [
+    {
+        table_start = 4396,
+        format = 0,
+        data = {
+            length = 262,
+            language = 0,
+            glyph_id_array = [
+                0,
+                0,
+                0,
+                0,
+...
+
+```
+
+## Error cases
+
+### Argument conflicts
+
+Arguments must be provided to `fathom data`
+
+```console
+$ fathom data
+? failed
+error: The following required arguments were not provided:
+    <BINARY_FILE>
+
+USAGE:
+    fathom data [OPTIONS] <BINARY_FILE>
+
+For more information try --help
+
+```
+
+The `--format` option must be present when `--module` is not supplied
+
+```console
+$ fathom data formats/data/edid/dell-P2415Q.edid
+? failed
+error: The following required arguments were not provided:
+    --format <FORMAT>
+
+USAGE:
+    fathom data --format <FORMAT> <BINARY_FILE>
+
+For more information try --help
+
+```
+
+### Missing files
+
+The path to the binary file must exist
+
+```console
+$ fathom data --format "{ magic <- u64le where u64_eq magic 0x00ffffffffffff00 }" does/not/exist
+? failed
+error: couldn't read `does/not/exist`: No such file or directory (os error 2)
+
+
+```
+
+The path supplied with `--module` must exist
+
+```console
+$ fathom data --module woopsie.fathom formats/data/edid/dell-P2415Q.edid
+? failed
+error: couldn't read `woopsie.fathom`: No such file or directory (os error 2)
+
+
+```
+
+### Malformed binary data
+
+Unexpected data in the binary file will result in an error
+
+```console
+$ fathom data --module formats/edid.fathom formats/data/edid/invalid/wrong-magic.edid
+? failed
+error: conditional format failed
+ = The predicate on a conditional format did not succeed.
+
+
+```
+
+### Type errors
+
+Fathom ensures that the term supplied with `--format` is of type `Format`
+
+```console
+$ fathom data --format "{ x : U64 }" formats/data/edid/dell-P2415Q.edid
+? failed
+error: mismatched types
+  ┌─ <FORMAT>:1:1
+  │
+1 │ { x : U64 }
+  │ ^^^^^^^^^^^ type mismatch, expected `Type`, found `Format`
+  │
+  = expected `Type`
+       found `Format`
+
+
+```
+
+The term supplied `--format` is also checked when `--module` is present
+
+```console
+$ fathom data --module formats/opentype.fathom --format "offset16"
+>             formats/data/opentype/aots/cmap0_font1.otf
+? failed
+error: mismatched types
+  ┌─ <FORMAT>:1:1
+  │
+1 │ offset16
+  │ ^^^^^^^^ type mismatch, expected `fun (base : Pos) -> fun (format : Format) -> Format`, found `Format`
+  │
+  = expected `fun (base : Pos) -> fun (format : Format) -> Format`
+       found `Format`
+
+
+```

--- a/tests/cmd/fathom-elab.md
+++ b/tests/cmd/fathom-elab.md
@@ -1,0 +1,146 @@
+# `fathom elab`
+
+## Help information
+
+Short help can be printed with `-h`
+
+```console
+$ fathom elab -h
+fathom-elab 
+Elaborate a Fathom module or term, printing the result to stdout
+
+USAGE:
+    fathom elab [OPTIONS]
+
+OPTIONS:
+        --module <MODULE_FILE>    Path to a module to elaborate
+        --term <TERM_FILE>        Path to a term to elaborate
+        --allow-errors            Continue even if errors were encountered
+    -h, --help                    Print help information
+
+```
+
+Long help can be printed with `--help`
+
+```console
+$ fathom elab --help
+fathom-elab 
+Elaborate a Fathom module or term, printing the result to stdout
+
+USAGE:
+    fathom elab [OPTIONS]
+
+OPTIONS:
+        --module <MODULE_FILE>    Path to a module to elaborate
+        --term <TERM_FILE>        Path to a term to elaborate
+        --allow-errors            Continue even if errors were encountered
+    -h, --help                    Print help information
+
+```
+
+## Usage examples
+
+### Elaborating modules
+
+Modules can be elaborated with `--module`
+
+```console
+$ fathom elab --module formats/object-id.fathom
+def u24be : Format = array8 3 u8;
+def main : Format = {
+    timestamp <- u32be,
+    random <- array8 5 u8,
+    counter <- u24be,
+};
+
+```
+
+### Elaborating terms
+
+Terms can be elaborated with `--term`
+
+```console
+$ fathom elab --term tests/succeed/record-type/pair-dependent.fathom
+{ A : Type, a : A } : Type
+
+```
+
+## Error cases
+
+### Missing arguments
+
+Either a `--module` or a `--term` must be provided
+
+```console
+$ fathom elab
+? failed
+error: The following required arguments were not provided:
+    --module <MODULE_FILE>
+    --term <TERM_FILE>
+
+USAGE:
+    fathom elab --module <MODULE_FILE> --term <TERM_FILE>
+
+For more information try --help
+
+```
+
+### Conflicting arguments
+
+The `--module` and `--term` inputs conflict with each other
+
+```console
+$ fathom elab --module formats/object-id.fathom
+>             --term tests/succeed/record-type/pair-dependent.fathom
+? failed
+error: The argument '--module <MODULE_FILE>' cannot be used with '--term <TERM_FILE>'
+
+USAGE:
+    fathom elab --module <MODULE_FILE>
+
+For more information try --help
+
+```
+
+### Missing files
+
+The path supplied to `--term` must exist
+
+```console
+$ fathom elab --term does/not/exist.fathom
+? failed
+error: couldn't read `does/not/exist.fathom`: No such file or directory (os error 2)
+
+
+```
+
+The path supplied to `--module` must exist
+
+```console
+$ fathom elab --module does/not/exist.fathom
+? failed
+error: couldn't read `does/not/exist.fathom`: No such file or directory (os error 2)
+
+
+```
+
+### Type errors
+
+Type errors will be reported during elaboration
+
+```console
+$ fathom elab --term tests/fail/elaboration/duplicate-field-labels/record-literal.fathom
+? failed
+error: duplicate labels found in record
+  ┌─ tests/fail/elaboration/duplicate-field-labels/record-literal.fathom:3:23
+  │
+3 │ { x = Type, y = Type, x = Type }
+  │ ----------------------^---------
+  │ │                     │
+  │ │                     duplicate field
+  │ the record literal
+  │
+  = duplicate fields `x`
+
+
+```

--- a/tests/cmd/fathom-norm.md
+++ b/tests/cmd/fathom-norm.md
@@ -1,0 +1,101 @@
+# `fathom-norm`
+
+## Help information
+
+Short help can be printed with `-h`
+
+```console
+$ fathom norm -h
+fathom-norm 
+Normalise a Fathom term, printing its normal form and type
+
+USAGE:
+    fathom norm [OPTIONS] --term <TERM_FILE>
+
+OPTIONS:
+        --term <TERM_FILE>    Path to a term to normalise
+        --allow-errors        Continue even if errors were encountered
+    -h, --help                Print help information
+
+```
+
+Long help can be printed with `--help`
+
+```console
+$ fathom norm --help
+fathom-norm 
+Normalise a Fathom term, printing its normal form and type
+
+USAGE:
+    fathom norm [OPTIONS] --term <TERM_FILE>
+
+OPTIONS:
+        --term <TERM_FILE>    Path to a term to normalise
+        --allow-errors        Continue even if errors were encountered
+    -h, --help                Print help information
+
+```
+
+## Usage examples
+
+### Normalising terms
+
+Terms can be normalised with `--term`
+
+```console
+$ fathom norm --term tests/succeed/fun-elim/ann-identity-poly-1.fathom
+fun a => a : fun (_ : Type) -> Type
+
+```
+
+## Error cases
+
+### Missing arguments
+
+At least a `--term` must be provided
+
+```console
+$ fathom norm
+? failed
+error: The following required arguments were not provided:
+    --term <TERM_FILE>
+
+USAGE:
+    fathom norm [OPTIONS] --term <TERM_FILE>
+
+For more information try --help
+
+```
+
+## Missing files
+
+The path supplied to `--term` must exist
+
+```console
+$ fathom norm --term does/not/exist.fathom
+? failed
+error: couldn't read `does/not/exist.fathom`: No such file or directory (os error 2)
+
+
+```
+
+### Type errors
+
+The term must be well-typed before normalisation
+
+```console
+$ fathom norm --term tests/fail/elaboration/duplicate-field-labels/record-literal.fathom
+? failed
+error: duplicate labels found in record
+  ┌─ tests/fail/elaboration/duplicate-field-labels/record-literal.fathom:3:23
+  │
+3 │ { x = Type, y = Type, x = Type }
+  │ ----------------------^---------
+  │ │                     │
+  │ │                     duplicate field
+  │ the record literal
+  │
+  = duplicate fields `x`
+
+
+```

--- a/tests/cmd/fathom.md
+++ b/tests/cmd/fathom.md
@@ -1,0 +1,75 @@
+# `fathom`
+
+## Help information
+
+Short help can be printed with `-h`
+
+```console
+$ fathom -h
+fathom 0.1.0
+YesLogic Pty. Ltd. <info@yeslogic.com>
+A language for declaratively specifying binary data formats
+
+USAGE:
+    fathom <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    data    Manipulate binary data based on a Fathom format
+    elab    Elaborate a Fathom module or term, printing the result to stdout
+    help    Print this message or the help of the given subcommand(s)
+    norm    Normalise a Fathom term, printing its normal form and type
+
+```
+
+Long help can be printed with `--help`
+
+```console
+$ fathom --help
+fathom 0.1.0
+YesLogic Pty. Ltd. <info@yeslogic.com>
+A language for declaratively specifying binary data formats
+
+USAGE:
+    fathom <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    data    Manipulate binary data based on a Fathom format
+    elab    Elaborate a Fathom module or term, printing the result to stdout
+    help    Print this message or the help of the given subcommand(s)
+    norm    Normalise a Fathom term, printing its normal form and type
+
+```
+
+## Missing subcommands
+
+A subcommand must be provided to `fathom`
+
+```console
+$ fathom
+? failed
+fathom 0.1.0
+YesLogic Pty. Ltd. <info@yeslogic.com>
+A language for declaratively specifying binary data formats
+
+USAGE:
+    fathom <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    data    Manipulate binary data based on a Fathom format
+    elab    Elaborate a Fathom module or term, printing the result to stdout
+    help    Print this message or the help of the given subcommand(s)
+    norm    Normalise a Fathom term, printing its normal form and type
+
+```


### PR DESCRIPTION
This is a first pass on implementing top-level items, as described in #318.

At the moment the items are still in order, but it opens the door to having out-of order definitions in the future.

Part of the challenge was figuring out an approach for checking the entrypoint read using `fathom data --module FILE --format FORMAT` was actually a `Format` or not, but I think I figured out a way that works decently for now.

This also resulted in me cleaning up the CLI a bit and improving error handling (for example when files are missing). I’m not super well-versed in designing good CLIs though, and we might be able to improve the ergonomics from what I have now.

Because the CLI is becoming more involved, I added some snapshot tests for various use cases. I was looking for a [cram](https://bitheap.org/cram/) implementation for Rust (which I’ve found pretty useful [in OCaml](https://dune.readthedocs.io/en/stable/tests.html#cram-tests)), and [trycmd](https://lib.rs/crates/trycmd) seemed pretty close. It’s not widely used at the moment, but the crates it is used in are pretty popular, like clap. We can always switch back to something else though.

Closes #318