### PR TITLE
Rename variants in the core language

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -146,13 +146,13 @@ pub enum Term<'arena> {
     Prim(Prim),
 
     /// Constant literals.
-    ConstLit(Const),
-    /// Constant case split.
+    ConstLit(ConstLit),
+    /// Case split on a constant.
     ///
     /// (head_expr, branches, default_expr)
     ConstCase(
         &'arena Term<'arena>,
-        &'arena [(Const, Term<'arena>)],
+        &'arena [(ConstLit, Term<'arena>)],
         Option<&'arena Term<'arena>>,
     ),
 }
@@ -439,7 +439,7 @@ pub enum UIntStyle {
 
 /// Constant literals
 #[derive(Debug, Copy, Clone, PartialOrd)]
-pub enum Const {
+pub enum ConstLit {
     Bool(bool),
     U8(u8, UIntStyle),
     U16(u16, UIntStyle),
@@ -456,22 +456,22 @@ pub enum Const {
     Ref(u64),
 }
 
-impl PartialEq for Const {
+impl PartialEq for ConstLit {
     fn eq(&self, other: &Self) -> bool {
         match (*self, *other) {
-            (Const::Bool(a), Const::Bool(b)) => a == b,
-            (Const::U8(a, _), Const::U8(b, _)) => a == b,
-            (Const::U16(a, _), Const::U16(b, _)) => a == b,
-            (Const::U32(a, _), Const::U32(b, _)) => a == b,
-            (Const::U64(a, _), Const::U64(b, _)) => a == b,
-            (Const::S8(a), Const::S8(b)) => a == b,
-            (Const::S16(a), Const::S16(b)) => a == b,
-            (Const::S32(a), Const::S32(b)) => a == b,
-            (Const::S64(a), Const::S64(b)) => a == b,
-            (Const::F32(a), Const::F32(b)) => a == b,
-            (Const::F64(a), Const::F64(b)) => a == b,
-            (Const::Pos(a), Const::Pos(b)) => a == b,
-            (Const::Ref(a), Const::Ref(b)) => a == b,
+            (ConstLit::Bool(a), ConstLit::Bool(b)) => a == b,
+            (ConstLit::U8(a, _), ConstLit::U8(b, _)) => a == b,
+            (ConstLit::U16(a, _), ConstLit::U16(b, _)) => a == b,
+            (ConstLit::U32(a, _), ConstLit::U32(b, _)) => a == b,
+            (ConstLit::U64(a, _), ConstLit::U64(b, _)) => a == b,
+            (ConstLit::S8(a), ConstLit::S8(b)) => a == b,
+            (ConstLit::S16(a), ConstLit::S16(b)) => a == b,
+            (ConstLit::S32(a), ConstLit::S32(b)) => a == b,
+            (ConstLit::S64(a), ConstLit::S64(b)) => a == b,
+            (ConstLit::F32(a), ConstLit::F32(b)) => a == b,
+            (ConstLit::F64(a), ConstLit::F64(b)) => a == b,
+            (ConstLit::Pos(a), ConstLit::Pos(b)) => a == b,
+            (ConstLit::Ref(a), ConstLit::Ref(b)) => a == b,
             _ => false,
         }
     }

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -119,17 +119,17 @@ pub enum Term<'arena> {
     ///
     /// Also known as: pi types, dependent product types.
     FunType(Option<StringId>, &'arena Term<'arena>, &'arena Term<'arena>),
-    /// Function introductions.
+    /// Function literals.
     ///
     /// Also known as: lambda expressions, anonymous functions.
-    FunIntro(Option<StringId>, &'arena Term<'arena>),
+    FunLit(Option<StringId>, &'arena Term<'arena>),
     /// Function applications.
     FunApp(&'arena Term<'arena>, &'arena Term<'arena>),
 
     /// Dependent record types.
     RecordType(&'arena [StringId], &'arena [Term<'arena>]),
-    /// Record introductions.
-    RecordIntro(&'arena [StringId], &'arena [Term<'arena>]),
+    /// Record literals.
+    RecordLit(&'arena [StringId], &'arena [Term<'arena>]),
     /// Record projections.
     RecordProj(&'arena Term<'arena>, StringId),
 
@@ -145,8 +145,8 @@ pub enum Term<'arena> {
     /// Primitives.
     Prim(Prim),
 
-    /// Constants.
-    Const(Const),
+    /// Constant literals.
+    ConstLit(Const),
     /// Constant case split.
     ///
     /// (head_expr, branches, default_expr)
@@ -437,7 +437,7 @@ pub enum UIntStyle {
     Ascii,
 }
 
-/// Constants
+/// Constant literals
 #[derive(Debug, Copy, Clone, PartialOrd)]
 pub enum Const {
     Bool(bool),

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -57,9 +57,9 @@ pub enum Term<'arena> {
     /// parameters will correspond to the [function introductions] that will be
     /// added to the flexible solution during unification.
     ///
-    /// We clone the entry information and perform the function eliminations
+    /// We clone the entry information and perform the function applications
     /// during evaluation because elaborating to a series of [function
-    /// eliminations] directly would involve expensively [quoting] each
+    /// applications] directly would involve expensively [quoting] each
     /// parameter.
     ///
     /// For example, given the following code:
@@ -92,7 +92,7 @@ pub enum Term<'arena> {
     ///
     /// [entry information]: EntryInfo
     /// [function introductions]: Term::FunIntro
-    /// [function eliminations]: Term::FunElim
+    /// [function applications]: Term::FunApp
     /// [evaluation]: semantics::EvalContext::eval
     /// [quoting]: semantics::QuoteContext::quote
     //
@@ -111,8 +111,10 @@ pub enum Term<'arena> {
         &'arena Term<'arena>,
         &'arena Term<'arena>,
     ),
+
     /// The type of types.
     Universe,
+
     /// Dependent function types.
     ///
     /// Also known as: pi types, dependent product types.
@@ -121,31 +123,34 @@ pub enum Term<'arena> {
     ///
     /// Also known as: lambda expressions, anonymous functions.
     FunIntro(Option<StringId>, &'arena Term<'arena>),
-    /// Function eliminations.
-    ///
-    /// Also known as: function applications.
-    FunElim(&'arena Term<'arena>, &'arena Term<'arena>),
+    /// Function applications.
+    FunApp(&'arena Term<'arena>, &'arena Term<'arena>),
+
     /// Dependent record types.
     RecordType(&'arena [StringId], &'arena [Term<'arena>]),
     /// Record introductions.
     RecordIntro(&'arena [StringId], &'arena [Term<'arena>]),
-    /// Record eliminations.
-    RecordElim(&'arena Term<'arena>, StringId),
+    /// Record projections.
+    RecordProj(&'arena Term<'arena>, StringId),
+
     /// Array introductions.
     ArrayIntro(&'arena [Term<'arena>]),
+
     /// Record formats, consisting of a list of dependent formats.
     FormatRecord(&'arena [StringId], &'arena [Term<'arena>]),
     /// Overlap formats, consisting of a list of dependent formats, overlapping
     /// in memory.
     FormatOverlap(&'arena [StringId], &'arena [Term<'arena>]),
+
     /// Primitives.
     Prim(Prim),
+
     /// Constants.
     Const(Const),
-    /// Constant eliminations.
+    /// Constant case split.
     ///
     /// (head_expr, branches, default_expr)
-    ConstElim(
+    ConstCase(
         &'arena Term<'arena>,
         &'arena [(Const, Term<'arena>)],
         Option<&'arena Term<'arena>>,

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -133,8 +133,8 @@ pub enum Term<'arena> {
     /// Record projections.
     RecordProj(&'arena Term<'arena>, StringId),
 
-    /// Array introductions.
-    ArrayIntro(&'arena [Term<'arena>]),
+    /// Array literals.
+    ArrayLit(&'arena [Term<'arena>]),
 
     /// Record formats, consisting of a list of dependent formats.
     FormatRecord(&'arena [StringId], &'arena [Term<'arena>]),

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -146,13 +146,13 @@ pub enum Term<'arena> {
     Prim(Prim),
 
     /// Constant literals.
-    ConstLit(ConstLit),
+    ConstLit(Const),
     /// Match on a constant.
     ///
     /// (head_expr, pattern_branches, default_expr)
     ConstMatch(
         &'arena Term<'arena>,
-        &'arena [(ConstLit, Term<'arena>)],
+        &'arena [(Const, Term<'arena>)],
         Option<&'arena Term<'arena>>,
     ),
 }
@@ -437,9 +437,9 @@ pub enum UIntStyle {
     Ascii,
 }
 
-/// Constant literals
+/// Constants
 #[derive(Debug, Copy, Clone, PartialOrd)]
-pub enum ConstLit {
+pub enum Const {
     Bool(bool),
     U8(u8, UIntStyle),
     U16(u16, UIntStyle),
@@ -456,22 +456,22 @@ pub enum ConstLit {
     Ref(u64),
 }
 
-impl PartialEq for ConstLit {
+impl PartialEq for Const {
     fn eq(&self, other: &Self) -> bool {
         match (*self, *other) {
-            (ConstLit::Bool(a), ConstLit::Bool(b)) => a == b,
-            (ConstLit::U8(a, _), ConstLit::U8(b, _)) => a == b,
-            (ConstLit::U16(a, _), ConstLit::U16(b, _)) => a == b,
-            (ConstLit::U32(a, _), ConstLit::U32(b, _)) => a == b,
-            (ConstLit::U64(a, _), ConstLit::U64(b, _)) => a == b,
-            (ConstLit::S8(a), ConstLit::S8(b)) => a == b,
-            (ConstLit::S16(a), ConstLit::S16(b)) => a == b,
-            (ConstLit::S32(a), ConstLit::S32(b)) => a == b,
-            (ConstLit::S64(a), ConstLit::S64(b)) => a == b,
-            (ConstLit::F32(a), ConstLit::F32(b)) => a == b,
-            (ConstLit::F64(a), ConstLit::F64(b)) => a == b,
-            (ConstLit::Pos(a), ConstLit::Pos(b)) => a == b,
-            (ConstLit::Ref(a), ConstLit::Ref(b)) => a == b,
+            (Const::Bool(a), Const::Bool(b)) => a == b,
+            (Const::U8(a, _), Const::U8(b, _)) => a == b,
+            (Const::U16(a, _), Const::U16(b, _)) => a == b,
+            (Const::U32(a, _), Const::U32(b, _)) => a == b,
+            (Const::U64(a, _), Const::U64(b, _)) => a == b,
+            (Const::S8(a), Const::S8(b)) => a == b,
+            (Const::S16(a), Const::S16(b)) => a == b,
+            (Const::S32(a), Const::S32(b)) => a == b,
+            (Const::S64(a), Const::S64(b)) => a == b,
+            (Const::F32(a), Const::F32(b)) => a == b,
+            (Const::F64(a), Const::F64(b)) => a == b,
+            (Const::Pos(a), Const::Pos(b)) => a == b,
+            (Const::Ref(a), Const::Ref(b)) => a == b,
             _ => false,
         }
     }

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -147,10 +147,10 @@ pub enum Term<'arena> {
 
     /// Constant literals.
     ConstLit(ConstLit),
-    /// Case split on a constant.
+    /// Match on a constant.
     ///
-    /// (head_expr, branches, default_expr)
-    ConstCase(
+    /// (head_expr, pattern_branches, default_expr)
+    ConstMatch(
         &'arena Term<'arena>,
         &'arena [(ConstLit, Term<'arena>)],
         Option<&'arena Term<'arena>>,

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -26,11 +26,11 @@ pub enum Term<'arena> {
     ///
     /// These correspond to variables that were most likely bound as a result of
     /// user code, for example from [let expressions]), [function types] and
-    /// [function introductions].
+    /// [function literals].
     ///
     /// [let expressions]: Term::Let
     /// [function types]: Term::FunType
-    /// [function introductions]: Term::FunIntro
+    /// [function literals]: Term::FunLit
     ///
     /// ## References
     ///
@@ -54,7 +54,7 @@ pub enum Term<'arena> {
     ///
     /// The entry information will let us know what rigidly bound parameters to
     /// apply to the flexible variable during [evaluation]. The applied
-    /// parameters will correspond to the [function introductions] that will be
+    /// parameters will correspond to the [function literals] that will be
     /// added to the flexible solution during unification.
     ///
     /// We clone the entry information and perform the function applications
@@ -91,7 +91,7 @@ pub enum Term<'arena> {
     /// applied, because it is bound as a definition.
     ///
     /// [entry information]: EntryInfo
-    /// [function introductions]: Term::FunIntro
+    /// [function literals]: Term::FunLit
     /// [function applications]: Term::FunApp
     /// [evaluation]: semantics::EvalContext::eval
     /// [quoting]: semantics::QuoteContext::quote

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -75,7 +75,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     formats = next_formats(expr);
                 }
 
-                Ok(Arc::new(Value::RecordIntro(labels, exprs)))
+                Ok(Arc::new(Value::RecordLit(labels, exprs)))
             }
             Value::FormatOverlap(labels, formats) => {
                 let initial_pos = reader.stream_position()?;
@@ -101,18 +101,18 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 // Seek to the maximum stream length
                 reader.seek(SeekFrom::Start(max_pos))?;
 
-                Ok(Arc::new(Value::RecordIntro(labels, exprs)))
+                Ok(Arc::new(Value::RecordLit(labels, exprs)))
             }
 
             Value::Stuck(Head::RigidVar(_), _)
             | Value::Stuck(Head::FlexibleVar(_), _)
             | Value::Universe
             | Value::FunType(_, _, _)
-            | Value::FunIntro(_, _)
+            | Value::FunLit(_, _)
             | Value::RecordType(_, _)
-            | Value::RecordIntro(_, _)
-            | Value::ArrayIntro(_)
-            | Value::Const(_) => Err(io::Error::new(io::ErrorKind::Other, "invalid format")),
+            | Value::RecordLit(_, _)
+            | Value::ArrayLit(_)
+            | Value::ConstLit(_) => Err(io::Error::new(io::ErrorKind::Other, "invalid format")),
         }
     }
 
@@ -169,10 +169,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
         elem_format: &ArcValue<'arena>,
     ) -> io::Result<ArcValue<'arena>> {
         let (len, mut elem_exprs) = match self.elim_context().force(len).as_ref() {
-            Value::Const(Const::U8(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
-            Value::Const(Const::U16(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
-            Value::Const(Const::U32(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
-            Value::Const(Const::U64(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
+            Value::ConstLit(Const::U8(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
+            Value::ConstLit(Const::U16(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
+            Value::ConstLit(Const::U32(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
+            Value::ConstLit(Const::U64(len, _)) => (*len as u64, Vec::with_capacity(*len as usize)),
             _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid array length")),
         };
 
@@ -181,7 +181,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
             elem_exprs.push(expr);
         }
 
-        Ok(Arc::new(Value::ArrayIntro(elem_exprs)))
+        Ok(Arc::new(Value::ArrayLit(elem_exprs)))
     }
 
     pub fn read_link(
@@ -190,13 +190,13 @@ impl<'arena, 'env> Context<'arena, 'env> {
         elem_format: &ArcValue<'arena>,
     ) -> io::Result<ArcValue<'arena>> {
         let pos = match self.elim_context().force(pos).as_ref() {
-            Value::Const(Const::Pos(pos)) => *pos,
+            Value::ConstLit(Const::Pos(pos)) => *pos,
             _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid link pos")),
         };
 
         self.pending_formats.push((pos, elem_format.clone()));
 
-        Ok(Arc::new(Value::Const(Const::Ref(pos))))
+        Ok(Arc::new(Value::ConstLit(Const::Ref(pos))))
     }
 
     fn read_deref(
@@ -206,7 +206,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         r#ref: &ArcValue<'arena>,
     ) -> io::Result<ArcValue<'arena>> {
         let pos = match self.elim_context().force(r#ref).as_ref() {
-            Value::Const(Const::Ref(pos)) => *pos,
+            Value::ConstLit(Const::Ref(pos)) => *pos,
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
@@ -279,7 +279,7 @@ impl<T: Seek + Read> SeekRead for T {}
 
 fn read_stream_pos<'arena>(reader: &mut dyn SeekRead) -> io::Result<ArcValue<'arena>> {
     let pos = reader.stream_position()?;
-    Ok(Arc::new(Value::Const(Const::Pos(pos))))
+    Ok(Arc::new(Value::ConstLit(Const::Pos(pos))))
 }
 
 fn read_const<'arena, T>(
@@ -288,7 +288,7 @@ fn read_const<'arena, T>(
     read: fn(&mut dyn SeekRead) -> io::Result<T>,
 ) -> io::Result<ArcValue<'arena>> {
     let data = read(reader)?;
-    Ok(Arc::new(Value::Const(wrap_const(data))))
+    Ok(Arc::new(Value::ConstLit(wrap_const(data))))
 }
 
 fn read_u8(reader: &mut dyn SeekRead) -> io::Result<u8> {

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -123,7 +123,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         prim: Prim,
         slice: &[Elim<'arena>],
     ) -> io::Result<ArcValue<'arena>> {
-        use crate::core::semantics::Elim::Fun;
+        use crate::core::semantics::Elim::FunApp;
 
         match (prim, &slice[..]) {
             (Prim::FormatU8, []) => read_const(reader, |num| Const::U8(num, UIntStyle::Decimal), read_u8),
@@ -144,17 +144,17 @@ impl<'arena, 'env> Context<'arena, 'env> {
             (Prim::FormatF32Le, []) => read_const(reader, Const::F32, read_f32le),
             (Prim::FormatF64Be, []) => read_const(reader, Const::F64, read_f64be),
             (Prim::FormatF64Le, []) => read_const(reader, Const::F64, read_f64le),
-            (Prim::FormatArray8, [Fun(len), Fun(elem_format)]) => self.read_array(reader, len, elem_format),
-            (Prim::FormatArray16, [Fun(len), Fun(elem_format)]) => self.read_array(reader, len, elem_format),
-            (Prim::FormatArray32, [Fun(len), Fun(elem_format)]) => self.read_array(reader, len, elem_format),
-            (Prim::FormatArray64, [Fun(len), Fun(elem_format)]) => self.read_array(reader, len, elem_format),
-            (Prim::FormatLink, [Fun(pos), Fun(elem_format)]) => self.read_link(pos, elem_format),
-            (Prim::FormatDeref, [Fun(elem_format), Fun(r#ref)]) => self.read_deref(reader, elem_format, r#ref),
+            (Prim::FormatArray8, [FunApp(len), FunApp(elem_format)]) => self.read_array(reader, len, elem_format),
+            (Prim::FormatArray16, [FunApp(len), FunApp(elem_format)]) => self.read_array(reader, len, elem_format),
+            (Prim::FormatArray32, [FunApp(len), FunApp(elem_format)]) => self.read_array(reader, len, elem_format),
+            (Prim::FormatArray64, [FunApp(len), FunApp(elem_format)]) => self.read_array(reader, len, elem_format),
+            (Prim::FormatLink, [FunApp(pos), FunApp(elem_format)]) => self.read_link(pos, elem_format),
+            (Prim::FormatDeref, [FunApp(elem_format), FunApp(r#ref)]) => self.read_deref(reader, elem_format, r#ref),
             (Prim::FormatStreamPos, []) => read_stream_pos(reader),
-            (Prim::FormatSucceed, [_, Fun(elem)]) => Ok(elem.clone()),
+            (Prim::FormatSucceed, [_, FunApp(elem)]) => Ok(elem.clone()),
             (Prim::FormatFail, []) => Err(io::Error::new(io::ErrorKind::Other, "parse failure")),
-            (Prim::FormatUnwrap, [_, Fun(option)]) => match option.match_prim_spine() {
-                Some((Prim::OptionSome, [Fun(elem)])) => Ok(elem.clone()),
+            (Prim::FormatUnwrap, [_, FunApp(option)]) => match option.match_prim_spine() {
+                Some((Prim::OptionSome, [FunApp(elem)])) => Ok(elem.clone()),
                 Some((Prim::OptionNone, [])) => Err(io::Error::new(io::ErrorKind::Other, "unwrapped none")),
                 _ => Err(io::Error::new(io::ErrorKind::Other, "invalid option")),
             },

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -5,7 +5,7 @@ use std::io::{self, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use crate::core::semantics::{self, ArcValue, Elim, Head, Value};
-use crate::core::{ConstLit, Prim, UIntStyle};
+use crate::core::{Const, Prim, UIntStyle};
 use crate::env::{EnvLen, SliceEnv};
 
 pub struct Context<'arena, 'env> {
@@ -126,24 +126,24 @@ impl<'arena, 'env> Context<'arena, 'env> {
         use crate::core::semantics::Elim::FunApp;
 
         match (prim, &slice[..]) {
-            (Prim::FormatU8, []) => read_const(reader, |num| ConstLit::U8(num, UIntStyle::Decimal), read_u8),
-            (Prim::FormatU16Be, []) => read_const(reader, |num| ConstLit::U16(num, UIntStyle::Decimal), read_u16be),
-            (Prim::FormatU16Le, []) => read_const(reader, |num| ConstLit::U16(num, UIntStyle::Decimal), read_u16le),
-            (Prim::FormatU32Be, []) => read_const(reader, |num| ConstLit::U32(num, UIntStyle::Decimal), read_u32be),
-            (Prim::FormatU32Le, []) => read_const(reader, |num| ConstLit::U32(num, UIntStyle::Decimal), read_u32le),
-            (Prim::FormatU64Be, []) => read_const(reader, |num| ConstLit::U64(num, UIntStyle::Decimal), read_u64be),
-            (Prim::FormatU64Le, []) => read_const(reader, |num| ConstLit::U64(num, UIntStyle::Decimal), read_u64le),
-            (Prim::FormatS8, []) => read_const(reader, ConstLit::S8, read_s8),
-            (Prim::FormatS16Be, []) => read_const(reader, ConstLit::S16, read_s16be),
-            (Prim::FormatS16Le, []) => read_const(reader, ConstLit::S16, read_s16le),
-            (Prim::FormatS32Be, []) => read_const(reader, ConstLit::S32, read_s32be),
-            (Prim::FormatS32Le, []) => read_const(reader, ConstLit::S32, read_s32le),
-            (Prim::FormatS64Be, []) => read_const(reader, ConstLit::S64, read_s64be),
-            (Prim::FormatS64Le, []) => read_const(reader, ConstLit::S64, read_s64le),
-            (Prim::FormatF32Be, []) => read_const(reader, ConstLit::F32, read_f32be),
-            (Prim::FormatF32Le, []) => read_const(reader, ConstLit::F32, read_f32le),
-            (Prim::FormatF64Be, []) => read_const(reader, ConstLit::F64, read_f64be),
-            (Prim::FormatF64Le, []) => read_const(reader, ConstLit::F64, read_f64le),
+            (Prim::FormatU8, []) => read_const(reader, |num| Const::U8(num, UIntStyle::Decimal), read_u8),
+            (Prim::FormatU16Be, []) => read_const(reader, |num| Const::U16(num, UIntStyle::Decimal), read_u16be),
+            (Prim::FormatU16Le, []) => read_const(reader, |num| Const::U16(num, UIntStyle::Decimal), read_u16le),
+            (Prim::FormatU32Be, []) => read_const(reader, |num| Const::U32(num, UIntStyle::Decimal), read_u32be),
+            (Prim::FormatU32Le, []) => read_const(reader, |num| Const::U32(num, UIntStyle::Decimal), read_u32le),
+            (Prim::FormatU64Be, []) => read_const(reader, |num| Const::U64(num, UIntStyle::Decimal), read_u64be),
+            (Prim::FormatU64Le, []) => read_const(reader, |num| Const::U64(num, UIntStyle::Decimal), read_u64le),
+            (Prim::FormatS8, []) => read_const(reader, Const::S8, read_s8),
+            (Prim::FormatS16Be, []) => read_const(reader, Const::S16, read_s16be),
+            (Prim::FormatS16Le, []) => read_const(reader, Const::S16, read_s16le),
+            (Prim::FormatS32Be, []) => read_const(reader, Const::S32, read_s32be),
+            (Prim::FormatS32Le, []) => read_const(reader, Const::S32, read_s32le),
+            (Prim::FormatS64Be, []) => read_const(reader, Const::S64, read_s64be),
+            (Prim::FormatS64Le, []) => read_const(reader, Const::S64, read_s64le),
+            (Prim::FormatF32Be, []) => read_const(reader, Const::F32, read_f32be),
+            (Prim::FormatF32Le, []) => read_const(reader, Const::F32, read_f32le),
+            (Prim::FormatF64Be, []) => read_const(reader, Const::F64, read_f64be),
+            (Prim::FormatF64Le, []) => read_const(reader, Const::F64, read_f64le),
             (Prim::FormatArray8, [FunApp(len), FunApp(elem_format)]) => self.read_array(reader, len, elem_format),
             (Prim::FormatArray16, [FunApp(len), FunApp(elem_format)]) => self.read_array(reader, len, elem_format),
             (Prim::FormatArray32, [FunApp(len), FunApp(elem_format)]) => self.read_array(reader, len, elem_format),
@@ -169,10 +169,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
         elem_format: &ArcValue<'arena>,
     ) -> io::Result<ArcValue<'arena>> {
         let len = match self.elim_context().force(len).as_ref() {
-            Value::ConstLit(ConstLit::U8(len, _)) => *len as u64,
-            Value::ConstLit(ConstLit::U16(len, _)) => *len as u64,
-            Value::ConstLit(ConstLit::U32(len, _)) => *len as u64,
-            Value::ConstLit(ConstLit::U64(len, _)) => *len as u64,
+            Value::ConstLit(Const::U8(len, _)) => *len as u64,
+            Value::ConstLit(Const::U16(len, _)) => *len as u64,
+            Value::ConstLit(Const::U32(len, _)) => *len as u64,
+            Value::ConstLit(Const::U64(len, _)) => *len as u64,
             _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid array length")),
         };
 
@@ -189,13 +189,13 @@ impl<'arena, 'env> Context<'arena, 'env> {
         elem_format: &ArcValue<'arena>,
     ) -> io::Result<ArcValue<'arena>> {
         let pos = match self.elim_context().force(pos).as_ref() {
-            Value::ConstLit(ConstLit::Pos(pos)) => *pos,
+            Value::ConstLit(Const::Pos(pos)) => *pos,
             _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid link pos")),
         };
 
         self.pending_formats.push((pos, elem_format.clone()));
 
-        Ok(Arc::new(Value::ConstLit(ConstLit::Ref(pos))))
+        Ok(Arc::new(Value::ConstLit(Const::Ref(pos))))
     }
 
     fn read_deref(
@@ -205,7 +205,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         r#ref: &ArcValue<'arena>,
     ) -> io::Result<ArcValue<'arena>> {
         let pos = match self.elim_context().force(r#ref).as_ref() {
-            Value::ConstLit(ConstLit::Ref(pos)) => *pos,
+            Value::ConstLit(Const::Ref(pos)) => *pos,
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
@@ -278,12 +278,12 @@ impl<T: Seek + Read> SeekRead for T {}
 
 fn read_stream_pos<'arena>(reader: &mut dyn SeekRead) -> io::Result<ArcValue<'arena>> {
     let pos = reader.stream_position()?;
-    Ok(Arc::new(Value::ConstLit(ConstLit::Pos(pos))))
+    Ok(Arc::new(Value::ConstLit(Const::Pos(pos))))
 }
 
 fn read_const<'arena, T>(
     reader: &mut dyn SeekRead,
-    wrap_const: fn(T) -> ConstLit,
+    wrap_const: fn(T) -> Const,
     read: fn(&mut dyn SeekRead) -> io::Result<T>,
 ) -> io::Result<ArcValue<'arena>> {
     let data = read(reader)?;

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -1156,6 +1156,10 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
     }
 
     /// Check that a function literal is equal to a value, using eta-conversion.
+    ///
+    /// ```fathom
+    /// (fun x => f x) = f
+    /// ```
     fn is_equal_fun_lit(&mut self, output_expr: &Closure<'_>, value: &ArcValue<'_>) -> bool {
         let var = Arc::new(Value::rigid_var(self.rigid_exprs.next_global()));
         let value = self
@@ -1171,6 +1175,10 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
     }
 
     /// Check that a record literal is equal to a value, using eta-conversion.
+    ///
+    /// ```fathom
+    /// { x = r.x, y = r.y, .. } = r
+    /// ```
     fn is_equal_record_lit(
         &mut self,
         labels: &[StringId],

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -6,7 +6,7 @@ use std::panic::panic_any;
 use std::sync::Arc;
 
 use crate::alloc::SliceVec;
-use crate::core::{ConstLit, EntryInfo, Prim, Term, UIntStyle};
+use crate::core::{Const, EntryInfo, Prim, Term, UIntStyle};
 use crate::env::{EnvLen, GlobalVar, SharedEnv, SliceEnv};
 use crate::StringId;
 
@@ -46,7 +46,7 @@ pub enum Value<'arena> {
     FormatOverlap(&'arena [StringId], Telescope<'arena>),
 
     /// Constant literals.
-    ConstLit(ConstLit),
+    ConstLit(Const),
 }
 
 impl<'arena> Value<'arena> {
@@ -91,7 +91,7 @@ pub enum Elim<'arena> {
     /// Record projections.
     RecordProj(StringId),
     /// Match on a constant.
-    ConstMatch(Branches<'arena, ConstLit>),
+    ConstMatch(Branches<'arena, Const>),
 }
 
 /// A closure is a term that can later be instantiated with a value.
@@ -370,13 +370,13 @@ macro_rules! step {
 macro_rules! const_step {
     ([$($input:ident : $Input:ident),*] => $output:expr) => {
         step!(_, [$($input),*] => match ($($input.as_ref(),)*) {
-            ($(Value::ConstLit(ConstLit::$Input($input, ..)),)*) => Arc::new(Value::ConstLit($output)),
+            ($(Value::ConstLit(Const::$Input($input, ..)),)*) => Arc::new(Value::ConstLit($output)),
             _ => return None,
         })
     };
     ([$($input:ident , $style:ident : $Input:ident),*] => $output:expr) => {
         step!(_, [$($input),*] => match ($($input.as_ref(),)*) {
-            ($(Value::ConstLit(ConstLit::$Input($input, $style)),)*) => Arc::new(Value::ConstLit($output)),
+            ($(Value::ConstLit(Const::$Input($input, $style)),)*) => Arc::new(Value::ConstLit($output)),
             _ => return None,
         })
     };
@@ -390,136 +390,136 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
     match prim {
         Prim::FormatRepr => step!(context, [format] => context.format_repr(format)),
 
-        Prim::BoolEq => const_step!([x: Bool, y: Bool] => ConstLit::Bool(x == y)),
-        Prim::BoolNeq => const_step!([x: Bool, y: Bool] => ConstLit::Bool(x != y)),
-        Prim::BoolNot => const_step!([x: Bool] => ConstLit::Bool(bool::not(*x))),
-        Prim::BoolAnd => const_step!([x: Bool, y: Bool] => ConstLit::Bool(*x && *y)),
-        Prim::BoolOr => const_step!([x: Bool, y: Bool] => ConstLit::Bool(*x || *y)),
-        Prim::BoolXor => const_step!([x: Bool, y: Bool] => ConstLit::Bool(*x ^ *y)),
+        Prim::BoolEq => const_step!([x: Bool, y: Bool] => Const::Bool(x == y)),
+        Prim::BoolNeq => const_step!([x: Bool, y: Bool] => Const::Bool(x != y)),
+        Prim::BoolNot => const_step!([x: Bool] => Const::Bool(bool::not(*x))),
+        Prim::BoolAnd => const_step!([x: Bool, y: Bool] => Const::Bool(*x && *y)),
+        Prim::BoolOr => const_step!([x: Bool, y: Bool] => Const::Bool(*x || *y)),
+        Prim::BoolXor => const_step!([x: Bool, y: Bool] => Const::Bool(*x ^ *y)),
 
-        Prim::U8Eq => const_step!([x: U8, y: U8] => ConstLit::Bool(x == y)),
-        Prim::U8Neq => const_step!([x: U8, y: U8] => ConstLit::Bool(x != y)),
-        Prim::U8Gt => const_step!([x: U8, y: U8] => ConstLit::Bool(x > y)),
-        Prim::U8Lt => const_step!([x: U8, y: U8] => ConstLit::Bool(x < y)),
-        Prim::U8Gte => const_step!([x: U8, y: U8] => ConstLit::Bool(x >= y)),
-        Prim::U8Lte => const_step!([x: U8, y: U8] => ConstLit::Bool(x <= y)),
-        Prim::U8Add => const_step!([x, xst: U8, y, yst: U8] => ConstLit::U8(u8::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U8Sub => const_step!([x, xst: U8, y, yst: U8] => ConstLit::U8(u8::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U8Mul => const_step!([x, xst: U8, y, yst: U8] => ConstLit::U8(u8::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U8Div => const_step!([x, xst: U8, y, yst: U8] => ConstLit::U8(u8::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U8Not => const_step!([x, style: U8] => ConstLit::U8(u8::not(*x), *style)),
-        Prim::U8Shl => const_step!([x, xst: U8, y, _yst: U8] => ConstLit::U8(u8::checked_shl(*x, u32::from(*y))?, *xst)),
-        Prim::U8Shr => const_step!([x, xst: U8, y, _yst: U8] => ConstLit::U8(u8::checked_shr(*x, u32::from(*y))?, *xst)),
-        Prim::U8And => const_step!([x, xst: U8, y, yst: U8] => ConstLit::U8(u8::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U8Or => const_step!([x, xst: U8, y, yst: U8] => ConstLit::U8(u8::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U8Xor => const_step!([x, xst: U8, y, yst: U8] => ConstLit::U8(u8::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U8Eq => const_step!([x: U8, y: U8] => Const::Bool(x == y)),
+        Prim::U8Neq => const_step!([x: U8, y: U8] => Const::Bool(x != y)),
+        Prim::U8Gt => const_step!([x: U8, y: U8] => Const::Bool(x > y)),
+        Prim::U8Lt => const_step!([x: U8, y: U8] => Const::Bool(x < y)),
+        Prim::U8Gte => const_step!([x: U8, y: U8] => Const::Bool(x >= y)),
+        Prim::U8Lte => const_step!([x: U8, y: U8] => Const::Bool(x <= y)),
+        Prim::U8Add => const_step!([x, xst: U8, y, yst: U8] => Const::U8(u8::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U8Sub => const_step!([x, xst: U8, y, yst: U8] => Const::U8(u8::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U8Mul => const_step!([x, xst: U8, y, yst: U8] => Const::U8(u8::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U8Div => const_step!([x, xst: U8, y, yst: U8] => Const::U8(u8::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U8Not => const_step!([x, style: U8] => Const::U8(u8::not(*x), *style)),
+        Prim::U8Shl => const_step!([x, xst: U8, y, _yst: U8] => Const::U8(u8::checked_shl(*x, u32::from(*y))?, *xst)),
+        Prim::U8Shr => const_step!([x, xst: U8, y, _yst: U8] => Const::U8(u8::checked_shr(*x, u32::from(*y))?, *xst)),
+        Prim::U8And => const_step!([x, xst: U8, y, yst: U8] => Const::U8(u8::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U8Or => const_step!([x, xst: U8, y, yst: U8] => Const::U8(u8::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U8Xor => const_step!([x, xst: U8, y, yst: U8] => Const::U8(u8::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
 
-        Prim::U16Eq => const_step!([x: U16, y: U16] => ConstLit::Bool(x == y)),
-        Prim::U16Neq => const_step!([x: U16, y: U16] => ConstLit::Bool(x != y)),
-        Prim::U16Gt => const_step!([x: U16, y: U16] => ConstLit::Bool(x > y)),
-        Prim::U16Lt => const_step!([x: U16, y: U16] => ConstLit::Bool(x < y)),
-        Prim::U16Gte => const_step!([x: U16, y: U16] => ConstLit::Bool(x >= y)),
-        Prim::U16Lte => const_step!([x: U16, y: U16] => ConstLit::Bool(x <= y)),
-        Prim::U16Add => const_step!([x, xst: U16, y, yst: U16] => ConstLit::U16(u16::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U16Sub => const_step!([x, xst: U16, y, yst: U16] => ConstLit::U16(u16::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U16Mul => const_step!([x, xst: U16, y, yst: U16] => ConstLit::U16(u16::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U16Div => const_step!([x, xst: U16, y, yst: U16] => ConstLit::U16(u16::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U16Not => const_step!([x: U16] => ConstLit::U16(u16::not(*x), UIntStyle::Decimal)),
-        Prim::U16Shl => const_step!([x, xst: U16, y, _yst: U8] => ConstLit::U16(u16::checked_shl(*x, u32::from(*y))?, *xst)),
-        Prim::U16Shr => const_step!([x, xst: U16, y, _yst: U8] => ConstLit::U16(u16::checked_shr(*x, u32::from(*y))?, *xst)),
-        Prim::U16And => const_step!([x, xst: U16, y, yst: U16] => ConstLit::U16(u16::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U16Or => const_step!([x, xst: U16, y, yst: U16] => ConstLit::U16(u16::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U16Xor => const_step!([x, xst: U16, y, yst: U16] => ConstLit::U16(u16::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U16Eq => const_step!([x: U16, y: U16] => Const::Bool(x == y)),
+        Prim::U16Neq => const_step!([x: U16, y: U16] => Const::Bool(x != y)),
+        Prim::U16Gt => const_step!([x: U16, y: U16] => Const::Bool(x > y)),
+        Prim::U16Lt => const_step!([x: U16, y: U16] => Const::Bool(x < y)),
+        Prim::U16Gte => const_step!([x: U16, y: U16] => Const::Bool(x >= y)),
+        Prim::U16Lte => const_step!([x: U16, y: U16] => Const::Bool(x <= y)),
+        Prim::U16Add => const_step!([x, xst: U16, y, yst: U16] => Const::U16(u16::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U16Sub => const_step!([x, xst: U16, y, yst: U16] => Const::U16(u16::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U16Mul => const_step!([x, xst: U16, y, yst: U16] => Const::U16(u16::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U16Div => const_step!([x, xst: U16, y, yst: U16] => Const::U16(u16::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U16Not => const_step!([x: U16] => Const::U16(u16::not(*x), UIntStyle::Decimal)),
+        Prim::U16Shl => const_step!([x, xst: U16, y, _yst: U8] => Const::U16(u16::checked_shl(*x, u32::from(*y))?, *xst)),
+        Prim::U16Shr => const_step!([x, xst: U16, y, _yst: U8] => Const::U16(u16::checked_shr(*x, u32::from(*y))?, *xst)),
+        Prim::U16And => const_step!([x, xst: U16, y, yst: U16] => Const::U16(u16::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U16Or => const_step!([x, xst: U16, y, yst: U16] => Const::U16(u16::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U16Xor => const_step!([x, xst: U16, y, yst: U16] => Const::U16(u16::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
 
-        Prim::U32Eq => const_step!([x: U32, y: U32] => ConstLit::Bool(x == y)),
-        Prim::U32Neq => const_step!([x: U32, y: U32] => ConstLit::Bool(x != y)),
-        Prim::U32Gt => const_step!([x: U32, y: U32] => ConstLit::Bool(x > y)),
-        Prim::U32Lt => const_step!([x: U32, y: U32] => ConstLit::Bool(x < y)),
-        Prim::U32Gte => const_step!([x: U32, y: U32] => ConstLit::Bool(x >= y)),
-        Prim::U32Lte => const_step!([x: U32, y: U32] => ConstLit::Bool(x <= y)),
-        Prim::U32Add => const_step!([x, xst: U32, y, yst: U32] => ConstLit::U32(u32::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U32Sub => const_step!([x, xst: U32, y, yst: U32] => ConstLit::U32(u32::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U32Mul => const_step!([x, xst: U32, y, yst: U32] => ConstLit::U32(u32::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U32Div => const_step!([x, xst: U32, y, yst: U32] => ConstLit::U32(u32::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U32Not => const_step!([x: U32] => ConstLit::U32(u32::not(*x), UIntStyle::Decimal)),
-        Prim::U32Shl => const_step!([x, xst: U32, y, _yst: U8] => ConstLit::U32(u32::checked_shl(*x, u32::from(*y))?, *xst)),
-        Prim::U32Shr => const_step!([x, xst: U32, y, _yst: U8] => ConstLit::U32(u32::checked_shr(*x, u32::from(*y))?, *xst)),
-        Prim::U32And => const_step!([x, xst: U32, y, yst: U32] => ConstLit::U32(u32::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U32Or => const_step!([x, xst: U32, y, yst: U32] => ConstLit::U32(u32::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U32Xor => const_step!([x, xst: U32, y, yst: U32] => ConstLit::U32(u32::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U32Eq => const_step!([x: U32, y: U32] => Const::Bool(x == y)),
+        Prim::U32Neq => const_step!([x: U32, y: U32] => Const::Bool(x != y)),
+        Prim::U32Gt => const_step!([x: U32, y: U32] => Const::Bool(x > y)),
+        Prim::U32Lt => const_step!([x: U32, y: U32] => Const::Bool(x < y)),
+        Prim::U32Gte => const_step!([x: U32, y: U32] => Const::Bool(x >= y)),
+        Prim::U32Lte => const_step!([x: U32, y: U32] => Const::Bool(x <= y)),
+        Prim::U32Add => const_step!([x, xst: U32, y, yst: U32] => Const::U32(u32::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U32Sub => const_step!([x, xst: U32, y, yst: U32] => Const::U32(u32::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U32Mul => const_step!([x, xst: U32, y, yst: U32] => Const::U32(u32::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U32Div => const_step!([x, xst: U32, y, yst: U32] => Const::U32(u32::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U32Not => const_step!([x: U32] => Const::U32(u32::not(*x), UIntStyle::Decimal)),
+        Prim::U32Shl => const_step!([x, xst: U32, y, _yst: U8] => Const::U32(u32::checked_shl(*x, u32::from(*y))?, *xst)),
+        Prim::U32Shr => const_step!([x, xst: U32, y, _yst: U8] => Const::U32(u32::checked_shr(*x, u32::from(*y))?, *xst)),
+        Prim::U32And => const_step!([x, xst: U32, y, yst: U32] => Const::U32(u32::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U32Or => const_step!([x, xst: U32, y, yst: U32] => Const::U32(u32::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U32Xor => const_step!([x, xst: U32, y, yst: U32] => Const::U32(u32::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
 
-        Prim::U64Eq => const_step!([x: U64, y: U64] => ConstLit::Bool(x == y)),
-        Prim::U64Neq => const_step!([x: U64, y: U64] => ConstLit::Bool(x != y)),
-        Prim::U64Gt => const_step!([x: U64, y: U64] => ConstLit::Bool(x > y)),
-        Prim::U64Lt => const_step!([x: U64, y: U64] => ConstLit::Bool(x < y)),
-        Prim::U64Gte => const_step!([x: U64, y: U64] => ConstLit::Bool(x >= y)),
-        Prim::U64Lte => const_step!([x: U64, y: U64] => ConstLit::Bool(x <= y)),
-        Prim::U64Add => const_step!([x, xst: U64, y, yst: U64] => ConstLit::U64(u64::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U64Sub => const_step!([x, xst: U64, y, yst: U64] => ConstLit::U64(u64::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U64Mul => const_step!([x, xst: U64, y, yst: U64] => ConstLit::U64(u64::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U64Div => const_step!([x, xst: U64, y, yst: U64] => ConstLit::U64(u64::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
-        Prim::U64Not => const_step!([x: U64] => ConstLit::U64(u64::not(*x), UIntStyle::Decimal)),
-        Prim::U64Shl => const_step!([x, xst: U64, y, _yst: U8] => ConstLit::U64(u64::checked_shl(*x, u32::from(*y))?, *xst)),
-        Prim::U64Shr => const_step!([x, xst: U64, y, _yst: U8] => ConstLit::U64(u64::checked_shr(*x, u32::from(*y))?, *xst)),
-        Prim::U64And => const_step!([x, xst: U64, y, yst: U64] => ConstLit::U64(u64::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U64Or => const_step!([x, xst: U64, y, yst: U64] => ConstLit::U64(u64::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
-        Prim::U64Xor => const_step!([x, xst: U64, y, yst: U64] => ConstLit::U64(u64::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U64Eq => const_step!([x: U64, y: U64] => Const::Bool(x == y)),
+        Prim::U64Neq => const_step!([x: U64, y: U64] => Const::Bool(x != y)),
+        Prim::U64Gt => const_step!([x: U64, y: U64] => Const::Bool(x > y)),
+        Prim::U64Lt => const_step!([x: U64, y: U64] => Const::Bool(x < y)),
+        Prim::U64Gte => const_step!([x: U64, y: U64] => Const::Bool(x >= y)),
+        Prim::U64Lte => const_step!([x: U64, y: U64] => Const::Bool(x <= y)),
+        Prim::U64Add => const_step!([x, xst: U64, y, yst: U64] => Const::U64(u64::checked_add(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U64Sub => const_step!([x, xst: U64, y, yst: U64] => Const::U64(u64::checked_sub(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U64Mul => const_step!([x, xst: U64, y, yst: U64] => Const::U64(u64::checked_mul(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U64Div => const_step!([x, xst: U64, y, yst: U64] => Const::U64(u64::checked_div(*x, *y)?, UIntStyle::merge(*xst, *yst))),
+        Prim::U64Not => const_step!([x: U64] => Const::U64(u64::not(*x), UIntStyle::Decimal)),
+        Prim::U64Shl => const_step!([x, xst: U64, y, _yst: U8] => Const::U64(u64::checked_shl(*x, u32::from(*y))?, *xst)),
+        Prim::U64Shr => const_step!([x, xst: U64, y, _yst: U8] => Const::U64(u64::checked_shr(*x, u32::from(*y))?, *xst)),
+        Prim::U64And => const_step!([x, xst: U64, y, yst: U64] => Const::U64(u64::bitand(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U64Or => const_step!([x, xst: U64, y, yst: U64] => Const::U64(u64::bitor(*x, *y), UIntStyle::merge(*xst, *yst))),
+        Prim::U64Xor => const_step!([x, xst: U64, y, yst: U64] => Const::U64(u64::bitxor(*x, *y), UIntStyle::merge(*xst, *yst))),
 
-        Prim::S8Eq => const_step!([x: S8, y: S8] => ConstLit::Bool(x == y)),
-        Prim::S8Neq => const_step!([x: S8, y: S8] => ConstLit::Bool(x != y)),
-        Prim::S8Gt => const_step!([x: S8, y: S8] => ConstLit::Bool(x > y)),
-        Prim::S8Lt => const_step!([x: S8, y: S8] => ConstLit::Bool(x < y)),
-        Prim::S8Gte => const_step!([x: S8, y: S8] => ConstLit::Bool(x >= y)),
-        Prim::S8Lte => const_step!([x: S8, y: S8] => ConstLit::Bool(x <= y)),
-        Prim::S8Neg => const_step!([x: S8] => ConstLit::S8(i8::checked_neg(*x)?)),
-        Prim::S8Add => const_step!([x: S8, y: S8] => ConstLit::S8(i8::checked_add(*x, *y)?)),
-        Prim::S8Sub => const_step!([x: S8, y: S8] => ConstLit::S8(i8::checked_sub(*x, *y)?)),
-        Prim::S8Mul => const_step!([x: S8, y: S8] => ConstLit::S8(i8::checked_mul(*x, *y)?)),
-        Prim::S8Div => const_step!([x: S8, y: S8] => ConstLit::S8(i8::checked_div(*x, *y)?)),
-        Prim::S8Abs => const_step!([x: S8] => ConstLit::S8(i8::abs(*x))),
-        Prim::S8UAbs => const_step!([x: S8] => ConstLit::U8(i8::unsigned_abs(*x), UIntStyle::Decimal)),
+        Prim::S8Eq => const_step!([x: S8, y: S8] => Const::Bool(x == y)),
+        Prim::S8Neq => const_step!([x: S8, y: S8] => Const::Bool(x != y)),
+        Prim::S8Gt => const_step!([x: S8, y: S8] => Const::Bool(x > y)),
+        Prim::S8Lt => const_step!([x: S8, y: S8] => Const::Bool(x < y)),
+        Prim::S8Gte => const_step!([x: S8, y: S8] => Const::Bool(x >= y)),
+        Prim::S8Lte => const_step!([x: S8, y: S8] => Const::Bool(x <= y)),
+        Prim::S8Neg => const_step!([x: S8] => Const::S8(i8::checked_neg(*x)?)),
+        Prim::S8Add => const_step!([x: S8, y: S8] => Const::S8(i8::checked_add(*x, *y)?)),
+        Prim::S8Sub => const_step!([x: S8, y: S8] => Const::S8(i8::checked_sub(*x, *y)?)),
+        Prim::S8Mul => const_step!([x: S8, y: S8] => Const::S8(i8::checked_mul(*x, *y)?)),
+        Prim::S8Div => const_step!([x: S8, y: S8] => Const::S8(i8::checked_div(*x, *y)?)),
+        Prim::S8Abs => const_step!([x: S8] => Const::S8(i8::abs(*x))),
+        Prim::S8UAbs => const_step!([x: S8] => Const::U8(i8::unsigned_abs(*x), UIntStyle::Decimal)),
 
-        Prim::S16Eq => const_step!([x: S16, y: S16] => ConstLit::Bool(x == y)),
-        Prim::S16Neq => const_step!([x: S16, y: S16] => ConstLit::Bool(x != y)),
-        Prim::S16Gt => const_step!([x: S16, y: S16] => ConstLit::Bool(x > y)),
-        Prim::S16Lt => const_step!([x: S16, y: S16] => ConstLit::Bool(x < y)),
-        Prim::S16Gte => const_step!([x: S16, y: S16] => ConstLit::Bool(x >= y)),
-        Prim::S16Lte => const_step!([x: S16, y: S16] => ConstLit::Bool(x <= y)),
-        Prim::S16Neg => const_step!([x: S16] => ConstLit::S16(i16::checked_neg(*x)?)),
-        Prim::S16Add => const_step!([x: S16, y: S16] => ConstLit::S16(i16::checked_add(*x, *y)?)),
-        Prim::S16Sub => const_step!([x: S16, y: S16] => ConstLit::S16(i16::checked_sub(*x, *y)?)),
-        Prim::S16Mul => const_step!([x: S16, y: S16] => ConstLit::S16(i16::checked_mul(*x, *y)?)),
-        Prim::S16Div => const_step!([x: S16, y: S16] => ConstLit::S16(i16::checked_div(*x, *y)?)),
-        Prim::S16Abs => const_step!([x: S16] => ConstLit::S16(i16::abs(*x))),
-        Prim::S16UAbs => const_step!([x: S16] => ConstLit::U16(i16::unsigned_abs(*x), UIntStyle::Decimal)),
+        Prim::S16Eq => const_step!([x: S16, y: S16] => Const::Bool(x == y)),
+        Prim::S16Neq => const_step!([x: S16, y: S16] => Const::Bool(x != y)),
+        Prim::S16Gt => const_step!([x: S16, y: S16] => Const::Bool(x > y)),
+        Prim::S16Lt => const_step!([x: S16, y: S16] => Const::Bool(x < y)),
+        Prim::S16Gte => const_step!([x: S16, y: S16] => Const::Bool(x >= y)),
+        Prim::S16Lte => const_step!([x: S16, y: S16] => Const::Bool(x <= y)),
+        Prim::S16Neg => const_step!([x: S16] => Const::S16(i16::checked_neg(*x)?)),
+        Prim::S16Add => const_step!([x: S16, y: S16] => Const::S16(i16::checked_add(*x, *y)?)),
+        Prim::S16Sub => const_step!([x: S16, y: S16] => Const::S16(i16::checked_sub(*x, *y)?)),
+        Prim::S16Mul => const_step!([x: S16, y: S16] => Const::S16(i16::checked_mul(*x, *y)?)),
+        Prim::S16Div => const_step!([x: S16, y: S16] => Const::S16(i16::checked_div(*x, *y)?)),
+        Prim::S16Abs => const_step!([x: S16] => Const::S16(i16::abs(*x))),
+        Prim::S16UAbs => const_step!([x: S16] => Const::U16(i16::unsigned_abs(*x), UIntStyle::Decimal)),
 
-        Prim::S32Eq => const_step!([x: S32, y: S32] => ConstLit::Bool(x == y)),
-        Prim::S32Neq => const_step!([x: S32, y: S32] => ConstLit::Bool(x != y)),
-        Prim::S32Gt => const_step!([x: S32, y: S32] => ConstLit::Bool(x > y)),
-        Prim::S32Lt => const_step!([x: S32, y: S32] => ConstLit::Bool(x < y)),
-        Prim::S32Gte => const_step!([x: S32, y: S32] => ConstLit::Bool(x >= y)),
-        Prim::S32Lte => const_step!([x: S32, y: S32] => ConstLit::Bool(x <= y)),
-        Prim::S32Neg => const_step!([x: S32] => ConstLit::S32(i32::checked_neg(*x)?)),
-        Prim::S32Add => const_step!([x: S32, y: S32] => ConstLit::S32(i32::checked_add(*x, *y)?)),
-        Prim::S32Sub => const_step!([x: S32, y: S32] => ConstLit::S32(i32::checked_sub(*x, *y)?)),
-        Prim::S32Mul => const_step!([x: S32, y: S32] => ConstLit::S32(i32::checked_mul(*x, *y)?)),
-        Prim::S32Div => const_step!([x: S32, y: S32] => ConstLit::S32(i32::checked_div(*x, *y)?)),
-        Prim::S32Abs => const_step!([x: S32] => ConstLit::S32(i32::abs(*x))),
-        Prim::S32UAbs => const_step!([x: S32] => ConstLit::U32(i32::unsigned_abs(*x), UIntStyle::Decimal)),
+        Prim::S32Eq => const_step!([x: S32, y: S32] => Const::Bool(x == y)),
+        Prim::S32Neq => const_step!([x: S32, y: S32] => Const::Bool(x != y)),
+        Prim::S32Gt => const_step!([x: S32, y: S32] => Const::Bool(x > y)),
+        Prim::S32Lt => const_step!([x: S32, y: S32] => Const::Bool(x < y)),
+        Prim::S32Gte => const_step!([x: S32, y: S32] => Const::Bool(x >= y)),
+        Prim::S32Lte => const_step!([x: S32, y: S32] => Const::Bool(x <= y)),
+        Prim::S32Neg => const_step!([x: S32] => Const::S32(i32::checked_neg(*x)?)),
+        Prim::S32Add => const_step!([x: S32, y: S32] => Const::S32(i32::checked_add(*x, *y)?)),
+        Prim::S32Sub => const_step!([x: S32, y: S32] => Const::S32(i32::checked_sub(*x, *y)?)),
+        Prim::S32Mul => const_step!([x: S32, y: S32] => Const::S32(i32::checked_mul(*x, *y)?)),
+        Prim::S32Div => const_step!([x: S32, y: S32] => Const::S32(i32::checked_div(*x, *y)?)),
+        Prim::S32Abs => const_step!([x: S32] => Const::S32(i32::abs(*x))),
+        Prim::S32UAbs => const_step!([x: S32] => Const::U32(i32::unsigned_abs(*x), UIntStyle::Decimal)),
 
-        Prim::S64Eq => const_step!([x: S64, y: S64] => ConstLit::Bool(x == y)),
-        Prim::S64Neq => const_step!([x: S64, y: S64] => ConstLit::Bool(x != y)),
-        Prim::S64Gt => const_step!([x: S64, y: S64] => ConstLit::Bool(x > y)),
-        Prim::S64Lt => const_step!([x: S64, y: S64] => ConstLit::Bool(x < y)),
-        Prim::S64Gte => const_step!([x: S64, y: S64] => ConstLit::Bool(x >= y)),
-        Prim::S64Lte => const_step!([x: S64, y: S64] => ConstLit::Bool(x <= y)),
-        Prim::S64Neg => const_step!([x: S64] => ConstLit::S64(i64::checked_neg(*x)?)),
-        Prim::S64Add => const_step!([x: S64, y: S64] => ConstLit::S64(i64::checked_add(*x, *y)?)),
-        Prim::S64Sub => const_step!([x: S64, y: S64] => ConstLit::S64(i64::checked_sub(*x, *y)?)),
-        Prim::S64Mul => const_step!([x: S64, y: S64] => ConstLit::S64(i64::checked_mul(*x, *y)?)),
-        Prim::S64Div => const_step!([x: S64, y: S64] => ConstLit::S64(i64::checked_div(*x, *y)?)),
-        Prim::S64Abs => const_step!([x: S64] => ConstLit::S64(i64::abs(*x))),
-        Prim::S64UAbs => const_step!([x: S64] => ConstLit::U64(i64::unsigned_abs(*x), UIntStyle::Decimal)),
+        Prim::S64Eq => const_step!([x: S64, y: S64] => Const::Bool(x == y)),
+        Prim::S64Neq => const_step!([x: S64, y: S64] => Const::Bool(x != y)),
+        Prim::S64Gt => const_step!([x: S64, y: S64] => Const::Bool(x > y)),
+        Prim::S64Lt => const_step!([x: S64, y: S64] => Const::Bool(x < y)),
+        Prim::S64Gte => const_step!([x: S64, y: S64] => Const::Bool(x >= y)),
+        Prim::S64Lte => const_step!([x: S64, y: S64] => Const::Bool(x <= y)),
+        Prim::S64Neg => const_step!([x: S64] => Const::S64(i64::checked_neg(*x)?)),
+        Prim::S64Add => const_step!([x: S64, y: S64] => Const::S64(i64::checked_add(*x, *y)?)),
+        Prim::S64Sub => const_step!([x: S64, y: S64] => Const::S64(i64::checked_sub(*x, *y)?)),
+        Prim::S64Mul => const_step!([x: S64, y: S64] => Const::S64(i64::checked_mul(*x, *y)?)),
+        Prim::S64Div => const_step!([x: S64, y: S64] => Const::S64(i64::checked_div(*x, *y)?)),
+        Prim::S64Abs => const_step!([x: S64] => Const::S64(i64::abs(*x))),
+        Prim::S64UAbs => const_step!([x: S64] => Const::U64(i64::unsigned_abs(*x), UIntStyle::Decimal)),
 
         Prim::OptionFold => step!(context, [_, _, on_none, on_some, option] => {
             match option.match_prim_spine()? {
@@ -536,10 +536,10 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
                 Value::ArrayLit(elems) => {
                     for elem in elems {
                         match context.fun_app(pred.clone(), elem.clone()).as_ref() {
-                            Value::ConstLit(ConstLit::Bool(true)) => {
+                            Value::ConstLit(Const::Bool(true)) => {
                                 return Some(Arc::new(Value::prim(Prim::OptionSome, [elem.clone()])))
                             },
-                            Value::ConstLit(ConstLit::Bool(false)) => {}
+                            Value::ConstLit(Const::Bool(false)) => {}
                             _ => return None,
                         }
                     }
@@ -549,10 +549,10 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
             })
         }
 
-        Prim::PosAddU8 => const_step!([x: Pos, y: U8] => ConstLit::Pos(u64::checked_add(*x, u64::from(*y))?)),
-        Prim::PosAddU16 => const_step!([x: Pos, y: U16] => ConstLit::Pos(u64::checked_add(*x, u64::from(*y))?)),
-        Prim::PosAddU32 => const_step!([x: Pos, y: U32] => ConstLit::Pos(u64::checked_add(*x, u64::from(*y))?)),
-        Prim::PosAddU64 => const_step!([x: Pos, y: U64] => ConstLit::Pos(u64::checked_add(*x, *y)?)),
+        Prim::PosAddU8 => const_step!([x: Pos, y: U8] => Const::Pos(u64::checked_add(*x, u64::from(*y))?)),
+        Prim::PosAddU16 => const_step!([x: Pos, y: U16] => Const::Pos(u64::checked_add(*x, u64::from(*y))?)),
+        Prim::PosAddU32 => const_step!([x: Pos, y: U32] => Const::Pos(u64::checked_add(*x, u64::from(*y))?)),
+        Prim::PosAddU64 => const_step!([x: Pos, y: U64] => Const::Pos(u64::checked_add(*x, *y)?)),
 
         _ => None,
     }
@@ -703,7 +703,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
     fn const_match(
         &self,
         mut head_expr: ArcValue<'arena>,
-        mut branches: Branches<'arena, ConstLit>,
+        mut branches: Branches<'arena, Const>,
     ) -> ArcValue<'arena> {
         match Arc::make_mut(&mut head_expr) {
             Value::ConstLit(r#const) => {

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -24,28 +24,33 @@ pub enum Value<'arena> {
     Stuck(Head, Vec<Elim<'arena>>),
     /// Universes.
     Universe,
+
     /// Dependent function types.
     FunType(Option<StringId>, ArcValue<'arena>, Closure<'arena>),
     /// Function introductions.
     FunIntro(Option<StringId>, Closure<'arena>),
+
     /// Record types.
     RecordType(&'arena [StringId], Telescope<'arena>),
     /// Record introductions.
     RecordIntro(&'arena [StringId], Vec<ArcValue<'arena>>),
+
     /// Array Introductions.
     ArrayIntro(Vec<ArcValue<'arena>>),
+
     /// Record formats, consisting of a list of dependent formats.
     FormatRecord(&'arena [StringId], Telescope<'arena>),
     /// Overlap formats, consisting of a list of dependent formats, overlapping
     /// in memory.
     FormatOverlap(&'arena [StringId], Telescope<'arena>),
+
     /// Constants.
     Const(Const),
 }
 
 impl<'arena> Value<'arena> {
     pub fn prim(prim: Prim, inputs: impl IntoIterator<Item = ArcValue<'arena>>) -> Value<'arena> {
-        let inputs = inputs.into_iter().map(Elim::Fun).collect();
+        let inputs = inputs.into_iter().map(Elim::FunApp).collect();
         Value::Stuck(Head::Prim(prim), inputs)
     }
 
@@ -68,7 +73,7 @@ impl<'arena> Value<'arena> {
 /// The head of a [stuck value][Value::Stuck].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Head {
-    /// Format repr eliminations.
+    /// Primitives that have not yet been reduced.
     Prim(Prim),
     /// Variables that refer to rigid binders.
     RigidVar(GlobalVar),
@@ -80,12 +85,12 @@ pub enum Head {
 /// value][Value::Stuck] becomes known.
 #[derive(Debug, Clone)]
 pub enum Elim<'arena> {
-    /// Function eliminations.
-    Fun(ArcValue<'arena>),
-    /// Record eliminations.
-    Record(StringId),
-    /// Constant Eliminations.
-    Const(Split<'arena>),
+    /// Function applications.
+    FunApp(ArcValue<'arena>),
+    /// Record projections.
+    RecordProj(StringId),
+    /// Constant branches.
+    ConstCase(Branches<'arena, Const>),
 }
 
 /// A closure is a term that can later be instantiated with a value.
@@ -155,37 +160,37 @@ impl<'arena> Telescope<'arena> {
 
 /// The branches of a case split.
 #[derive(Debug, Clone)]
-pub struct Split<'arena> {
+pub struct Branches<'arena, P> {
     rigid_exprs: SharedEnv<ArcValue<'arena>>,
-    branches: &'arena [(Const, Term<'arena>)],
+    pattern_branches: &'arena [(P, Term<'arena>)],
     default_expr: Option<&'arena Term<'arena>>,
 }
 
-impl<'arena> Split<'arena> {
+impl<'arena, P> Branches<'arena, P> {
     /// Construct a case split.
     pub fn new(
         rigid_exprs: SharedEnv<ArcValue<'arena>>,
-        branches: &'arena [(Const, Term<'arena>)],
+        pattern_branches: &'arena [(P, Term<'arena>)],
         default_expr: Option<&'arena Term<'arena>>,
-    ) -> Split<'arena> {
-        Split {
+    ) -> Branches<'arena, P> {
+        Branches {
             rigid_exprs,
-            branches,
+            pattern_branches,
             default_expr,
         }
     }
 
     /// The number of branches in the case split.
     pub fn branches_len(&self) -> usize {
-        self.branches.len()
+        self.pattern_branches.len()
     }
 }
 
-pub type Branch<'arena> = (Const, ArcValue<'arena>);
+pub type PatternBranch<'arena, P> = (P, ArcValue<'arena>);
 
 #[derive(Clone, Debug)]
-pub enum SplitConstBranches<'arena> {
-    Branch(Branch<'arena>, Split<'arena>),
+pub enum SplitBranches<'arena, P> {
+    Branch(PatternBranch<'arena, P>, Branches<'arena, P>),
     Default(Closure<'arena>),
     None,
 }
@@ -196,8 +201,8 @@ pub enum SplitConstBranches<'arena> {
 pub enum Error {
     InvalidRigidVar,
     InvalidFlexibleVar,
-    InvalidFunctionElim,
-    InvalidRecordElim,
+    InvalidFunctionApp,
+    InvalidRecordProj,
     InvalidFormatRepr,
     MissingConstDefault,
 }
@@ -207,8 +212,8 @@ impl Error {
         match &self {
             Error::InvalidRigidVar => "invalid rigid variable",
             Error::InvalidFlexibleVar => "invalid flexible variable",
-            Error::InvalidFunctionElim => "invalid function elim",
-            Error::InvalidRecordElim => "invalid record elim",
+            Error::InvalidFunctionApp => "invalid function application",
+            Error::InvalidRecordProj => "invalid record projection",
             Error::InvalidFormatRepr => "invalid format repr",
             Error::MissingConstDefault => "missing default expression",
         }
@@ -273,7 +278,7 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                     head_expr = match info {
                         EntryInfo::Definition => head_expr,
                         EntryInfo::Parameter => {
-                            self.elim_context().apply_fun(head_expr, expr.clone())
+                            self.elim_context().apply_fun_app(head_expr, expr.clone())
                         }
                     };
                 }
@@ -288,6 +293,7 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 output_expr
             }
             Term::Universe => Arc::new(Value::Universe),
+
             Term::FunType(input_name, input_type, output_type) => Arc::new(Value::FunType(
                 *input_name,
                 self.eval(input_type),
@@ -297,11 +303,12 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 *input_name,
                 Closure::new(self.rigid_exprs.clone(), output_expr),
             )),
-            Term::FunElim(head_expr, input_expr) => {
+            Term::FunApp(head_expr, input_expr) => {
                 let head_expr = self.eval(head_expr);
                 let input_expr = self.eval(input_expr);
-                self.elim_context().apply_fun(head_expr, input_expr)
+                self.elim_context().apply_fun_app(head_expr, input_expr)
             }
+
             Term::RecordType(labels, types) => {
                 let types = Telescope::new(self.rigid_exprs.clone(), types);
                 Arc::new(Value::RecordType(labels, types))
@@ -310,16 +317,18 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 let exprs = exprs.iter().map(|expr| self.eval(expr)).collect();
                 Arc::new(Value::RecordIntro(labels, exprs))
             }
-            Term::RecordElim(head_expr, label) => {
+            Term::RecordProj(head_expr, label) => {
                 let head_expr = self.eval(head_expr);
-                self.elim_context().apply_record(head_expr, *label)
+                self.elim_context().apply_record_proj(head_expr, *label)
             }
+
             Term::ArrayIntro(elem_exprs) => {
                 let elem_exprs = (elem_exprs.iter())
                     .map(|elem_expr| self.eval(elem_expr))
                     .collect();
                 Arc::new(Value::ArrayIntro(elem_exprs))
             }
+
             Term::FormatRecord(labels, formats) => {
                 let formats = Telescope::new(self.rigid_exprs.clone(), formats);
                 Arc::new(Value::FormatRecord(labels, formats))
@@ -328,14 +337,14 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 let formats = Telescope::new(self.rigid_exprs.clone(), formats);
                 Arc::new(Value::FormatOverlap(labels, formats))
             }
+
             Term::Prim(prim) => Arc::new(Value::prim(*prim, [])),
+
             Term::Const(r#const) => Arc::new(Value::Const(*r#const)),
-            Term::ConstElim(head_expr, branches, default_expr) => {
+            Term::ConstCase(head_expr, branches, default_expr) => {
                 let head_expr = self.eval(head_expr);
-                self.elim_context().apply_const(
-                    head_expr,
-                    Split::new(self.rigid_exprs.clone(), branches, *default_expr),
-                )
+                let branches = Branches::new(self.rigid_exprs.clone(), branches, *default_expr);
+                self.elim_context().apply_const_case(head_expr, branches)
             }
         }
     }
@@ -348,7 +357,7 @@ type PrimStep =
 macro_rules! step {
     ($context:pat, [$($input:pat),*] => $output:expr) => {
         Some(|$context, spine| match spine {
-            [$(Elim::Fun($input)),*] => Some($output),
+            [$(Elim::FunApp($input)),*] => Some($output),
             _ => return None,
         })
     };
@@ -510,8 +519,8 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
 
         Prim::OptionFold => step!(context, [_, _, on_none, on_some, option] => {
             match option.match_prim_spine()? {
-                (Prim::OptionSome, [Elim::Fun(value)]) => {
-                    context.apply_fun(on_some.clone(), value.clone())
+                (Prim::OptionSome, [Elim::FunApp(value)]) => {
+                    context.apply_fun_app(on_some.clone(), value.clone())
                 },
                 (Prim::OptionNone, []) => on_none.clone(),
                 _ => return None,
@@ -522,7 +531,7 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
             step!(context, [_, _, pred, array] => match array.as_ref() {
                 Value::ArrayIntro(elems) => {
                     for elem in elems {
-                        match context.apply_fun(pred.clone(), elem.clone()).as_ref() {
+                        match context.apply_fun_app(pred.clone(), elem.clone()).as_ref() {
                             Value::Const(Const::Bool(true)) => {
                                 return Some(Arc::new(Value::prim(Prim::OptionSome, [elem.clone()])))
                             },
@@ -613,32 +622,30 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
         }))
     }
 
-    pub fn split_const_branches(
+    pub fn split_branches<P: Copy>(
         &self,
-        mut const_branches: Split<'arena>,
-    ) -> SplitConstBranches<'arena> {
-        match const_branches.branches.split_first() {
-            Some(((r#const, output_expr), branches)) => {
-                const_branches.branches = branches;
-                let mut context =
-                    EvalContext::new(&mut const_branches.rigid_exprs, self.flexible_exprs);
-                SplitConstBranches::Branch((*r#const, context.eval(output_expr)), const_branches)
+        mut branches: Branches<'arena, P>,
+    ) -> SplitBranches<'arena, P> {
+        match branches.pattern_branches.split_first() {
+            Some(((r#const, output_expr), pattern_branches)) => {
+                branches.pattern_branches = pattern_branches;
+                let mut context = EvalContext::new(&mut branches.rigid_exprs, self.flexible_exprs);
+                SplitBranches::Branch((*r#const, context.eval(output_expr)), branches)
             }
-            None => match const_branches.default_expr {
-                Some(default_expr) => SplitConstBranches::Default(Closure::new(
-                    const_branches.rigid_exprs,
-                    default_expr,
-                )),
-                None => SplitConstBranches::None,
+            None => match branches.default_expr {
+                Some(default_expr) => {
+                    SplitBranches::Default(Closure::new(branches.rigid_exprs, default_expr))
+                }
+                None => SplitBranches::None,
             },
         }
     }
 
-    /// Apply a function elimination to an expression, performing
+    /// Apply a function application to an expression, performing
     /// [beta-reduction] if possible.
     ///
     /// [beta-reduction]: https://ncatlab.org/nlab/show/beta-reduction
-    pub fn apply_fun(
+    pub fn apply_fun_app(
         &self,
         mut head_expr: ArcValue<'arena>,
         input_expr: ArcValue<'arena>,
@@ -648,7 +655,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
             Value::FunIntro(_, output_expr) => self.apply_closure(output_expr, input_expr),
             // The computation is stuck, preventing further reduction
             Value::Stuck(head, spine) => {
-                spine.push(Elim::Fun(input_expr));
+                spine.push(Elim::FunApp(input_expr));
 
                 match head {
                     Head::Prim(prim) => prim_step(*prim)
@@ -657,15 +664,15 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
                     _ => head_expr,
                 }
             }
-            _ => panic_any(Error::InvalidFunctionElim),
+            _ => panic_any(Error::InvalidFunctionApp),
         }
     }
 
-    /// Apply a record elimination to an expression, performing
+    /// Apply a record projection to an expression, performing
     /// [beta-reduction] if possible.
     ///
     /// [beta-reduction]: https://ncatlab.org/nlab/show/beta-reduction
-    pub fn apply_record(
+    pub fn apply_record_proj(
         &self,
         mut head_expr: ArcValue<'arena>,
         label: StringId,
@@ -675,29 +682,29 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
             Value::RecordIntro(labels, exprs) => (labels.iter())
                 .position(|current_label| *current_label == label)
                 .and_then(|expr_index| exprs.get(expr_index).cloned())
-                .unwrap_or_else(|| panic_any(Error::InvalidRecordElim)),
+                .unwrap_or_else(|| panic_any(Error::InvalidRecordProj)),
             // The computation is stuck, preventing further reduction
             Value::Stuck(_, spine) => {
-                spine.push(Elim::Record(label));
+                spine.push(Elim::RecordProj(label));
                 head_expr
             }
-            _ => panic_any(Error::InvalidRecordElim),
+            _ => panic_any(Error::InvalidRecordProj),
         }
     }
 
-    /// Apply a constant elimination to an expression, performing
+    /// Apply a constant case split to an expression, performing
     /// [beta-reduction] if possible.
     ///
     /// [beta-reduction]: https://ncatlab.org/nlab/show/beta-reduction
-    fn apply_const(
+    fn apply_const_case(
         &self,
         mut head_expr: ArcValue<'arena>,
-        mut split: Split<'arena>,
+        mut split: Branches<'arena, Const>,
     ) -> ArcValue<'arena> {
         match Arc::make_mut(&mut head_expr) {
             Value::Const(r#const) => {
                 // Try each branch
-                for (branch_const, output_expr) in split.branches {
+                for (branch_const, output_expr) in split.pattern_branches {
                     if r#const == branch_const {
                         return EvalContext::new(&mut split.rigid_exprs, self.flexible_exprs)
                             .eval(output_expr);
@@ -715,19 +722,19 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
             }
             // The computation is stuck, preventing further reduction
             Value::Stuck(_, spine) => {
-                spine.push(Elim::Const(split));
+                spine.push(Elim::ConstCase(split));
                 head_expr
             }
-            _ => panic_any(Error::InvalidRecordElim),
+            _ => panic_any(Error::InvalidRecordProj),
         }
     }
 
     /// Apply an expression to an elimination spine.
     fn apply_spine(&self, head_expr: ArcValue<'arena>, spine: &[Elim<'arena>]) -> ArcValue<'arena> {
         spine.iter().fold(head_expr, |head_expr, elim| match elim {
-            Elim::Fun(input_expr) => self.apply_fun(head_expr, input_expr.clone()),
-            Elim::Record(label) => self.apply_record(head_expr, *label),
-            Elim::Const(split) => self.apply_const(head_expr, split.clone()),
+            Elim::FunApp(input_expr) => self.apply_fun_app(head_expr, input_expr.clone()),
+            Elim::RecordProj(label) => self.apply_record_proj(head_expr, *label),
+            Elim::ConstCase(split) => self.apply_const_case(head_expr, split.clone()),
         })
     }
 
@@ -737,50 +744,48 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
             Value::FormatRecord(labels, formats) | Value::FormatOverlap(labels, formats) => {
                 Arc::new(Value::RecordType(labels, formats.clone().apply_repr()))
             }
-            Value::Stuck(Head::Prim(prim), spine) => {
-                match (prim, &spine[..]) {
-                    (Prim::FormatU8, []) => Arc::new(Value::prim(Prim::U8Type, [])),
-                    (Prim::FormatU16Be, []) => Arc::new(Value::prim(Prim::U16Type, [])),
-                    (Prim::FormatU16Le, []) => Arc::new(Value::prim(Prim::U16Type, [])),
-                    (Prim::FormatU32Be, []) => Arc::new(Value::prim(Prim::U32Type, [])),
-                    (Prim::FormatU32Le, []) => Arc::new(Value::prim(Prim::U32Type, [])),
-                    (Prim::FormatU64Be, []) => Arc::new(Value::prim(Prim::U64Type, [])),
-                    (Prim::FormatU64Le, []) => Arc::new(Value::prim(Prim::U64Type, [])),
-                    (Prim::FormatS8, []) => Arc::new(Value::prim(Prim::S8Type, [])),
-                    (Prim::FormatS16Be, []) => Arc::new(Value::prim(Prim::S16Type, [])),
-                    (Prim::FormatS16Le, []) => Arc::new(Value::prim(Prim::S16Type, [])),
-                    (Prim::FormatS32Be, []) => Arc::new(Value::prim(Prim::S32Type, [])),
-                    (Prim::FormatS32Le, []) => Arc::new(Value::prim(Prim::S32Type, [])),
-                    (Prim::FormatS64Be, []) => Arc::new(Value::prim(Prim::S64Type, [])),
-                    (Prim::FormatS64Le, []) => Arc::new(Value::prim(Prim::S64Type, [])),
-                    (Prim::FormatF32Be, []) => Arc::new(Value::prim(Prim::F32Type, [])),
-                    (Prim::FormatF32Le, []) => Arc::new(Value::prim(Prim::F32Type, [])),
-                    (Prim::FormatF64Be, []) => Arc::new(Value::prim(Prim::F64Type, [])),
-                    (Prim::FormatF64Le, []) => Arc::new(Value::prim(Prim::F64Type, [])),
-                    (Prim::FormatArray8, [Elim::Fun(len), Elim::Fun(elem)]) => Arc::new(
-                        Value::prim(Prim::Array8Type, [len.clone(), self.apply_repr(elem)]),
-                    ),
-                    (Prim::FormatArray16, [Elim::Fun(len), Elim::Fun(elem)]) => Arc::new(
-                        Value::prim(Prim::Array16Type, [len.clone(), self.apply_repr(elem)]),
-                    ),
-                    (Prim::FormatArray32, [Elim::Fun(len), Elim::Fun(elem)]) => Arc::new(
-                        Value::prim(Prim::Array32Type, [len.clone(), self.apply_repr(elem)]),
-                    ),
-                    (Prim::FormatArray64, [Elim::Fun(len), Elim::Fun(elem)]) => Arc::new(
-                        Value::prim(Prim::Array64Type, [len.clone(), self.apply_repr(elem)]),
-                    ),
-                    (Prim::FormatLink, [Elim::Fun(_), Elim::Fun(elem)]) => {
-                        Arc::new(Value::prim(Prim::RefType, [elem.clone()]))
-                    }
-                    (Prim::FormatDeref, [Elim::Fun(elem), Elim::Fun(_)]) => self.apply_repr(elem),
-                    (Prim::FormatStreamPos, []) => Arc::new(Value::prim(Prim::PosType, [])),
-                    (Prim::FormatSucceed, [Elim::Fun(elem), _]) => elem.clone(),
-                    (Prim::FormatFail, []) => Arc::new(Value::prim(Prim::VoidType, [])),
-                    (Prim::FormatUnwrap, [Elim::Fun(elem), _]) => elem.clone(),
-                    (Prim::ReportedError, []) => Arc::new(Value::prim(Prim::ReportedError, [])),
-                    _ => Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
+            Value::Stuck(Head::Prim(prim), spine) => match (prim, &spine[..]) {
+                (Prim::FormatU8, []) => Arc::new(Value::prim(Prim::U8Type, [])),
+                (Prim::FormatU16Be, []) => Arc::new(Value::prim(Prim::U16Type, [])),
+                (Prim::FormatU16Le, []) => Arc::new(Value::prim(Prim::U16Type, [])),
+                (Prim::FormatU32Be, []) => Arc::new(Value::prim(Prim::U32Type, [])),
+                (Prim::FormatU32Le, []) => Arc::new(Value::prim(Prim::U32Type, [])),
+                (Prim::FormatU64Be, []) => Arc::new(Value::prim(Prim::U64Type, [])),
+                (Prim::FormatU64Le, []) => Arc::new(Value::prim(Prim::U64Type, [])),
+                (Prim::FormatS8, []) => Arc::new(Value::prim(Prim::S8Type, [])),
+                (Prim::FormatS16Be, []) => Arc::new(Value::prim(Prim::S16Type, [])),
+                (Prim::FormatS16Le, []) => Arc::new(Value::prim(Prim::S16Type, [])),
+                (Prim::FormatS32Be, []) => Arc::new(Value::prim(Prim::S32Type, [])),
+                (Prim::FormatS32Le, []) => Arc::new(Value::prim(Prim::S32Type, [])),
+                (Prim::FormatS64Be, []) => Arc::new(Value::prim(Prim::S64Type, [])),
+                (Prim::FormatS64Le, []) => Arc::new(Value::prim(Prim::S64Type, [])),
+                (Prim::FormatF32Be, []) => Arc::new(Value::prim(Prim::F32Type, [])),
+                (Prim::FormatF32Le, []) => Arc::new(Value::prim(Prim::F32Type, [])),
+                (Prim::FormatF64Be, []) => Arc::new(Value::prim(Prim::F64Type, [])),
+                (Prim::FormatF64Le, []) => Arc::new(Value::prim(Prim::F64Type, [])),
+                (Prim::FormatArray8, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
+                    Value::prim(Prim::Array8Type, [len.clone(), self.apply_repr(elem)]),
+                ),
+                (Prim::FormatArray16, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
+                    Value::prim(Prim::Array16Type, [len.clone(), self.apply_repr(elem)]),
+                ),
+                (Prim::FormatArray32, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
+                    Value::prim(Prim::Array32Type, [len.clone(), self.apply_repr(elem)]),
+                ),
+                (Prim::FormatArray64, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
+                    Value::prim(Prim::Array64Type, [len.clone(), self.apply_repr(elem)]),
+                ),
+                (Prim::FormatLink, [Elim::FunApp(_), Elim::FunApp(elem)]) => {
+                    Arc::new(Value::prim(Prim::RefType, [elem.clone()]))
                 }
-            }
+                (Prim::FormatDeref, [Elim::FunApp(elem), Elim::FunApp(_)]) => self.apply_repr(elem),
+                (Prim::FormatStreamPos, []) => Arc::new(Value::prim(Prim::PosType, [])),
+                (Prim::FormatSucceed, [Elim::FunApp(elem), _]) => elem.clone(),
+                (Prim::FormatFail, []) => Arc::new(Value::prim(Prim::VoidType, [])),
+                (Prim::FormatUnwrap, [Elim::FunApp(elem), _]) => elem.clone(),
+                (Prim::ReportedError, []) => Arc::new(Value::prim(Prim::ReportedError, [])),
+                _ => Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
+            },
             Value::Stuck(_, _) => Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
             _ => panic_any(Error::InvalidFormatRepr),
         }
@@ -838,29 +843,31 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 };
 
                 spine.iter().fold(head_expr, |head_expr, elim| match elim {
-                    Elim::Fun(input_expr) => Term::FunElim(
+                    Elim::FunApp(input_expr) => Term::FunApp(
                         self.scope.to_scope(head_expr),
                         self.scope.to_scope(self.quote(input_expr)),
                     ),
-                    Elim::Record(label) => Term::RecordElim(self.scope.to_scope(head_expr), *label),
-                    Elim::Const(split) => {
+                    Elim::RecordProj(label) => {
+                        Term::RecordProj(self.scope.to_scope(head_expr), *label)
+                    }
+                    Elim::ConstCase(split) => {
                         let mut split = split.clone();
                         let mut branches = SliceVec::new(self.scope, split.branches_len());
 
                         let default_expr = loop {
-                            match self.elim_context().split_const_branches(split) {
-                                SplitConstBranches::Branch((r#const, output_expr), next_split) => {
+                            match self.elim_context().split_branches(split) {
+                                SplitBranches::Branch((r#const, output_expr), next_split) => {
                                     branches.push((r#const, self.quote(&output_expr)));
                                     split = next_split;
                                 }
-                                SplitConstBranches::Default(default_expr) => {
+                                SplitBranches::Default(default_expr) => {
                                     break Some(self.quote_closure(&default_expr))
                                 }
-                                SplitConstBranches::None => break None,
+                                SplitBranches::None => break None,
                             }
                         };
 
-                        Term::ConstElim(
+                        Term::ConstCase(
                             self.scope.to_scope(head_expr),
                             branches.into(),
                             default_expr.map(|expr| self.scope.to_scope(expr) as &_),
@@ -868,7 +875,9 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                     }
                 })
             }
+
             Value::Universe => Term::Universe,
+
             Value::FunType(input_name, input_type, output_type) => {
                 let input_type = self.quote(input_type);
                 let output_type = self.quote_closure(output_type);
@@ -884,6 +893,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
 
                 Term::FunIntro(*input_name, self.scope.to_scope(output_expr))
             }
+
             Value::RecordType(labels, types) => {
                 let labels = self.scope.to_scope_from_iter(labels.iter().copied()); // FIXME: avoid copy if this is the same arena?
                 let types = self.quote_telescope(types);
@@ -903,6 +913,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
 
                 Term::ArrayIntro(elem_exprs)
             }
+
             Value::FormatRecord(labels, formats) => {
                 let labels = self.scope.to_scope_from_iter(labels.iter().copied()); // FIXME: avoid copy if this is the same arena?
                 let formats = self.quote_telescope(formats);
@@ -915,6 +926,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
 
                 Term::FormatOverlap(labels, formats)
             }
+
             Value::Const(r#const) => Term::Const(*r#const),
         }
     }
@@ -1004,14 +1016,16 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
             | (_, Value::Stuck(Head::Prim(Prim::ReportedError), _)) => true,
 
             (Value::Stuck(head0, spine0), Value::Stuck(head1, spine1)) => {
+                use Elim::*;
+
                 head0 == head1
                     && spine0.len() == spine1.len()
                     && Iterator::zip(spine0.iter(), spine1.iter()).all(|(elim0, elim1)| {
                         match (elim0, elim1) {
-                            (Elim::Fun(expr0), Elim::Fun(expr1)) => self.is_equal(expr0, expr1),
-                            (Elim::Record(label0), Elim::Record(label1)) => label0 == label1,
-                            (Elim::Const(split0), Elim::Const(split1)) => {
-                                self.is_equal_splits(split0, split1)
+                            (FunApp(expr0), FunApp(expr1)) => self.is_equal(expr0, expr1),
+                            (RecordProj(label0), RecordProj(label1)) => label0 == label1,
+                            (ConstCase(branches0), ConstCase(branches1)) => {
+                                self.is_equal_branches(branches0, branches1)
                             }
                             (_, _) => false,
                         }
@@ -1026,11 +1040,9 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
                 self.is_equal(input_type0, input_type1)
                     && self.is_equal_closures(output_type0, output_type1)
             }
-
             (Value::FunIntro(_, output_expr0), Value::FunIntro(_, output_expr1)) => {
                 self.is_equal_closures(output_expr0, output_expr1)
             }
-            // Eta-conversion
             (Value::FunIntro(_, output_expr), _) => {
                 self.is_equal_fun_intro_elim(output_expr, &value1)
             }
@@ -1047,7 +1059,6 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
                     && Iterator::zip(exprs0.iter(), exprs1.iter())
                         .all(|(expr0, expr1)| self.is_equal(&expr0, &expr1))
             }
-            // Eta-conversion
             (Value::RecordIntro(labels, exprs), _) => {
                 self.is_equal_record_intro_elim(labels, exprs, &value1)
             }
@@ -1117,35 +1128,34 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
         true
     }
 
-    /// Check that two [case splits][Split] are equal.
-    fn is_equal_splits(&mut self, split0: &Split<'_>, split1: &Split<'_>) -> bool {
-        let mut split0 = split0.clone();
-        let mut split1 = split1.clone();
+    /// Check that two [constant branches][Branches] are equal.
+    fn is_equal_branches<P: PartialEq + Copy>(
+        &mut self,
+        branches0: &Branches<'_, P>,
+        branches1: &Branches<'_, P>,
+    ) -> bool {
+        use SplitBranches::*;
+
+        let mut branches0 = branches0.clone();
+        let mut branches1 = branches1.clone();
 
         loop {
             match (
-                self.elim_context().split_const_branches(split0),
-                self.elim_context().split_const_branches(split1),
+                self.elim_context().split_branches(branches0),
+                self.elim_context().split_branches(branches1),
             ) {
                 (
-                    SplitConstBranches::Branch((const0, output_expr0), next_split0),
-                    SplitConstBranches::Branch((const1, output_expr1), next_split1),
+                    Branch((const0, output_expr0), next_branches0),
+                    Branch((const1, output_expr1), next_branches1),
                 ) if const0 == const1 && self.is_equal(&output_expr0, &output_expr1) => {
-                    split0 = next_split0;
-                    split1 = next_split1;
+                    branches0 = next_branches0;
+                    branches1 = next_branches1;
                 }
-                (
-                    SplitConstBranches::Default(default_expr0),
-                    SplitConstBranches::Default(default_expr1),
-                ) => {
+                (Default(default_expr0), Default(default_expr1)) => {
                     return self.is_equal_closures(&default_expr0, &default_expr1);
                 }
-                (SplitConstBranches::None, SplitConstBranches::None) => {
-                    return true;
-                }
-                (_, _) => {
-                    return false;
-                }
+                (None, None) => return true,
+                (_, _) => return false,
             }
         }
     }
@@ -1153,7 +1163,9 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
     /// Check that a function is equal to a value, using eta-conversion.
     fn is_equal_fun_intro_elim(&mut self, output_expr: &Closure<'_>, value: &ArcValue<'_>) -> bool {
         let var = Arc::new(Value::rigid_var(self.rigid_exprs.next_global()));
-        let value = self.elim_context().apply_fun(value.clone(), var.clone());
+        let value = self
+            .elim_context()
+            .apply_fun_app(value.clone(), var.clone());
         let output_expr = self.elim_context().apply_closure(output_expr, var);
 
         self.push_rigid();
@@ -1171,7 +1183,7 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
         value: &ArcValue<'_>,
     ) -> bool {
         Iterator::zip(labels.iter(), exprs.iter()).all(|(label, expr)| {
-            let field_value = self.elim_context().apply_record(value.clone(), *label);
+            let field_value = self.elim_context().apply_record_proj(value.clone(), *label);
             self.is_equal(expr, &field_value)
         })
     }

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -22,6 +22,7 @@ pub enum Value<'arena> {
     /// of eliminations. Subsequent eliminations applied to this value are
     /// accumulated in the spine.
     Stuck(Head, Vec<Elim<'arena>>),
+
     /// Universes.
     Universe,
 
@@ -292,6 +293,7 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 self.rigid_exprs.pop();
                 output_expr
             }
+
             Term::Universe => Arc::new(Value::Universe),
 
             Term::FunType(input_name, input_type, output_type) => Arc::new(Value::FunType(
@@ -322,7 +324,7 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 self.elim_context().apply_record_proj(head_expr, *label)
             }
 
-            Term::ArrayIntro(elem_exprs) => {
+            Term::ArrayLit(elem_exprs) => {
                 let elem_exprs = (elem_exprs.iter())
                     .map(|elem_expr| self.eval(elem_expr))
                     .collect();
@@ -911,7 +913,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let elem_exprs = (self.scope)
                     .to_scope_from_iter(elem_exprs.iter().map(|elem_expr| self.quote(elem_expr)));
 
-                Term::ArrayIntro(elem_exprs)
+                Term::ArrayLit(elem_exprs)
             }
 
             Value::FormatRecord(labels, formats) => {

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -101,8 +101,8 @@ pub enum Term<'arena, Range> {
         Option<&'arena Term<'arena, Range>>,
         &'arena Term<'arena, Range>,
     ),
-    /// Function eliminations.
-    FunElim(
+    /// Applications.
+    App(
         Range,
         &'arena Term<'arena, Range>,
         &'arena Term<'arena, Range>,
@@ -113,8 +113,8 @@ pub enum Term<'arena, Range> {
     RecordLiteral(Range, &'arena [((Range, StringId), Term<'arena, Range>)]),
     /// Unit literals.
     UnitLiteral(Range),
-    /// Record eliminations.
-    RecordElim(Range, &'arena Term<'arena, Range>, (Range, StringId)),
+    /// Projections.
+    Proj(Range, &'arena Term<'arena, Range>, (Range, StringId)),
     /// Array literals.
     ArrayLiteral(Range, &'arena [Term<'arena, Range>]),
     /// String literal.
@@ -151,11 +151,11 @@ impl<'arena, Range: Clone> Term<'arena, Range> {
             | Term::Arrow(range, _, _)
             | Term::FunType(range, _, _, _)
             | Term::FunLiteral(range, _, _, _)
-            | Term::FunElim(range, _, _)
+            | Term::App(range, _, _)
             | Term::RecordType(range, _)
             | Term::RecordLiteral(range, _)
             | Term::UnitLiteral(range)
-            | Term::RecordElim(range, _, _)
+            | Term::Proj(range, _, _)
             | Term::ArrayLiteral(range, _)
             | Term::StringLiteral(range, _)
             | Term::NumberLiteral(range, _)

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -179,7 +179,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_expr),
                 )
             }
-            core::Term::FunIntro(input_name, output_expr) => {
+            core::Term::FunLit(input_name, output_expr) => {
                 let input_name = self.push_rigid(*input_name);
                 let output_expr = self.check(output_expr);
                 self.pop_rigid();
@@ -192,8 +192,8 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 )
             }
             core::Term::RecordType(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
-            core::Term::RecordIntro(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
-            core::Term::RecordIntro(labels, exprs) => {
+            core::Term::RecordLit(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
+            core::Term::RecordLit(labels, exprs) => {
                 let scope = self.scope;
                 let expr_fields = Iterator::zip(labels.iter(), exprs.iter())
                     .map(|(label, expr)| (((), *label), self.check(expr)));
@@ -207,7 +207,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 Term::ArrayLiteral((), scope.to_scope_from_iter(elem_exprs))
             }
             core::Term::FormatRecord(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
-            core::Term::Const(r#const) => match r#const {
+            core::Term::ConstLit(r#const) => match r#const {
                 core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
                 core::Const::U8(number, style) => self.check_number_literal_styled(number, *style),
                 core::Const::U16(number, style) => self.check_number_literal_styled(number, *style),
@@ -336,7 +336,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_type),
                 )
             }
-            core::Term::FunIntro(input_name, output_expr) => {
+            core::Term::FunLit(input_name, output_expr) => {
                 let input_name = self.push_rigid(*input_name);
                 let output_expr = self.synth(output_expr);
                 self.pop_rigid();
@@ -374,8 +374,8 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::RecordType((), type_fields)
             }
-            core::Term::RecordIntro(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
-            core::Term::RecordIntro(labels, exprs) => {
+            core::Term::RecordLit(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
+            core::Term::RecordLit(labels, exprs) => {
                 let scope = self.scope;
                 let expr_fields = Iterator::zip(labels.iter(), exprs.iter())
                     .map(|(label, expr)| (((), *label), self.synth(expr)));
@@ -406,7 +406,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 Term::FormatOverlap((), self.synth_format_fields(labels, formats))
             }
             core::Term::Prim(prim) => self.synth_prim(*prim),
-            core::Term::Const(r#const) => match r#const {
+            core::Term::ConstLit(r#const) => match r#const {
                 core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
                 core::Const::U8(number, style) => {
                     self.synth_number_literal_styled(number, *style, core::Prim::U8Type)

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -222,7 +222,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::ConstLit::Pos(num) => self.check_number_literal(num),
                 core::ConstLit::Ref(num) => self.check_number_literal(num),
             },
-            core::Term::ConstCase(head_expr, branches, default_expr) => {
+            core::Term::ConstMatch(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
                 match default_expr {
                     Some(default_expr) => {
@@ -429,7 +429,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::ConstLit::Pos(num) => self.synth_number_literal(num, core::Prim::PosType),
                 core::ConstLit::Ref(num) => self.synth_number_literal(num, core::Prim::RefType),
             },
-            core::Term::ConstCase(head_expr, branches, default_expr) => {
+            core::Term::ConstMatch(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
                 match default_expr {
                     Some(default_expr) => {

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -222,7 +222,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::Const::Pos(number) => self.check_number_literal(number),
                 core::Const::Ref(number) => self.check_number_literal(number),
             },
-            core::Term::ConstElim(head_expr, branches, default_expr) => {
+            core::Term::ConstCase(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
                 match default_expr {
                     Some(default_expr) => {
@@ -287,7 +287,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                         core::EntryInfo::Parameter => {
                             let var = self.rigid_len().global_to_local(var).unwrap();
                             let input_expr = self.check(&core::Term::RigidVar(var));
-                            head_expr = Term::FunElim(
+                            head_expr = Term::App(
                                 (),
                                 self.scope.to_scope(head_expr),
                                 self.scope.to_scope(input_expr),
@@ -348,11 +348,11 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_expr),
                 )
             }
-            core::Term::FunElim(head_expr, input_expr) => {
+            core::Term::FunApp(head_expr, input_expr) => {
                 let head_expr = self.synth(head_expr);
                 let input_expr = self.check(input_expr);
 
-                Term::FunElim(
+                Term::App(
                     (),
                     self.scope.to_scope(head_expr),
                     self.scope.to_scope(input_expr),
@@ -383,10 +383,10 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 // TODO: type annotations?
                 Term::RecordLiteral((), scope.to_scope_from_iter(expr_fields))
             }
-            core::Term::RecordElim(head_expr, label) => {
+            core::Term::RecordProj(head_expr, label) => {
                 let head_expr = self.synth(head_expr);
 
-                Term::RecordElim((), self.scope.to_scope(head_expr), ((), *label))
+                Term::Proj((), self.scope.to_scope(head_expr), ((), *label))
             }
             core::Term::ArrayIntro(elem_exprs) => {
                 let scope = self.scope;
@@ -429,7 +429,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::Const::Pos(number) => self.synth_number_literal(number, core::Prim::PosType),
                 core::Const::Ref(number) => self.synth_number_literal(number, core::Prim::RefType),
             },
-            core::Term::ConstElim(head_expr, branches, default_expr) => {
+            core::Term::ConstCase(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
                 match default_expr {
                     Some(default_expr) => {

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -109,21 +109,21 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
         Pattern::NumberLiteral((), number)
     }
 
-    fn check_constant_pattern(&mut self, r#const: &core::ConstLit) -> Pattern<()> {
+    fn check_constant_pattern(&mut self, r#const: &core::Const) -> Pattern<()> {
         match r#const {
-            core::ConstLit::Bool(boolean) => self.check_boolean_pattern(*boolean),
-            core::ConstLit::U8(num, style) => self.check_number_pattern_styled(num, *style),
-            core::ConstLit::U16(num, style) => self.check_number_pattern_styled(num, *style),
-            core::ConstLit::U32(num, style) => self.check_number_pattern_styled(num, *style),
-            core::ConstLit::U64(num, style) => self.check_number_pattern_styled(num, *style),
-            core::ConstLit::S8(num) => self.check_number_pattern(num),
-            core::ConstLit::S16(num) => self.check_number_pattern(num),
-            core::ConstLit::S32(num) => self.check_number_pattern(num),
-            core::ConstLit::S64(num) => self.check_number_pattern(num),
-            core::ConstLit::F32(num) => self.check_number_pattern(num),
-            core::ConstLit::F64(num) => self.check_number_pattern(num),
-            core::ConstLit::Pos(num) => self.check_number_pattern(num),
-            core::ConstLit::Ref(num) => self.check_number_pattern(num),
+            core::Const::Bool(boolean) => self.check_boolean_pattern(*boolean),
+            core::Const::U8(number, style) => self.check_number_pattern_styled(number, *style),
+            core::Const::U16(number, style) => self.check_number_pattern_styled(number, *style),
+            core::Const::U32(number, style) => self.check_number_pattern_styled(number, *style),
+            core::Const::U64(number, style) => self.check_number_pattern_styled(number, *style),
+            core::Const::S8(number) => self.check_number_pattern(number),
+            core::Const::S16(number) => self.check_number_pattern(number),
+            core::Const::S32(number) => self.check_number_pattern(number),
+            core::Const::S64(number) => self.check_number_pattern(number),
+            core::Const::F32(number) => self.check_number_pattern(number),
+            core::Const::F64(number) => self.check_number_pattern(number),
+            core::Const::Pos(number) => self.check_number_pattern(number),
+            core::Const::Ref(number) => self.check_number_pattern(number),
         }
     }
 
@@ -208,19 +208,19 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             }
             core::Term::FormatRecord(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
             core::Term::ConstLit(r#const) => match r#const {
-                core::ConstLit::Bool(boolean) => Term::BooleanLiteral((), *boolean),
-                core::ConstLit::U8(num, style) => self.check_number_literal_styled(num, *style),
-                core::ConstLit::U16(num, style) => self.check_number_literal_styled(num, *style),
-                core::ConstLit::U32(num, style) => self.check_number_literal_styled(num, *style),
-                core::ConstLit::U64(num, style) => self.check_number_literal_styled(num, *style),
-                core::ConstLit::S8(num) => self.check_number_literal(num),
-                core::ConstLit::S16(num) => self.check_number_literal(num),
-                core::ConstLit::S32(num) => self.check_number_literal(num),
-                core::ConstLit::S64(num) => self.check_number_literal(num),
-                core::ConstLit::F32(num) => self.check_number_literal(num),
-                core::ConstLit::F64(num) => self.check_number_literal(num),
-                core::ConstLit::Pos(num) => self.check_number_literal(num),
-                core::ConstLit::Ref(num) => self.check_number_literal(num),
+                core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
+                core::Const::U8(number, style) => self.check_number_literal_styled(number, *style),
+                core::Const::U16(number, style) => self.check_number_literal_styled(number, *style),
+                core::Const::U32(number, style) => self.check_number_literal_styled(number, *style),
+                core::Const::U64(number, style) => self.check_number_literal_styled(number, *style),
+                core::Const::S8(number) => self.check_number_literal(number),
+                core::Const::S16(number) => self.check_number_literal(number),
+                core::Const::S32(number) => self.check_number_literal(number),
+                core::Const::S64(number) => self.check_number_literal(number),
+                core::Const::F32(number) => self.check_number_literal(number),
+                core::Const::F64(number) => self.check_number_literal(number),
+                core::Const::Pos(number) => self.check_number_literal(number),
+                core::Const::Ref(number) => self.check_number_literal(number),
             },
             core::Term::ConstMatch(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
@@ -407,27 +407,27 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             }
             core::Term::Prim(prim) => self.synth_prim(*prim),
             core::Term::ConstLit(r#const) => match r#const {
-                core::ConstLit::Bool(boolean) => Term::BooleanLiteral((), *boolean),
-                core::ConstLit::U8(num, style) => {
-                    self.synth_number_literal_styled(num, *style, core::Prim::U8Type)
+                core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
+                core::Const::U8(number, style) => {
+                    self.synth_number_literal_styled(number, *style, core::Prim::U8Type)
                 }
-                core::ConstLit::U16(num, style) => {
-                    self.synth_number_literal_styled(num, *style, core::Prim::U16Type)
+                core::Const::U16(number, style) => {
+                    self.synth_number_literal_styled(number, *style, core::Prim::U16Type)
                 }
-                core::ConstLit::U32(num, style) => {
-                    self.synth_number_literal_styled(num, *style, core::Prim::U32Type)
+                core::Const::U32(number, style) => {
+                    self.synth_number_literal_styled(number, *style, core::Prim::U32Type)
                 }
-                core::ConstLit::U64(num, style) => {
-                    self.synth_number_literal_styled(num, *style, core::Prim::U64Type)
+                core::Const::U64(number, style) => {
+                    self.synth_number_literal_styled(number, *style, core::Prim::U64Type)
                 }
-                core::ConstLit::S8(num) => self.synth_number_literal(num, core::Prim::S8Type),
-                core::ConstLit::S16(num) => self.synth_number_literal(num, core::Prim::S16Type),
-                core::ConstLit::S32(num) => self.synth_number_literal(num, core::Prim::S32Type),
-                core::ConstLit::S64(num) => self.synth_number_literal(num, core::Prim::S64Type),
-                core::ConstLit::F32(num) => self.synth_number_literal(num, core::Prim::F32Type),
-                core::ConstLit::F64(num) => self.synth_number_literal(num, core::Prim::F64Type),
-                core::ConstLit::Pos(num) => self.synth_number_literal(num, core::Prim::PosType),
-                core::ConstLit::Ref(num) => self.synth_number_literal(num, core::Prim::RefType),
+                core::Const::S8(number) => self.synth_number_literal(number, core::Prim::S8Type),
+                core::Const::S16(number) => self.synth_number_literal(number, core::Prim::S16Type),
+                core::Const::S32(number) => self.synth_number_literal(number, core::Prim::S32Type),
+                core::Const::S64(number) => self.synth_number_literal(number, core::Prim::S64Type),
+                core::Const::F32(number) => self.synth_number_literal(number, core::Prim::F32Type),
+                core::Const::F64(number) => self.synth_number_literal(number, core::Prim::F64Type),
+                core::Const::Pos(number) => self.synth_number_literal(number, core::Prim::PosType),
+                core::Const::Ref(number) => self.synth_number_literal(number, core::Prim::RefType),
             },
             core::Term::ConstMatch(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -109,21 +109,21 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
         Pattern::NumberLiteral((), number)
     }
 
-    fn check_constant_pattern(&mut self, r#const: &core::Const) -> Pattern<()> {
+    fn check_constant_pattern(&mut self, r#const: &core::ConstLit) -> Pattern<()> {
         match r#const {
-            core::Const::Bool(boolean) => self.check_boolean_pattern(*boolean),
-            core::Const::U8(number, style) => self.check_number_pattern_styled(number, *style),
-            core::Const::U16(number, style) => self.check_number_pattern_styled(number, *style),
-            core::Const::U32(number, style) => self.check_number_pattern_styled(number, *style),
-            core::Const::U64(number, style) => self.check_number_pattern_styled(number, *style),
-            core::Const::S8(number) => self.check_number_pattern(number),
-            core::Const::S16(number) => self.check_number_pattern(number),
-            core::Const::S32(number) => self.check_number_pattern(number),
-            core::Const::S64(number) => self.check_number_pattern(number),
-            core::Const::F32(number) => self.check_number_pattern(number),
-            core::Const::F64(number) => self.check_number_pattern(number),
-            core::Const::Pos(number) => self.check_number_pattern(number),
-            core::Const::Ref(number) => self.check_number_pattern(number),
+            core::ConstLit::Bool(boolean) => self.check_boolean_pattern(*boolean),
+            core::ConstLit::U8(num, style) => self.check_number_pattern_styled(num, *style),
+            core::ConstLit::U16(num, style) => self.check_number_pattern_styled(num, *style),
+            core::ConstLit::U32(num, style) => self.check_number_pattern_styled(num, *style),
+            core::ConstLit::U64(num, style) => self.check_number_pattern_styled(num, *style),
+            core::ConstLit::S8(num) => self.check_number_pattern(num),
+            core::ConstLit::S16(num) => self.check_number_pattern(num),
+            core::ConstLit::S32(num) => self.check_number_pattern(num),
+            core::ConstLit::S64(num) => self.check_number_pattern(num),
+            core::ConstLit::F32(num) => self.check_number_pattern(num),
+            core::ConstLit::F64(num) => self.check_number_pattern(num),
+            core::ConstLit::Pos(num) => self.check_number_pattern(num),
+            core::ConstLit::Ref(num) => self.check_number_pattern(num),
         }
     }
 
@@ -208,19 +208,19 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             }
             core::Term::FormatRecord(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
             core::Term::ConstLit(r#const) => match r#const {
-                core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
-                core::Const::U8(number, style) => self.check_number_literal_styled(number, *style),
-                core::Const::U16(number, style) => self.check_number_literal_styled(number, *style),
-                core::Const::U32(number, style) => self.check_number_literal_styled(number, *style),
-                core::Const::U64(number, style) => self.check_number_literal_styled(number, *style),
-                core::Const::S8(number) => self.check_number_literal(number),
-                core::Const::S16(number) => self.check_number_literal(number),
-                core::Const::S32(number) => self.check_number_literal(number),
-                core::Const::S64(number) => self.check_number_literal(number),
-                core::Const::F32(number) => self.check_number_literal(number),
-                core::Const::F64(number) => self.check_number_literal(number),
-                core::Const::Pos(number) => self.check_number_literal(number),
-                core::Const::Ref(number) => self.check_number_literal(number),
+                core::ConstLit::Bool(boolean) => Term::BooleanLiteral((), *boolean),
+                core::ConstLit::U8(num, style) => self.check_number_literal_styled(num, *style),
+                core::ConstLit::U16(num, style) => self.check_number_literal_styled(num, *style),
+                core::ConstLit::U32(num, style) => self.check_number_literal_styled(num, *style),
+                core::ConstLit::U64(num, style) => self.check_number_literal_styled(num, *style),
+                core::ConstLit::S8(num) => self.check_number_literal(num),
+                core::ConstLit::S16(num) => self.check_number_literal(num),
+                core::ConstLit::S32(num) => self.check_number_literal(num),
+                core::ConstLit::S64(num) => self.check_number_literal(num),
+                core::ConstLit::F32(num) => self.check_number_literal(num),
+                core::ConstLit::F64(num) => self.check_number_literal(num),
+                core::ConstLit::Pos(num) => self.check_number_literal(num),
+                core::ConstLit::Ref(num) => self.check_number_literal(num),
             },
             core::Term::ConstCase(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
@@ -407,27 +407,27 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             }
             core::Term::Prim(prim) => self.synth_prim(*prim),
             core::Term::ConstLit(r#const) => match r#const {
-                core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
-                core::Const::U8(number, style) => {
-                    self.synth_number_literal_styled(number, *style, core::Prim::U8Type)
+                core::ConstLit::Bool(boolean) => Term::BooleanLiteral((), *boolean),
+                core::ConstLit::U8(num, style) => {
+                    self.synth_number_literal_styled(num, *style, core::Prim::U8Type)
                 }
-                core::Const::U16(number, style) => {
-                    self.synth_number_literal_styled(number, *style, core::Prim::U16Type)
+                core::ConstLit::U16(num, style) => {
+                    self.synth_number_literal_styled(num, *style, core::Prim::U16Type)
                 }
-                core::Const::U32(number, style) => {
-                    self.synth_number_literal_styled(number, *style, core::Prim::U32Type)
+                core::ConstLit::U32(num, style) => {
+                    self.synth_number_literal_styled(num, *style, core::Prim::U32Type)
                 }
-                core::Const::U64(number, style) => {
-                    self.synth_number_literal_styled(number, *style, core::Prim::U64Type)
+                core::ConstLit::U64(num, style) => {
+                    self.synth_number_literal_styled(num, *style, core::Prim::U64Type)
                 }
-                core::Const::S8(number) => self.synth_number_literal(number, core::Prim::S8Type),
-                core::Const::S16(number) => self.synth_number_literal(number, core::Prim::S16Type),
-                core::Const::S32(number) => self.synth_number_literal(number, core::Prim::S32Type),
-                core::Const::S64(number) => self.synth_number_literal(number, core::Prim::S64Type),
-                core::Const::F32(number) => self.synth_number_literal(number, core::Prim::F32Type),
-                core::Const::F64(number) => self.synth_number_literal(number, core::Prim::F64Type),
-                core::Const::Pos(number) => self.synth_number_literal(number, core::Prim::PosType),
-                core::Const::Ref(number) => self.synth_number_literal(number, core::Prim::RefType),
+                core::ConstLit::S8(num) => self.synth_number_literal(num, core::Prim::S8Type),
+                core::ConstLit::S16(num) => self.synth_number_literal(num, core::Prim::S16Type),
+                core::ConstLit::S32(num) => self.synth_number_literal(num, core::Prim::S32Type),
+                core::ConstLit::S64(num) => self.synth_number_literal(num, core::Prim::S64Type),
+                core::ConstLit::F32(num) => self.synth_number_literal(num, core::Prim::F32Type),
+                core::ConstLit::F64(num) => self.synth_number_literal(num, core::Prim::F64Type),
+                core::ConstLit::Pos(num) => self.synth_number_literal(num, core::Prim::PosType),
+                core::ConstLit::Ref(num) => self.synth_number_literal(num, core::Prim::RefType),
             },
             core::Term::ConstCase(head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -200,7 +200,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::RecordLiteral((), scope.to_scope_from_iter(expr_fields))
             }
-            core::Term::ArrayIntro(elem_exprs) => {
+            core::Term::ArrayLit(elem_exprs) => {
                 let scope = self.scope;
                 let elem_exprs = elem_exprs.iter().map(|elem_exprs| self.check(elem_exprs));
 
@@ -388,7 +388,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::Proj((), self.scope.to_scope(head_expr), ((), *label))
             }
-            core::Term::ArrayIntro(elem_exprs) => {
+            core::Term::ArrayLit(elem_exprs) => {
                 let scope = self.scope;
                 let elem_exprs = elem_exprs.iter().map(|elem_exprs| self.check(elem_exprs));
 

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1278,7 +1278,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     (elem_exprs.iter()).map(|elem_expr| self.check(elem_expr, elem_type)),
                 );
 
-                core::Term::ArrayIntro(elem_exprs)
+                core::Term::ArrayLit(elem_exprs)
             }
             (Term::StringLiteral(range, string), _) => {
                 let constant = match expected_type.match_prim_spine() {

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 use crate::alloc::SliceVec;
 use crate::core::semantics::{self, ArcValue, Closure, Head, Telescope, Value};
-use crate::core::{self, binary, ConstLit, Prim, UIntStyle};
+use crate::core::{self, binary, Const, Prim, UIntStyle};
 use crate::env::{self, EnvLen, GlobalVar, SharedEnv, UniqueEnv};
 use crate::source::ByteRange;
 use crate::surface::elaboration::reporting::Message;
@@ -600,7 +600,7 @@ impl<'arena> FlexibleEnv<'arena> {
 enum CheckedPattern {
     Name(ByteRange, StringId),
     Placeholder(ByteRange),
-    Const(ByteRange, ConstLit),
+    Const(ByteRange, Const),
     ReportedError(ByteRange),
 }
 
@@ -893,16 +893,16 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let constant = match expected_type.match_prim_spine() {
                     Some((Prim::U8Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U8(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U8(num, UIntStyle::Ascii)),
                     Some((Prim::U16Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U16(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U16(num, UIntStyle::Ascii)),
                     Some((Prim::U32Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U32(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U32(num, UIntStyle::Ascii)),
                     Some((Prim::U64Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U64(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U64(num, UIntStyle::Ascii)),
                     // Some((Prim::Array8Type, [len, _])) => todo!(),
                     // Some((Prim::Array16Type, [len, _])) => todo!(),
                     // Some((Prim::Array32Type, [len, _])) => todo!(),
@@ -927,26 +927,26 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     }
                 }
             }
-            Pattern::NumberLiteral(range, num) => {
+            Pattern::NumberLiteral(range, number) => {
                 let constant = match expected_type.match_prim_spine() {
                     Some((Prim::U8Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U8(num, style)),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U8(num, style)),
                     Some((Prim::U16Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U16(num, style)),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U16(num, style)),
                     Some((Prim::U32Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U32(num, style)),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U32(num, style)),
                     Some((Prim::U64Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U64(num, style)),
-                    Some((Prim::S8Type, [])) => self.parse_number(*range, *num).map(ConstLit::S8),
-                    Some((Prim::S16Type, [])) => self.parse_number(*range, *num).map(ConstLit::S16),
-                    Some((Prim::S32Type, [])) => self.parse_number(*range, *num).map(ConstLit::S32),
-                    Some((Prim::S64Type, [])) => self.parse_number(*range, *num).map(ConstLit::S64),
-                    Some((Prim::F32Type, [])) => self.parse_number(*range, *num).map(ConstLit::F32),
-                    Some((Prim::F64Type, [])) => self.parse_number(*range, *num).map(ConstLit::F64),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U64(num, style)),
+                    Some((Prim::S8Type, [])) => self.parse_number(*range, *number).map(Const::S8),
+                    Some((Prim::S16Type, [])) => self.parse_number(*range, *number).map(Const::S16),
+                    Some((Prim::S32Type, [])) => self.parse_number(*range, *number).map(Const::S32),
+                    Some((Prim::S64Type, [])) => self.parse_number(*range, *number).map(Const::S64),
+                    Some((Prim::F32Type, [])) => self.parse_number(*range, *number).map(Const::F32),
+                    Some((Prim::F64Type, [])) => self.parse_number(*range, *number).map(Const::F64),
                     Some((Prim::ReportedError, _)) => None,
                     _ => {
                         self.push_message(Message::NumericLiteralNotSupported { range: *range });
@@ -970,8 +970,8 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
             Pattern::BooleanLiteral(range, boolean) => {
                 let constant = match expected_type.match_prim_spine() {
                     Some((Prim::BoolType, [])) => match *boolean {
-                        true => Some(ConstLit::Bool(true)),
-                        false => Some(ConstLit::Bool(false)),
+                        true => Some(Const::Bool(true)),
+                        false => Some(Const::Bool(false)),
                     },
                     _ => {
                         self.push_message(Message::BooleanLiteralNotSupported { range: *range });
@@ -1024,7 +1024,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 (CheckedPattern::ReportedError(*range), r#type)
             }
             Pattern::BooleanLiteral(range, val) => {
-                let r#const = ConstLit::Bool(*val);
+                let r#const = Const::Bool(*val);
                 let r#type = Arc::new(Value::prim(Prim::BoolType, []));
                 (CheckedPattern::Const(*range, r#const), r#type)
             }
@@ -1247,10 +1247,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 };
 
                 let len = match len.as_ref() {
-                    Value::ConstLit(ConstLit::U8(len, _)) => Some(*len as u64),
-                    Value::ConstLit(ConstLit::U16(len, _)) => Some(*len as u64),
-                    Value::ConstLit(ConstLit::U32(len, _)) => Some(*len as u64),
-                    Value::ConstLit(ConstLit::U64(len, _)) => Some(*len as u64),
+                    Value::ConstLit(Const::U8(len, _)) => Some(*len as u64),
+                    Value::ConstLit(Const::U16(len, _)) => Some(*len as u64),
+                    Value::ConstLit(Const::U32(len, _)) => Some(*len as u64),
+                    Value::ConstLit(Const::U64(len, _)) => Some(*len as u64),
                     Value::Stuck(Head::Prim(Prim::ReportedError), _) => {
                         return core::Term::Prim(Prim::ReportedError);
                     }
@@ -1275,7 +1275,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             found_len: elem_exprs.len(),
                         });
 
-                        core::Term::Prim(Prim::ReportedError)
+                        return core::Term::Prim(Prim::ReportedError);
                     }
                 }
             }
@@ -1283,16 +1283,16 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let constant = match expected_type.match_prim_spine() {
                     Some((Prim::U8Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U8(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U8(num, UIntStyle::Ascii)),
                     Some((Prim::U16Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U16(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U16(num, UIntStyle::Ascii)),
                     Some((Prim::U32Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U32(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U32(num, UIntStyle::Ascii)),
                     Some((Prim::U64Type, [])) => self
                         .parse_ascii(*range, *string)
-                        .map(|num| ConstLit::U64(num, UIntStyle::Ascii)),
+                        .map(|num| Const::U64(num, UIntStyle::Ascii)),
                     // Some((Prim::Array8Type, [len, _])) => todo!(),
                     // Some((Prim::Array16Type, [len, _])) => todo!(),
                     // Some((Prim::Array32Type, [len, _])) => todo!(),
@@ -1309,26 +1309,26 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     None => core::Term::Prim(Prim::ReportedError),
                 }
             }
-            (Term::NumberLiteral(range, num), _) => {
+            (Term::NumberLiteral(range, number), _) => {
                 let constant = match expected_type.match_prim_spine() {
                     Some((Prim::U8Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U8(num, style)),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U8(num, style)),
                     Some((Prim::U16Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U16(num, style)),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U16(num, style)),
                     Some((Prim::U32Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U32(num, style)),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U32(num, style)),
                     Some((Prim::U64Type, [])) => self
-                        .parse_number_radix(*range, *num)
-                        .map(|(num, style)| ConstLit::U64(num, style)),
-                    Some((Prim::S8Type, [])) => self.parse_number(*range, *num).map(ConstLit::S8),
-                    Some((Prim::S16Type, [])) => self.parse_number(*range, *num).map(ConstLit::S16),
-                    Some((Prim::S32Type, [])) => self.parse_number(*range, *num).map(ConstLit::S32),
-                    Some((Prim::S64Type, [])) => self.parse_number(*range, *num).map(ConstLit::S64),
-                    Some((Prim::F32Type, [])) => self.parse_number(*range, *num).map(ConstLit::F32),
-                    Some((Prim::F64Type, [])) => self.parse_number(*range, *num).map(ConstLit::F64),
+                        .parse_number_radix(*range, *number)
+                        .map(|(num, style)| Const::U64(num, style)),
+                    Some((Prim::S8Type, [])) => self.parse_number(*range, *number).map(Const::S8),
+                    Some((Prim::S16Type, [])) => self.parse_number(*range, *number).map(Const::S16),
+                    Some((Prim::S32Type, [])) => self.parse_number(*range, *number).map(Const::S32),
+                    Some((Prim::S64Type, [])) => self.parse_number(*range, *number).map(Const::S64),
+                    Some((Prim::F32Type, [])) => self.parse_number(*range, *number).map(Const::F32),
+                    Some((Prim::F64Type, [])) => self.parse_number(*range, *number).map(Const::F64),
                     Some((Prim::ReportedError, _)) => None,
                     _ => {
                         self.push_message(Message::NumericLiteralNotSupported { range: *range });
@@ -1654,7 +1654,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
             }
             Term::BooleanLiteral(_range, val) => {
                 let bool_type = Arc::new(Value::prim(Prim::BoolType, []));
-                (core::Term::ConstLit(ConstLit::Bool(*val)), bool_type)
+                (core::Term::ConstLit(Const::Bool(*val)), bool_type)
             }
             Term::FormatRecord(range, format_fields) => {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));
@@ -1791,7 +1791,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                                     let output_term = self.check(output_expr, expected_type);
                                     // Find insertion index
                                     let res = branches.binary_search_by(
-                                        |(probe_const, _term): &(ConstLit, _)| {
+                                        |(probe_const, _term): &(Const, _)| {
                                             probe_const
                                                 .partial_cmp(&r#const)
                                                 .expect("attempt to compare non-ordered value")

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1189,7 +1189,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 self.rigid_env.pop();
 
-                core::Term::FunIntro(input_name, self.scope.to_scope(output_expr))
+                core::Term::FunLit(input_name, self.scope.to_scope(output_expr))
             }
             (Term::RecordLiteral(range, expr_fields), Value::RecordType(labels, types)) => {
                 // TODO: improve handling of duplicate labels
@@ -1220,7 +1220,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     exprs.push(expr);
                 }
 
-                core::Term::RecordIntro(labels, exprs.into())
+                core::Term::RecordLit(labels, exprs.into())
             }
             (Term::UnitLiteral(_), Value::Universe) => core::Term::RecordType(&[], &[]),
             (Term::UnitLiteral(_), _)
@@ -1247,10 +1247,14 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 };
 
                 match len.as_ref() {
-                    Value::Const(Const::U8(len, _)) if elem_exprs.len() as u64 == *len as u64 => {}
-                    Value::Const(Const::U16(len, _)) if elem_exprs.len() as u64 == *len as u64 => {}
-                    Value::Const(Const::U32(len, _)) if elem_exprs.len() as u64 == *len as u64 => {}
-                    Value::Const(Const::U64(len, _)) if elem_exprs.len() as u64 == *len as u64 => {}
+                    Value::ConstLit(Const::U8(len, _))
+                        if elem_exprs.len() as u64 == *len as u64 => {}
+                    Value::ConstLit(Const::U16(len, _))
+                        if elem_exprs.len() as u64 == *len as u64 => {}
+                    Value::ConstLit(Const::U32(len, _))
+                        if elem_exprs.len() as u64 == *len as u64 => {}
+                    Value::ConstLit(Const::U64(len, _))
+                        if elem_exprs.len() as u64 == *len as u64 => {}
                     Value::Stuck(Head::Prim(Prim::ReportedError), _) => {
                         return core::Term::Prim(Prim::ReportedError);
                     }
@@ -1302,7 +1306,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 };
 
                 match constant {
-                    Some(constant) => core::Term::Const(constant),
+                    Some(constant) => core::Term::ConstLit(constant),
                     None => core::Term::Prim(Prim::ReportedError),
                 }
             }
@@ -1334,7 +1338,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 };
 
                 match constant {
-                    Some(constant) => core::Term::Const(constant),
+                    Some(constant) => core::Term::ConstLit(constant),
                     None => core::Term::Prim(Prim::ReportedError),
                 }
             }
@@ -1480,7 +1484,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 self.rigid_env.pop();
 
                 (
-                    core::Term::FunIntro(input_name, self.scope.to_scope(output_expr)),
+                    core::Term::FunLit(input_name, self.scope.to_scope(output_expr)),
                     Arc::new(Value::FunType(
                         input_name,
                         input_type,
@@ -1586,12 +1590,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let types = Telescope::new(self.rigid_env.exprs.clone(), types.into());
 
                 (
-                    core::Term::RecordIntro(labels, exprs.into()),
+                    core::Term::RecordLit(labels, exprs.into()),
                     Arc::new(Value::RecordType(labels, types)),
                 )
             }
             Term::UnitLiteral(_) => (
-                core::Term::RecordIntro(&[], &[]),
+                core::Term::RecordLit(&[], &[]),
                 Arc::new(Value::RecordType(
                     &[],
                     Telescope::new(SharedEnv::new(), &[]),
@@ -1653,7 +1657,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
             }
             Term::BooleanLiteral(_range, val) => {
                 let bool_type = Arc::new(Value::prim(Prim::BoolType, []));
-                (core::Term::Const(Const::Bool(*val)), bool_type)
+                (core::Term::ConstLit(Const::Bool(*val)), bool_type)
             }
             Term::FormatRecord(range, format_fields) => {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -332,14 +332,14 @@ impl Message {
                         SpineError::NonLinearSpine(_var) => Diagnostic::error()
                             .with_message("variable appeared more than once in problem spine")
                             .with_labels(vec![Label::primary(file_id, *range)]),
-                        SpineError::NonRigidFunElim => Diagnostic::error()
+                        SpineError::NonRigidFunApp => Diagnostic::error()
                             .with_message("non-variable function application in problem spine")
                             .with_labels(vec![Label::primary(file_id, *range)]),
-                        SpineError::RecordElim(_label) => Diagnostic::error()
+                        SpineError::RecordProj(_label) => Diagnostic::error()
                             .with_message("record projection found in problem spine")
                             .with_labels(vec![Label::primary(file_id, *range)]),
-                        SpineError::ConstElim => Diagnostic::error()
-                            .with_message("constant elimination found in problem spine")
+                        SpineError::ConstCase => Diagnostic::error()
+                            .with_message("constant case split found in problem spine")
                             .with_labels(vec![Label::primary(file_id, *range)]),
                     },
                     Error::Rename(error) => match error {

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -338,8 +338,8 @@ impl Message {
                         SpineError::RecordProj(_label) => Diagnostic::error()
                             .with_message("record projection found in problem spine")
                             .with_labels(vec![Label::primary(file_id, *range)]),
-                        SpineError::ConstCase => Diagnostic::error()
-                            .with_message("constant case split found in problem spine")
+                        SpineError::ConstMatch => Diagnostic::error()
+                            .with_message("constant match found in problem spine")
                             .with_labels(vec![Label::primary(file_id, *range)]),
                     },
                     Error::Rename(error) => match error {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -362,6 +362,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
     }
 
     /// Unify a function literal with a value, using eta-conversion.
+    ///
+    /// ```fathom
+    /// (fun x => f x) = f
+    /// ```
     fn unify_fun_lit(
         &mut self,
         output_expr: &Closure<'arena>,
@@ -381,6 +385,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
     }
 
     /// Unify a record literal with a value, using eta-conversion.
+    ///
+    /// ```fathom
+    /// { x = r.x, y = r.y, .. } = r
+    /// ```
     fn unify_record_lit(
         &mut self,
         labels: &[StringId],

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -576,7 +576,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     new_elem_exprs.push(self.rename(flexible_var, elem_expr)?);
                 }
 
-                Ok(Term::ArrayIntro(new_elem_exprs.into()))
+                Ok(Term::ArrayLit(new_elem_exprs.into()))
             }
 
             Value::FormatRecord(labels, formats) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -453,7 +453,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         Ok(())
     }
 
-    /// Wrap a `term` in [function introductions][Term::FunIntro] that
+    /// Wrap a `term` in [function literals][Term::FunLit] that
     /// correspond to the given `spine`.
     fn fun_intros(&self, spine: &[Elim<'arena>], term: Term<'arena>) -> Term<'arena> {
         spine.iter().fold(term, |term, elim| match elim {
@@ -471,7 +471,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
     /// check error][Error::InfiniteSolution]).
     ///
     /// This allows us to subsequently wrap the returned term in function
-    /// introductions, using [`Context::function_intros`].
+    /// literals, using [`Context::function_intros`].
     fn rename(
         &mut self,
         flexible_var: GlobalVar,

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -120,7 +120,7 @@ FunTerm: Term<'arena, ByteRange> = {
 AppTerm: Term<'arena, ByteRange> = {
     AtomicTerm,
     <start: @L> <head_expr: AppTerm> <input_expr: AtomicTerm> <end: @R> => {
-        Term::FunElim(
+        Term::App(
             ByteRange::new(start, end),
             scope.to_scope(head_expr),
             scope.to_scope(input_expr),
@@ -156,11 +156,7 @@ AtomicTerm: Term<'arena, ByteRange> = {
         Term::FormatOverlap(ByteRange::new(start, end), fields)
     },
     <start: @L> <head_expr: AtomicTerm> "." <label: RangedName> <end: @R> => {
-        Term::RecordElim(
-            ByteRange::new(start, end),
-            scope.to_scope(head_expr),
-            label,
-        )
+        Term::Proj(ByteRange::new(start, end), scope.to_scope(head_expr), label)
     },
     <start: @L> "[" <exprs: Seq<Term, ",">> "]" <end: @R> => {
         Term::ArrayLiteral(ByteRange::new(start, end), exprs)

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -177,7 +177,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                     self.term_prec(Prec::Let, output_expr),
                 ]),
             ),
-            Term::FunElim(_, head_expr, input_expr) => self.paren(
+            Term::App(_, head_expr, input_expr) => self.paren(
                 prec > Prec::App,
                 self.concat([
                     self.term_prec(Prec::App, head_expr),
@@ -214,7 +214,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 self.text("}"),
             ),
             Term::UnitLiteral(_) => self.text("{}"),
-            Term::RecordElim(_, head_expr, (_, label)) => self.concat([
+            Term::Proj(_, head_expr, (_, label)) => self.concat([
                 self.term_prec(Prec::Atomic, head_expr),
                 self.text("."),
                 self.string_id(*label),

--- a/tests/succeed/prelude.fathom
+++ b/tests/succeed/prelude.fathom
@@ -119,7 +119,7 @@ let sym : fun (A : _) -> fun (a0 : A) -> fun (a1 : A) -> Eq _ a0 a1 -> Eq _ a1 a
 
 // Examples
 
-let id_elim_type = (fun a => a) Type;
+let id_apply_type = (fun a => a) Type;
 
 let list1 : List Bool
   = cons _ (id _ true) (nil _);
@@ -131,9 +131,9 @@ let thousand : Nat = mul ten hundred;
 
 let eq_test : Eq _ hundred hundred = refl _ _;
 
-let eq_id_elim_type : Eq _ ((fun a => a) Type) Type = refl _ _;
-let eq_id_elim_true : Eq _ ((fun a => a) true) true = refl _ _;
-let eq_id_elim_false : Eq _ ((fun a => a) false) false = refl _ _;
+let eq_id_apply_type : Eq _ ((fun a => a) Type) Type = refl _ _;
+let eq_id_apply_true : Eq _ ((fun a => a) true) true = refl _ _;
+let eq_id_apply_false : Eq _ ((fun a => a) false) false = refl _ _;
 
 
 Type

--- a/tests/succeed/prelude.snap
+++ b/tests/succeed/prelude.snap
@@ -86,7 +86,7 @@ let sym : fun (A : Type) -> fun (a0 : A) -> fun (a1 : A) -> fun (_ : fun (P :
 fun (_ : A) -> Type) -> fun (_ : P a0) -> P a1) -> fun (P : fun (_ : A) ->
 Type) -> fun (_ : P a1) -> P a0 =
 fun _ => fun a0 => fun a1 => fun p => p (fun a1 => Eq (_ _ a0 a1 p a1) a1 a0) (refl (_ _ a0 a1 p) (_ _ a0 a1 p));
-let id_elim_type : _ = (fun a => a) Type;
+let id_apply_type : _ = (fun a => a) Type;
 let list1 : fun (List : Type) -> fun (nil : List) -> fun (cons : fun (_ :
 Bool) -> fun (_ : List) -> List) -> List = cons _ (id _ true) (nil _);
 let five : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero :
@@ -102,11 +102,11 @@ Nat) -> fun (zero : Nat) -> Nat) -> Type) -> fun (_ :
 P (fun Nat => fun succ => fun zero => succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) ->
 P (fun Nat => fun succ => fun zero => succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) =
 refl _ _;
-let eq_id_elim_type : fun (P : fun (_ : Type) -> Type) -> fun (_ : P Type) ->
+let eq_id_apply_type : fun (P : fun (_ : Type) -> Type) -> fun (_ : P Type) ->
 P Type = refl _ _;
-let eq_id_elim_true : fun (P : fun (_ : Bool) -> Type) -> fun (_ : P true) ->
+let eq_id_apply_true : fun (P : fun (_ : Bool) -> Type) -> fun (_ : P true) ->
 P true = refl _ _;
-let eq_id_elim_false : fun (P : fun (_ : Bool) -> Type) -> fun (_ : P false) ->
+let eq_id_apply_false : fun (P : fun (_ : Bool) -> Type) -> fun (_ : P false) ->
 P false = refl _ _;
 Type : Type
 '''


### PR DESCRIPTION
Currently I use terminology from [natural deduction](https://ncatlab.org/nlab/show/natural+deduction) to inform the names of the variants in the core language. This has turned out to be a bit intimidating and a source of confusion. The consistency between the names seems to also get in the way of understanding.

In the interest of making it a bit easier to understand and work on Fathom, this PR switches to more familiar names. We can tweak this further down the line, but I hope it helps!

Let me know your thoughts on this.