### PR TITLE
Make read errors slightly better

### DIFF
--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt;
 use std::slice::SliceIndex;
 use std::sync::Arc;
 
@@ -20,6 +21,25 @@ pub enum ReadError {
     UnexpectedEndOfBuffer,
     PositionOverflow,
 }
+
+impl fmt::Display for ReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReadError::InvalidFormat => f.write_str("invalid format"),
+            ReadError::InvalidValue => f.write_str("invalid value"),
+            ReadError::UnwrappedNone => f.write_str("unwrapped none"),
+            ReadError::ReadFailFormat => f.write_str("read a fail format"),
+            ReadError::CondFailure => f.write_str("conditional format failed"),
+            ReadError::SetOffsetOutsideBuffer => {
+                f.write_str("attempt to set buffer offset beyond bounds of buffer")
+            }
+            ReadError::UnexpectedEndOfBuffer => f.write_str("unexpected end of buffer"),
+            ReadError::PositionOverflow => f.write_str("position overflow"),
+        }
+    }
+}
+
+impl std::error::Error for ReadError {}
 
 /// A buffer that starts at an offset into a larger buffer.
 ///

--- a/formats/data/edid/invalid/wrong-magic.snap
+++ b/formats/data/edid/invalid/wrong-magic.snap
@@ -1,10 +1,6 @@
 stdout = ''
 stderr = '''
-thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CondFailure', fathom/src/driver.rs:259:14
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-bug: compiler panicked at 'called `Result::unwrap()` on an `Err` value: CondFailure'
- = panicked at: fathom/src/driver.rs:259:14
- = please file a bug report at: https://github.com/yeslogic/fathom/issues/new
+error: conditional format failed
+ = The predicate on a conditional format did not succeed.
 
 '''


### PR DESCRIPTION
As discussed this is an attempt to make the read errors a bit nicer.

Some of the copy probably still has room for improvement/expanding. Also I wasn't sure about `InvalidFormat`. Is that an error that can be readily user triggered or is not supposed to be encountered in practice? If that latter then it can probably be moved to an `UnexpectedError`, at least for now.