### PR TITLE
Implement `where` sugar for refined fields

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -265,16 +265,16 @@ array8 3 {}
 #### Field refinements
 
 The parsed representations of fields can be refined with boolean predicates
-using the `when` syntax. If the predicate evaluates to `false`, the rest of the
+using the `where` syntax. If the predicate evaluates to `false`, the rest of the
 record format will fail to parse. For example:
 
 ```fathom
 {
-    magic <- u32be when u32_eq magic "icns",
-    //                  ▲      ▲
-    //                  │      └──── `magic` is bound as type `Repr u32be`
-    //                  │
-    //                  └──── `u32_eq magic "icns"` must be of type `Bool`
+    magic <- u32be where u32_eq magic "icns",
+    //                   ▲      ▲
+    //                   │      └──── `magic` is bound as type `Repr u32be`
+    //                   │
+    //                   └──── `u32_eq magic "icns"` must be of type `Bool`
 }
 ```
 
@@ -301,7 +301,7 @@ Some examples are as follows:
 | `{}`                                              | `{}`                                   |
 | `{ x <- f32le, y <- f32le }`                      | `{ x : F32, y : F32 }`                 |
 | `{ len <- u16be, data <- array16 len s8 }`        | `{ len : U16, data : Array16 len S8 }` |
-| `{ magic <- u32be when u32_eq magic "icns" }`     | `{ magic : U32 }`                      |
+| `{ magic <- u32be where u32_eq magic "icns" }`    | `{ magic : U32 }`                      |
 
 ### Conditional formats
 

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -240,6 +240,8 @@ data-dependent formats. For example:
 }
 ```
 
+#### Empty record formats
+
 Empty record formats must be checked in the presence of an annotation in order
 to disambiguate them from unit record types and literals. For example:
 
@@ -250,8 +252,7 @@ to disambiguate them from unit record types and literals. For example:
 ```fathom
 let unit : Format =
     {};
-
-...
+⋮
 ```
 
 No annotations needed in the following example, as the type can be inferred from
@@ -259,6 +260,32 @@ the type of `array8`:
 
 ```fathom
 array8 3 {}
+```
+
+#### Field refinements
+
+The parsed representations of fields can be refined with boolean predicates
+using the `when` syntax. If the predicate evaluates to `false`, the rest of the
+record format will fail to parse. For example:
+
+```fathom
+{
+    magic <- u32be when u32_eq magic "icns",
+    //                  ▲      ▲
+    //                  │      └──── `magic` is bound as type `Repr u32be`
+    //                  │
+    //                  └──── `u32_eq magic "icns"` must be of type `Bool`
+}
+```
+
+This can be thought of as a shorthand form of [conditional formats](#conditional-format),
+allowing the field label to be reused as the name bound by the conditional
+format. For example, the above format is equivalent to:
+
+```fathom
+{
+    magic <- { magic <- u32be | u32_eq magic "icns" },
+}
 ```
 
 #### Representation of record formats
@@ -269,30 +296,41 @@ formats, preserving dependencies as required.
 
 Some examples are as follows:
 
-| format                                     | `Repr` format                          |
-| ------------------------------------------ | -------------------------------------- |
-| `{}`                                       | `{}`                                   |
-| `{ x <- f32le, y <- f32le }`               | `{ x : F32, y : F32 }`                 |
-| `{ len <- u16be, data <- array16 len s8 }` | `{ len : U16, data : Array16 len S8 }` |
+| format                                            | `Repr` format                          |
+| ------------------------------------------------- | -------------------------------------- |
+| `{}`                                              | `{}`                                   |
+| `{ x <- f32le, y <- f32le }`                      | `{ x : F32, y : F32 }`                 |
+| `{ len <- u16be, data <- array16 len s8 }`        | `{ len : U16, data : Array16 len S8 }` |
+| `{ magic <- u32be when u32_eq magic "icns" }`     | `{ magic : U32 }`                      |
 
 ### Conditional formats
 
-Conditional formats are formats with an associated condition predicate. The format
-will only succeed if the condition is `true`. This can be used to verify magic numbers
-or version expectations. E.g.
+Conditional formats are formats that that have their parsed representations
+refined with boolean predicates. The format will only succeed if the predicate
+evaluates to `true`.
 
 ```fathom
-{ magic <- { magic <- u64le | u64_eq magic 0x00ffffffffffff00 } }
+{ x <- format | pred x }
+//              ▲    ▲
+//              │    └─── `x` is bound as type `Repr format` in the predicate
+//              │
+//              └──── `pred x` must be of type `Bool`
+```
+
+This can be used to verify magic numbers or version expectations. For example:
+
+```fathom
+{ magic <- u64le | u64_eq magic 0x00ffffffffffff00 }
 ```
 
 ```fathom
-{ major_version <- { version <- u16be | u16_lte version 2 } }
+{ version <- u16be | u16_lte version 2 }
 ```
 
 #### Representation of conditional formats
 
-The [representation](#format-representations) of a conditional format is the same
-as the representation of the format guarded by the predicate. I.e.
+The [representation](#format-representations) of a conditional format is the
+same as the representation of the refined format. I.e.
 
 | format                    | `Repr` format        |
 | ------------------------- | -------------------- |
@@ -306,10 +344,13 @@ enriched with information that occurs later on in the stream:
 
 ```fathom
 overlap {
-  records0 : array16 len array_record0,
-  records1 : array16 len (array_record0 records0),
+    records0 : array16 len array_record0,
+    records1 : array16 len (array_record0 records0),
 }
 ```
+
+Overlap formats also support [field refinements](#field-refinements), like in
+record formats.
 
 #### Representation of overlap formats
 
@@ -571,7 +612,7 @@ associated with a corresponding parameter.
 
 ### Record types
 
-Record types are formed as sequences of fields:
+Record types are formed as sequences of field declarations:
 
 ```fathom
 { x : F32, y : F32 }
@@ -590,7 +631,7 @@ The types of later fields and depend on previous fields:
 
 ### Record literals
 
-Records literals consist of a sequence of field assignments. For example:
+Records literals consist of a sequence of field definitions. For example:
 
 ```fathom
 let Point = { x : U32, y : U32 };

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -756,7 +756,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
             Value::FormatRecord(labels, formats) | Value::FormatOverlap(labels, formats) => {
                 Arc::new(Value::RecordType(labels, formats.clone().apply_repr()))
             }
-            Value::FormatCond(_label, format, _cond) => Arc::clone(format),
+            Value::FormatCond(_, format, _) => self.format_repr(format),
             Value::Stuck(Head::Prim(prim), spine) => match (prim, &spine[..]) {
                 (Prim::FormatU8, []) => Arc::new(Value::prim(Prim::U8Type, [])),
                 (Prim::FormatU16Be, []) => Arc::new(Value::prim(Prim::U16Type, [])),

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -204,9 +204,9 @@ pub struct FormatField<'arena, Range> {
     /// Label identifying the field
     label: (Range, StringId),
     /// The format that this field will be parsed with
-    format: &'arena Term<'arena, Range>,
+    format: Term<'arena, Range>,
     /// An optional predicate that refines the format field
-    pred: Option<&'arena Term<'arena, Range>>,
+    pred: Option<Term<'arena, Range>>,
 }
 
 /// A field declaration in a record type
@@ -215,7 +215,8 @@ pub struct TypeField<'arena, Range> {
     /// Label identifying the field
     label: (Range, StringId),
     /// The type that is expected for this field
-    type_: &'arena Term<'arena, Range>,
+    // FIXME: raw identifiers in LALRPOP grammars https://github.com/lalrpop/lalrpop/issues/613
+    type_: Term<'arena, Range>,
 }
 
 /// A field definition in a record literal
@@ -224,7 +225,7 @@ pub struct ExprField<'arena, Range> {
     /// Label identifying the field
     label: (Range, StringId),
     /// The expression that this field will store
-    expr: &'arena Term<'arena, Range>,
+    expr: Term<'arena, Range>,
 }
 
 /// Messages produced during parsing

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -108,9 +108,9 @@ pub enum Term<'arena, Range> {
         &'arena Term<'arena, Range>,
     ),
     /// Dependent record types.
-    RecordType(Range, &'arena [((Range, StringId), Term<'arena, Range>)]),
+    RecordType(Range, &'arena [TypeField<'arena, Range>]),
     /// Record literals.
-    RecordLiteral(Range, &'arena [((Range, StringId), Term<'arena, Range>)]),
+    RecordLiteral(Range, &'arena [ExprField<'arena, Range>]),
     /// Unit literals.
     UnitLiteral(Range),
     /// Projections.
@@ -130,9 +130,9 @@ pub enum Term<'arena, Range> {
     /// Boolean literals.
     BooleanLiteral(Range, bool),
     /// Record format.
-    FormatRecord(Range, &'arena [((Range, StringId), Term<'arena, Range>)]),
+    FormatRecord(Range, &'arena [FormatField<'arena, Range>]),
     /// Overlap format.
-    FormatOverlap(Range, &'arena [((Range, StringId), Term<'arena, Range>)]),
+    FormatOverlap(Range, &'arena [FormatField<'arena, Range>]),
     /// Conditional format.
     FormatCond(
         Range,
@@ -196,6 +196,35 @@ impl<'arena> Term<'arena, ByteRange> {
 
         (term, messages)
     }
+}
+
+/// A field declaration in a record and offset format
+#[derive(Debug, Clone)]
+pub struct FormatField<'arena, Range> {
+    /// Label identifying the field
+    label: (Range, StringId),
+    /// The format that this field will be parsed with
+    format: &'arena Term<'arena, Range>,
+    /// An optional predicate that refines the format field
+    pred: Option<&'arena Term<'arena, Range>>,
+}
+
+/// A field declaration in a record type
+#[derive(Debug, Clone)]
+pub struct TypeField<'arena, Range> {
+    /// Label identifying the field
+    label: (Range, StringId),
+    /// The type that is expected for this field
+    type_: &'arena Term<'arena, Range>,
+}
+
+/// A field definition in a record literal
+#[derive(Debug, Clone)]
+pub struct ExprField<'arena, Range> {
+    /// Label identifying the field
+    label: (Range, StringId),
+    /// The expression that this field will store
+    expr: &'arena Term<'arena, Range>,
 }
 
 /// Messages produced during parsing

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use crate::core::UIntStyle;
 use crate::env::{self, EnvLen, GlobalVar, LocalVar, UniqueEnv};
 use crate::surface::elaboration::FlexSource;
-use crate::surface::{Pattern, Term};
+use crate::surface::{ExprField, FormatField, Pattern, Term, TypeField};
 use crate::{core, StringId, StringInterner};
 
 /// Distillation context.
@@ -195,8 +195,11 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             core::Term::RecordLit(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
             core::Term::RecordLit(labels, exprs) => {
                 let scope = self.scope;
-                let expr_fields = Iterator::zip(labels.iter(), exprs.iter())
-                    .map(|(label, expr)| (((), *label), self.check(expr)));
+                let expr_fields =
+                    Iterator::zip(labels.iter(), exprs.iter()).map(|(label, expr)| ExprField {
+                        label: ((), *label),
+                        expr: scope.to_scope(self.check(expr)),
+                    });
 
                 Term::RecordLiteral((), scope.to_scope_from_iter(expr_fields))
             }
@@ -367,7 +370,10 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     Iterator::zip(labels.iter(), types.iter()).map(|(label, r#type)| {
                         let r#type = self.check(r#type);
                         self.push_rigid(Some(*label));
-                        (((), *label), r#type)
+                        TypeField {
+                            label: ((), *label),
+                            type_: self.scope.to_scope(r#type),
+                        }
                     }),
                 );
                 self.truncate_rigid(initial_rigid_len);
@@ -377,8 +383,14 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             core::Term::RecordLit(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
             core::Term::RecordLit(labels, exprs) => {
                 let scope = self.scope;
-                let expr_fields = Iterator::zip(labels.iter(), exprs.iter())
-                    .map(|(label, expr)| (((), *label), self.synth(expr)));
+                let expr_fields =
+                    Iterator::zip(labels.iter(), exprs.iter()).map(|(label, expr)| {
+                        let expr = self.synth(expr);
+                        ExprField {
+                            label: ((), *label),
+                            expr: self.scope.to_scope(expr),
+                        }
+                    });
 
                 // TODO: type annotations?
                 Term::RecordLiteral((), scope.to_scope_from_iter(expr_fields))
@@ -488,13 +500,17 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
         &mut self,
         labels: &[StringId],
         core_formats: &[core::Term<'_>],
-    ) -> &'arena [(((), StringId), Term<'arena, ()>)] {
+    ) -> &'arena [FormatField<'arena, ()>] {
         let initial_rigid_len = self.rigid_len();
         let format_fields = (self.scope).to_scope_from_iter(
             Iterator::zip(labels.iter(), core_formats.iter()).map(|(label, format)| {
                 let format = self.check(format);
                 self.push_rigid(Some(*label));
-                (((), *label), format)
+                FormatField {
+                    label: ((), *label),
+                    format: self.scope.to_scope(format),
+                    pred: None, // TODO: Use this when `format` is a conditional format
+                }
             }),
         );
         self.truncate_rigid(initial_rigid_len);

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -31,7 +31,7 @@ use crate::core::{self, binary, Const, Prim, UIntStyle};
 use crate::env::{self, EnvLen, GlobalVar, SharedEnv, UniqueEnv};
 use crate::source::ByteRange;
 use crate::surface::elaboration::reporting::Message;
-use crate::surface::{distillation, pretty, Pattern, Term};
+use crate::surface::{distillation, pretty, FormatField, Pattern, Term};
 use crate::{StringId, StringInterner};
 
 mod reporting;
@@ -760,25 +760,24 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
     /// Reports an error if there are duplicate fields found, returning a slice
     /// of the labels unique labels and an iterator over the unique fields.
-    fn report_duplicate_labels<'fields, 'a>(
+    fn report_duplicate_labels<'fields, F>(
         &mut self,
         range: ByteRange,
-        fields: &'fields [((ByteRange, StringId), Term<'a, ByteRange>)],
-    ) -> (
-        &'arena [StringId],
-        impl Iterator<Item = &'fields ((ByteRange, StringId), Term<'a, ByteRange>)>,
-    ) {
+        fields: &'fields [F],
+        get_label: fn(&F) -> (ByteRange, StringId),
+    ) -> (&'arena [StringId], impl Iterator<Item = &'fields F>) {
         let mut labels = SliceVec::new(self.scope, fields.len());
         // Will only allocate when duplicates are encountered
         let mut duplicate_indices = Vec::new();
         let mut duplicate_labels = Vec::new();
 
-        for (index, ((range, label), _)) in fields.iter().enumerate() {
-            if labels.contains(label) {
+        for (index, field) in fields.iter().enumerate() {
+            let (range, label) = get_label(field);
+            if labels.contains(&label) {
                 duplicate_indices.push(index);
-                duplicate_labels.push((*range, *label));
+                duplicate_labels.push((range, label));
             } else {
-                labels.push(*label)
+                labels.push(label)
             }
         }
 
@@ -1237,12 +1236,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 // TODO: improve handling of duplicate labels
                 if expr_fields.len() != labels.len()
                     || Iterator::zip(expr_fields.iter(), labels.iter())
-                        .any(|(((_, expr_label), _), type_label)| expr_label != type_label)
+                        .any(|(expr_field, type_label)| expr_field.label.1 != *type_label)
                 {
                     self.push_message(Message::MismatchedFieldLabels {
                         range: *range,
                         expr_labels: (expr_fields.iter())
-                            .map(|(ranged_label, _)| *ranged_label)
+                            .map(|expr_field| expr_field.label)
                             .collect(),
                         type_labels: labels.iter().copied().collect(),
                     });
@@ -1253,11 +1252,11 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let mut expr_fields = expr_fields.iter();
                 let mut exprs = SliceVec::new(self.scope, types.len());
 
-                while let Some(((_, expr), (r#type, next_types))) = Option::zip(
+                while let Some((expr_field, (r#type, next_types))) = Option::zip(
                     expr_fields.next(),
                     self.elim_context().split_telescope(types),
                 ) {
-                    let expr = self.check(expr, &r#type);
+                    let expr = self.check(expr_field.expr, &r#type);
                     types = next_types(self.eval_context().eval(&expr));
                     exprs.push(expr);
                 }
@@ -1619,13 +1618,15 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
             Term::RecordType(range, type_fields) => {
                 let universe = Arc::new(Value::Universe);
                 let initial_rigid_len = self.rigid_env.len();
-                let (labels, type_fields) = self.report_duplicate_labels(*range, type_fields);
+                let (labels, type_fields) =
+                    self.report_duplicate_labels(*range, type_fields, |f| f.label);
                 let mut types = SliceVec::new(self.scope, labels.len());
 
-                for ((_, label), r#type) in type_fields {
-                    let r#type = self.check(r#type, &universe);
+                for type_field in type_fields {
+                    let r#type = self.check(type_field.type_, &universe);
                     let type_value = self.eval_context().eval(&r#type);
-                    self.rigid_env.push_param(Some(*label), type_value);
+                    self.rigid_env
+                        .push_param(Some(type_field.label.1), type_value);
                     types.push(r#type);
                 }
 
@@ -1634,12 +1635,13 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 (core::Term::RecordType(labels, types.into()), universe)
             }
             Term::RecordLiteral(range, expr_fields) => {
-                let (labels, expr_fields) = self.report_duplicate_labels(*range, expr_fields);
+                let (labels, expr_fields) =
+                    self.report_duplicate_labels(*range, expr_fields, |f| f.label);
                 let mut types = SliceVec::new(self.scope, labels.len());
                 let mut exprs = SliceVec::new(self.scope, labels.len());
 
-                for (_, expr) in expr_fields {
-                    let (expr, r#type) = self.synth(expr);
+                for expr_field in expr_fields {
+                    let (expr, r#type) = self.synth(expr_field.expr);
                     types.push(self.quote_context(self.scope).quote(&r#type)); // NOTE: Unsure if these are correctly bound!
                     exprs.push(expr);
                 }
@@ -1720,21 +1722,21 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (core::Term::FormatRecord(labels, formats), format_type)
             }
-            Term::FormatCond(_range, (_, label), format, cond) => {
+            Term::FormatCond(_range, (_, name), format, pred) => {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));
                 let format = self.check(format, &format_type);
                 let format_value = self.eval_context().eval(&format);
-                let r#type = self.elim_context().format_repr(&format_value);
-                self.rigid_env.push_param(Some(*label), r#type);
+                let repr_type = self.elim_context().format_repr(&format_value);
+                self.rigid_env.push_param(Some(*name), repr_type);
                 let bool_type = Arc::new(Value::prim(Prim::BoolType, []));
-                let cond_expr = self.check(cond, &bool_type);
+                let pred_expr = self.check(pred, &bool_type);
                 self.rigid_env.pop();
 
                 (
                     core::Term::FormatCond(
-                        *label,
+                        *name,
                         self.scope.to_scope(format),
-                        self.scope.to_scope(cond_expr),
+                        self.scope.to_scope(pred_expr),
                     ),
                     format_type,
                 )
@@ -1759,19 +1761,38 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
     fn check_format_fields(
         &mut self,
         range: ByteRange,
-        format_fields: &[((ByteRange, StringId), Term<'_, ByteRange>)],
+        format_fields: &[FormatField<'_, ByteRange>],
     ) -> (&'arena [StringId], &'arena [core::Term<'arena>]) {
         let format_type = Arc::new(Value::prim(Prim::FormatType, []));
         let initial_rigid_len = self.rigid_env.len();
-        let (labels, format_fields) = self.report_duplicate_labels(range, format_fields);
+        let (labels, format_fields) =
+            self.report_duplicate_labels(range, format_fields, |f| f.label);
         let mut formats = SliceVec::new(self.scope, labels.len());
 
-        for ((_, label), format) in format_fields {
-            let format = self.check(format, &format_type);
+        for format_field in format_fields {
+            let label = format_field.label.1;
+            let format = self.check(format_field.format, &format_type);
             let format_value = self.eval_context().eval(&format);
             let r#type = self.elim_context().format_repr(&format_value);
-            self.rigid_env.push_param(Some(*label), r#type);
-            formats.push(format);
+
+            self.rigid_env.push_param(Some(label), r#type);
+
+            match format_field.pred {
+                None => formats.push(format),
+                // Elaborate refined fields to conditional formats
+                Some(pred) => {
+                    // Note: No need to push a param, as this was done above,
+                    // in preparation for checking the the next format field.
+                    let bool_type = Arc::new(Value::prim(Prim::BoolType, []));
+                    let cond_expr = self.check(pred, &bool_type);
+
+                    formats.push(core::Term::FormatCond(
+                        label,
+                        self.scope.to_scope(format),
+                        self.scope.to_scope(cond_expr),
+                    ));
+                }
+            }
         }
 
         self.rigid_env.truncate(initial_rigid_len);

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -29,7 +29,7 @@ extern {
         "Type" => Token::KeywordType,
         "true" => Token::KeywordTrue,
         "false" => Token::KeywordFalse,
-        "when" => Token::KeywordWhen,
+        "where" => Token::KeywordWhere,
 
         ":" => Token::Colon,
         "," => Token::Comma,
@@ -173,7 +173,7 @@ AtomicTerm: Term<'arena, ByteRange> = {
 };
 
 FormatField: FormatField<'arena, ByteRange> = {
-    <label: RangedName> "<-" <format: Term> <pred: ("when" <Term>)?> => {
+    <label: RangedName> "<-" <format: Term> <pred: ("where" <Term>)?> => {
         FormatField { label, format, pred }
     },
 };

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 
 use crate::{StringId, StringInterner};
 use crate::source::ByteRange;
-use crate::surface::{Term, ParseMessage, Pattern};
+use crate::surface::{ExprField, FormatField, ParseMessage, Pattern, Term, TypeField};
 use crate::surface::lexer::{Error as LexerError, Token};
 
 grammar<'arena, 'source>(
@@ -29,6 +29,7 @@ extern {
         "Type" => Token::KeywordType,
         "true" => Token::KeywordTrue,
         "false" => Token::KeywordFalse,
+        "when" => Token::KeywordWhen,
 
         ":" => Token::Colon,
         "," => Token::Comma,
@@ -144,19 +145,19 @@ AtomicTerm: Term<'arena, ByteRange> = {
     <start: @L> "true" <end: @R> => Term::BooleanLiteral(ByteRange::new(start, end), true),
     <start: @L> "false" <end: @R> => Term::BooleanLiteral(ByteRange::new(start, end), false),
     <start: @L> "{" "}" <end: @R> => Term::UnitLiteral(ByteRange::new(start, end)),
-    <start: @L> "{" <fields: NonEmptySeq<(<RangedName> ":" <Term>), ",">> "}" <end: @R> => {
+    <start: @L> "{" <fields: NonEmptySeq<TypeField, ",">> "}" <end: @R> => {
         Term::RecordType(ByteRange::new(start, end), fields)
     },
-    <start: @L> "{" <fields: NonEmptySeq<(<RangedName> "=" <Term>), ",">> "}" <end: @R> => {
+    <start: @L> "{" <fields: NonEmptySeq<ExprField, ",">> "}" <end: @R> => {
         Term::RecordLiteral(ByteRange::new(start, end), fields)
     },
-    <start: @L> "{" <fields: NonEmptySeq<(<RangedName> "<-" <Term>), ",">> "}" <end: @R> => {
+    <start: @L> "{" <fields: NonEmptySeq<FormatField, ",">> "}" <end: @R> => {
         Term::FormatRecord(ByteRange::new(start, end), fields)
     },
-    <start: @L> "{" <name:RangedName> "<-" <format:Term> "|" <cond:Term> "}" <end: @R> => {
+    <start: @L> "{" <name: RangedName> "<-" <format:Term> "|" <cond:Term> "}" <end: @R> => {
         Term::FormatCond(ByteRange::new(start, end), name, scope.to_scope(format), scope.to_scope(cond))
     },
-    <start: @L> "overlap" "{" <fields: NonEmptySeq<(<RangedName> "<-" <Term>), ",">> "}" <end: @R> => {
+    <start: @L> "overlap" "{" <fields: NonEmptySeq<FormatField, ",">> "}" <end: @R> => {
         Term::FormatOverlap(ByteRange::new(start, end), fields)
     },
     <start: @L> <head_expr: AtomicTerm> "." <label: RangedName> <end: @R> => {
@@ -169,6 +170,24 @@ AtomicTerm: Term<'arena, ByteRange> = {
         messages.push(ParseMessage::from(error));
         Term::ReportedError(ByteRange::new(start, end))
     },
+};
+
+FormatField: FormatField<'arena, ByteRange> = {
+    <label: RangedName> "<-" <format: Term> <pred: ("when" <Term>)?> => {
+        FormatField {
+            label,
+            format: scope.to_scope(format),
+            pred: pred.map(|pred| scope.to_scope(pred) as &_),
+        }
+    },
+};
+
+TypeField: TypeField<'arena, ByteRange> = {
+    <label: RangedName> ":" <type_: Term> => TypeField { label, type_: scope.to_scope(type_) },
+};
+
+ExprField: ExprField<'arena, ByteRange> = {
+    <label: RangedName> "=" <expr: Term> => ExprField { label, expr: scope.to_scope(expr) },
 };
 
 #[inline] Name: StringId = { <"name"> => interner.borrow_mut().get_or_intern(<>) };

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -174,20 +174,16 @@ AtomicTerm: Term<'arena, ByteRange> = {
 
 FormatField: FormatField<'arena, ByteRange> = {
     <label: RangedName> "<-" <format: Term> <pred: ("when" <Term>)?> => {
-        FormatField {
-            label,
-            format: scope.to_scope(format),
-            pred: pred.map(|pred| scope.to_scope(pred) as &_),
-        }
+        FormatField { label, format, pred }
     },
 };
 
 TypeField: TypeField<'arena, ByteRange> = {
-    <label: RangedName> ":" <type_: Term> => TypeField { label, type_: scope.to_scope(type_) },
+    <label: RangedName> ":" <type_: Term> => TypeField { label, type_ },
 };
 
 ExprField: ExprField<'arena, ByteRange> = {
-    <label: RangedName> "=" <expr: Term> => ExprField { label, expr: scope.to_scope(expr) },
+    <label: RangedName> "=" <expr: Term> => ExprField { label, expr },
 };
 
 #[inline] Name: StringId = { <"name"> => interner.borrow_mut().get_or_intern(<>) };

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -28,8 +28,8 @@ pub enum Token<'source> {
     KeywordTrue,
     #[token("false")]
     KeywordFalse,
-    #[token("when")]
-    KeywordWhen,
+    #[token("where")]
+    KeywordWhere,
 
     #[token(":")]
     Colon,
@@ -121,7 +121,7 @@ impl<'source> Token<'source> {
             Token::KeywordMatch => "match",
             Token::KeywordOverlap => "overlap",
             Token::KeywordType => "Type",
-            Token::KeywordWhen => "when",
+            Token::KeywordWhere => "where",
             Token::Colon => ":",
             Token::Comma => ",",
             Token::Equals => "=>",

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -28,6 +28,8 @@ pub enum Token<'source> {
     KeywordTrue,
     #[token("false")]
     KeywordFalse,
+    #[token("when")]
+    KeywordWhen,
 
     #[token(":")]
     Colon,
@@ -119,6 +121,7 @@ impl<'source> Token<'source> {
             Token::KeywordMatch => "match",
             Token::KeywordOverlap => "overlap",
             Token::KeywordType => "Type",
+            Token::KeywordWhen => "when",
             Token::Colon => ":",
             Token::Comma => ",",
             Token::Equals => "=>",

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -277,7 +277,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
             match &format_field.pred {
                 Some(pred) => self.concat([
                     self.space(),
-                    self.text("when"),
+                    self.text("where"),
                     self.space(),
                     self.term_prec(Prec::Top, &pred),
                 ]),
@@ -373,7 +373,7 @@ impl<'interner, 'arena, A: 'arena> DocAllocator<'arena, A> for Context<'interner
             Doc::BorrowedText("let") => &Doc::BorrowedText("let"),
             Doc::BorrowedText("overlap") => &Doc::BorrowedText("overlap"),
             Doc::BorrowedText("Type") => &Doc::BorrowedText("Type"),
-            Doc::BorrowedText("when") => &Doc::BorrowedText("when"),
+            Doc::BorrowedText("where") => &Doc::BorrowedText("where"),
             Doc::BorrowedText(":") => &Doc::BorrowedText(":"),
             Doc::BorrowedText(",") => &Doc::BorrowedText(","),
             Doc::BorrowedText("=") => &Doc::BorrowedText("="),

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -193,7 +193,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                         self.space(),
                         self.text(":"),
                         self.space(),
-                        self.term_prec(Prec::Top, field.type_),
+                        self.term_prec(Prec::Top, &field.type_),
                     ])
                 }),
                 self.text(","),
@@ -207,7 +207,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                         self.space(),
                         self.text("="),
                         self.space(),
-                        self.term_prec(Prec::Top, field.expr),
+                        self.term_prec(Prec::Top, &field.expr),
                     ])
                 }),
                 self.text(","),
@@ -273,13 +273,13 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
             self.space(),
             self.text("<-"),
             self.space(),
-            self.term_prec(Prec::Top, format_field.format),
-            match format_field.pred {
+            self.term_prec(Prec::Top, &format_field.format),
+            match &format_field.pred {
                 Some(pred) => self.concat([
                     self.space(),
                     self.text("when"),
                     self.space(),
-                    self.term_prec(Prec::Top, pred),
+                    self.term_prec(Prec::Top, &pred),
                 ]),
                 None => self.nil(),
             },

--- a/formats/edid.fathom
+++ b/formats/edid.fathom
@@ -15,7 +15,7 @@
 // TODO: Versions 1.0-1.4
 
 let header = {
-    magic <- { magic <- u64le | u64_eq magic 0x00ffffffffffff00 },
+    magic <- u64le when u64_eq magic 0x00ffffffffffff00,
     manufacturer_id <- u16le,                // TODO: bit patterns
     product_code <- u16le,
     serial <- u32le,

--- a/formats/edid.fathom
+++ b/formats/edid.fathom
@@ -15,7 +15,7 @@
 // TODO: Versions 1.0-1.4
 
 let header = {
-    magic <- u64le when u64_eq magic 0x00ffffffffffff00,
+    magic <- u64le where u64_eq magic 0x00ffffffffffff00,
     manufacturer_id <- u16le,                // TODO: bit patterns
     product_code <- u16le,
     serial <- u32le,

--- a/formats/edid.snap
+++ b/formats/edid.snap
@@ -1,6 +1,6 @@
 stdout = '''
 let header : _ = {
-    magic <- { magic <- u64le | u64_eq magic 0xffffffffffff00 },
+    magic <- u64le when u64_eq magic 0xffffffffffff00,
     manufacturer_id <- u16le,
     product_code <- u16le,
     serial <- u32le,

--- a/formats/edid.snap
+++ b/formats/edid.snap
@@ -1,6 +1,6 @@
 stdout = '''
 let header : _ = {
-    magic <- u64le when u64_eq magic 0xffffffffffff00,
+    magic <- u64le where u64_eq magic 0xffffffffffff00,
     manufacturer_id <- u16le,
     product_code <- u16le,
     serial <- u32le,

--- a/formats/icns.fathom
+++ b/formats/icns.fathom
@@ -5,7 +5,7 @@
 //! - [Wikipedia](https://en.wikipedia.org/wiki/Apple_Icon_Image_format)
 
 let header = {
-    magic <- u32be,                 // TODO: where magic == ascii "icns",
+    magic <- u32be when u32_eq magic "icns",
     file_length <- u32be,
 };
 
@@ -13,8 +13,7 @@ let icon_data = {
     icon_type <- u32be,             // TODO: bit patterns
     icon_data_length <- u32be,
     // TODO: decode data based on `icon_type`
-    // TODO: repeat while `current_pos < data_start + icon_data_length`
-    data <- array8 0 u8,
+    data <- limit32 icon_data_length (repeat_until_end u8),
 };
 
 let main = {

--- a/formats/icns.fathom
+++ b/formats/icns.fathom
@@ -5,7 +5,7 @@
 //! - [Wikipedia](https://en.wikipedia.org/wiki/Apple_Icon_Image_format)
 
 let header = {
-    magic <- u32be when u32_eq magic "icns",
+    magic <- u32be where u32_eq magic "icns",
     file_length <- u32be,
 };
 

--- a/formats/icns.snap
+++ b/formats/icns.snap
@@ -1,6 +1,6 @@
 stdout = '''
 let header : _ = {
-    magic <- u32be when u32_eq magic "icns",
+    magic <- u32be where u32_eq magic "icns",
     file_length <- u32be,
 };
 let icon_data : _ = {

--- a/formats/icns.snap
+++ b/formats/icns.snap
@@ -1,6 +1,6 @@
 stdout = '''
 let header : _ = {
-    magic <- { magic <- u32be | u32_eq magic "icns" },
+    magic <- u32be when u32_eq magic "icns",
     file_length <- u32be,
 };
 let icon_data : _ = {

--- a/formats/icns.snap
+++ b/formats/icns.snap
@@ -1,9 +1,12 @@
 stdout = '''
-let header : _ = { magic <- u32be, file_length <- u32be };
+let header : _ = {
+    magic <- { magic <- u32be | u32_eq magic "icns" },
+    file_length <- u32be,
+};
 let icon_data : _ = {
     icon_type <- u32be,
     icon_data_length <- u32be,
-    data <- array8 0 u8,
+    data <- limit32 icon_data_length (repeat_until_end u8),
 };
 let main : _ = { header <- header, icons <- repeat_until_end icon_data };
 main : Format

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -852,7 +852,7 @@ let cmap_table = {
 /// - [Apple's TrueType Reference Manual: The `'head'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6head.html)
 let head_table = {
     /// Major version number of the font header table.
-    major_version <- { version <- u16be | u16_eq version 1 },
+    major_version <- u16be when u16_eq major_version 1,
     /// Minor version number of the font header table.
     minor_version <- u16be, // TODO: where minor_version == 0
     /// Set by the font manufacturer.
@@ -864,13 +864,13 @@ let head_table = {
     checksum_adjustment <- u32be,
     /// [Magic number](https://en.wikipedia.org/wiki/File_format#Magic_number), always set to
     /// 0x5F0F3CF5
-    magic_number <- { magic <- u32be | u32_eq magic 0x5F0F3CF5 },
+    magic_number <- u32be when u32_eq magic_number 0x5F0F3CF5,
     /// General font flags.
     ///
     // TODO: Document flags
     flags <- u16be,  // TODO: bit patterns?
     /// The granularity of the font's coordinate grid.
-    units_per_em <- { units_per_em <- u16be | bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384) },
+    units_per_em <- u16be when bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384),
     /// The date when the font was created.
     created <- long_date_time,
     /// The date when the font was modified.
@@ -954,7 +954,7 @@ let head_table = {
 /// - [Apple's TrueType Reference Manual: The `'hhea'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hhea.html)
 let hhea_table = {
     /// Major version number of the horizontal header table.
-    major_version <- { version <- u16be | u16_eq version 1 },
+    major_version <- u16be when u16_eq major_version 1,
     /// Minor version number of the horizontal header table.
     minor_version <- u16be, // TODO: where minor_version == 0
     /// Distance from the baseline to the highest ascender.
@@ -1666,14 +1666,14 @@ let gdef_table = (
     let gdef_header_version_1_3 = fun (gdef_start : Pos) => {
         /// Offset to the Item Variation Store table, from beginning of GDEF header (may be NULL)
         // TODO: Implement [Item Variation Store](https://docs.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store)
-        item_var_store <- u32be, 
+        item_var_store <- u32be,
     };
 
     {
         /// The start of the `GDEF` table
         table_start <- stream_pos,
         /// Major version of the GDEF table, = 1
-        major_version <- { version <- u16be | u16_eq version 1 },
+        major_version <- u16be when u16_eq major_version 1,
         /// Minor version of the GDEF table
         minor_version <- u16be,
         /// Class definition table for glyph type, from beginning of GDEF header (may be NULL)
@@ -1815,7 +1815,8 @@ let table_directory = fun (file_start : Pos) => {
     /// | `0x4F54544F`  | (`'OTTO'`) for fonts containing CFF data  |
     ///
     /// Apple allows 'true' and 'typ1', but this should not be found in OpenType files.
-    sfnt_version <- { version <- u32be | bool_or (u32_eq version 0x00010000) (u32_eq version "OTTO") },
+    sfnt_version <- u32be when
+        bool_or (u32_eq sfnt_version 0x00010000) (u32_eq sfnt_version "OTTO"),
 
     /// Number of tables in the directory.
     num_tables <- u16be,

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -852,7 +852,7 @@ let cmap_table = {
 /// - [Apple's TrueType Reference Manual: The `'head'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6head.html)
 let head_table = {
     /// Major version number of the font header table.
-    major_version <- u16be when u16_eq major_version 1,
+    major_version <- u16be where u16_eq major_version 1,
     /// Minor version number of the font header table.
     minor_version <- u16be, // TODO: where minor_version == 0
     /// Set by the font manufacturer.
@@ -864,13 +864,13 @@ let head_table = {
     checksum_adjustment <- u32be,
     /// [Magic number](https://en.wikipedia.org/wiki/File_format#Magic_number), always set to
     /// 0x5F0F3CF5
-    magic_number <- u32be when u32_eq magic_number 0x5F0F3CF5,
+    magic_number <- u32be where u32_eq magic_number 0x5F0F3CF5,
     /// General font flags.
     ///
     // TODO: Document flags
     flags <- u16be,  // TODO: bit patterns?
     /// The granularity of the font's coordinate grid.
-    units_per_em <- u16be when bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384),
+    units_per_em <- u16be where bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384),
     /// The date when the font was created.
     created <- long_date_time,
     /// The date when the font was modified.
@@ -954,7 +954,7 @@ let head_table = {
 /// - [Apple's TrueType Reference Manual: The `'hhea'` table](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hhea.html)
 let hhea_table = {
     /// Major version number of the horizontal header table.
-    major_version <- u16be when u16_eq major_version 1,
+    major_version <- u16be where u16_eq major_version 1,
     /// Minor version number of the horizontal header table.
     minor_version <- u16be, // TODO: where minor_version == 0
     /// Distance from the baseline to the highest ascender.
@@ -1673,7 +1673,7 @@ let gdef_table = (
         /// The start of the `GDEF` table
         table_start <- stream_pos,
         /// Major version of the GDEF table, = 1
-        major_version <- u16be when u16_eq major_version 1,
+        major_version <- u16be where u16_eq major_version 1,
         /// Minor version of the GDEF table
         minor_version <- u16be,
         /// Class definition table for glyph type, from beginning of GDEF header (may be NULL)
@@ -1815,7 +1815,7 @@ let table_directory = fun (file_start : Pos) => {
     /// | `0x4F54544F`  | (`'OTTO'`) for fonts containing CFF data  |
     ///
     /// Apple allows 'true' and 'typ1', but this should not be found in OpenType files.
-    sfnt_version <- u32be when
+    sfnt_version <- u32be where
         bool_or (u32_eq sfnt_version 0x00010000) (u32_eq sfnt_version "OTTO"),
 
     /// Number of tables in the directory.

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -226,13 +226,13 @@ let cmap_table : _ = {
     encoding_records <- array16 num_tables (encoding_record table_start),
 };
 let head_table : _ = {
-    major_version <- u16be when u16_eq major_version 1,
+    major_version <- u16be where u16_eq major_version 1,
     minor_version <- u16be,
     font_revision <- fixed,
     checksum_adjustment <- u32be,
-    magic_number <- u32be when u32_eq magic_number 0x5f0f3cf5,
+    magic_number <- u32be where u32_eq magic_number 0x5f0f3cf5,
     flags <- u16be,
-    units_per_em <- u16be when bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384),
+    units_per_em <- u16be where bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384),
     created <- long_date_time,
     modified <- long_date_time,
     glyph_extents <- {
@@ -248,7 +248,7 @@ let head_table : _ = {
     glyph_data_format <- s16be,
 };
 let hhea_table : _ = {
-    major_version <- u16be when u16_eq major_version 1,
+    major_version <- u16be where u16_eq major_version 1,
     minor_version <- u16be,
     ascent <- fword,
     descent <- fword,
@@ -468,7 +468,7 @@ let gdef_table : _ = let gdef_header_version_1_2 : _ = fun gdef_start => {
 let gdef_header_version_1_3 : _ = fun gdef_start => { item_var_store <- u32be };
 {
     table_start <- stream_pos,
-    major_version <- u16be when u16_eq major_version 1,
+    major_version <- u16be where u16_eq major_version 1,
     minor_version <- u16be,
     glyph_class_def <- offset16 table_start class_def,
     attach_list <- offset16 table_start attach_list,
@@ -497,7 +497,7 @@ fun num_tables => fun table_records => fun table_id => array16_find (_ num_table
 let link_table : _ =
 fun file_start => fun table_record => fun table_format => link (pos_add_u32 file_start table_record.offset) (limit32 table_record.length table_format);
 let table_directory : _ = fun file_start => {
-    sfnt_version <- u32be when bool_or (u32_eq sfnt_version 0x10000) (u32_eq sfnt_version "OTTO"),
+    sfnt_version <- u32be where bool_or (u32_eq sfnt_version 0x10000) (u32_eq sfnt_version "OTTO"),
     num_tables <- u16be,
     search_range <- u16be,
     entry_selector <- u16be,

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -226,11 +226,11 @@ let cmap_table : _ = {
     encoding_records <- array16 num_tables (encoding_record table_start),
 };
 let head_table : _ = {
-    major_version <- { version <- u16be | u16_eq version 1 },
+    major_version <- { major_version <- u16be | u16_eq major_version 1 },
     minor_version <- u16be,
     font_revision <- fixed,
     checksum_adjustment <- u32be,
-    magic_number <- { magic <- u32be | u32_eq magic 0x5f0f3cf5 },
+    magic_number <- { magic_number <- u32be | u32_eq magic_number 0x5f0f3cf5 },
     flags <- u16be,
     units_per_em <- { units_per_em <- u16be | bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384) },
     created <- long_date_time,
@@ -248,7 +248,7 @@ let head_table : _ = {
     glyph_data_format <- s16be,
 };
 let hhea_table : _ = {
-    major_version <- { version <- u16be | u16_eq version 1 },
+    major_version <- { major_version <- u16be | u16_eq major_version 1 },
     minor_version <- u16be,
     ascent <- fword,
     descent <- fword,
@@ -468,7 +468,7 @@ let gdef_table : _ = let gdef_header_version_1_2 : _ = fun gdef_start => {
 let gdef_header_version_1_3 : _ = fun gdef_start => { item_var_store <- u32be };
 {
     table_start <- stream_pos,
-    major_version <- { version <- u16be | u16_eq version 1 },
+    major_version <- { major_version <- u16be | u16_eq major_version 1 },
     minor_version <- u16be,
     glyph_class_def <- offset16 table_start class_def,
     attach_list <- offset16 table_start attach_list,
@@ -497,7 +497,7 @@ fun num_tables => fun table_records => fun table_id => array16_find (_ num_table
 let link_table : _ =
 fun file_start => fun table_record => fun table_format => link (pos_add_u32 file_start table_record.offset) (limit32 table_record.length table_format);
 let table_directory : _ = fun file_start => {
-    sfnt_version <- { version <- u32be | bool_or (u32_eq version 0x10000) (u32_eq version "OTTO") },
+    sfnt_version <- { sfnt_version <- u32be | bool_or (u32_eq sfnt_version 0x10000) (u32_eq sfnt_version "OTTO") },
     num_tables <- u16be,
     search_range <- u16be,
     entry_selector <- u16be,

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -226,13 +226,13 @@ let cmap_table : _ = {
     encoding_records <- array16 num_tables (encoding_record table_start),
 };
 let head_table : _ = {
-    major_version <- { major_version <- u16be | u16_eq major_version 1 },
+    major_version <- u16be when u16_eq major_version 1,
     minor_version <- u16be,
     font_revision <- fixed,
     checksum_adjustment <- u32be,
-    magic_number <- { magic_number <- u32be | u32_eq magic_number 0x5f0f3cf5 },
+    magic_number <- u32be when u32_eq magic_number 0x5f0f3cf5,
     flags <- u16be,
-    units_per_em <- { units_per_em <- u16be | bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384) },
+    units_per_em <- u16be when bool_and (u16_gte units_per_em 16) (u16_lte units_per_em 16384),
     created <- long_date_time,
     modified <- long_date_time,
     glyph_extents <- {
@@ -248,7 +248,7 @@ let head_table : _ = {
     glyph_data_format <- s16be,
 };
 let hhea_table : _ = {
-    major_version <- { major_version <- u16be | u16_eq major_version 1 },
+    major_version <- u16be when u16_eq major_version 1,
     minor_version <- u16be,
     ascent <- fword,
     descent <- fword,
@@ -468,7 +468,7 @@ let gdef_table : _ = let gdef_header_version_1_2 : _ = fun gdef_start => {
 let gdef_header_version_1_3 : _ = fun gdef_start => { item_var_store <- u32be };
 {
     table_start <- stream_pos,
-    major_version <- { major_version <- u16be | u16_eq major_version 1 },
+    major_version <- u16be when u16_eq major_version 1,
     minor_version <- u16be,
     glyph_class_def <- offset16 table_start class_def,
     attach_list <- offset16 table_start attach_list,
@@ -497,7 +497,7 @@ fun num_tables => fun table_records => fun table_id => array16_find (_ num_table
 let link_table : _ =
 fun file_start => fun table_record => fun table_format => link (pos_add_u32 file_start table_record.offset) (limit32 table_record.length table_format);
 let table_directory : _ = fun file_start => {
-    sfnt_version <- { sfnt_version <- u32be | bool_or (u32_eq sfnt_version 0x10000) (u32_eq sfnt_version "OTTO") },
+    sfnt_version <- u32be when bool_or (u32_eq sfnt_version 0x10000) (u32_eq sfnt_version "OTTO"),
     num_tables <- u16be,
     search_range <- u16be,
     entry_selector <- u16be,

--- a/tests/succeed/format-cond/simple.fathom
+++ b/tests/succeed/format-cond/simple.fathom
@@ -1,1 +1,6 @@
-{ sfnt_version <- { version <- u32be | (u32_eq version 0xffff) } }
+let format = { sfnt_version <- { version <- u32be | (u32_eq version 0xffff) } };
+
+let _ : Repr format -> { sfnt_version : Repr u32be } =
+    fun x => x;
+
+{}

--- a/tests/succeed/format-cond/simple.snap
+++ b/tests/succeed/format-cond/simple.snap
@@ -1,4 +1,8 @@
 stdout = '''
-{ sfnt_version <- { version <- u32be | u32_eq version 0xffff } } : Format
+let format : _ = {
+    sfnt_version <- { version <- u32be | u32_eq version 0xffff },
+};
+let _ : fun (_ : { sfnt_version : U32 }) -> { sfnt_version : U32 } = fun x => x;
+{} : {}
 '''
 stderr = ''

--- a/tests/succeed/format-overlap/field-refinements.fathom
+++ b/tests/succeed/format-overlap/field-refinements.fathom
@@ -1,0 +1,9 @@
+let number = overlap {
+    u <- u32be when u32_gte u 2,
+    s <- s32be,
+};
+
+let _ : Repr number -> { u : U32, s : S32 } =
+    fun n => n;
+
+{}

--- a/tests/succeed/format-overlap/field-refinements.fathom
+++ b/tests/succeed/format-overlap/field-refinements.fathom
@@ -1,5 +1,5 @@
 let number = overlap {
-    u <- u32be when u32_gte u 2,
+    u <- u32be where u32_gte u 2,
     s <- s32be,
 };
 

--- a/tests/succeed/format-overlap/field-refinements.snap
+++ b/tests/succeed/format-overlap/field-refinements.snap
@@ -1,5 +1,5 @@
 stdout = '''
-let number : _ = overlap { u <- { u <- u32be | u32_gte u 2 }, s <- s32be };
+let number : _ = overlap { u <- u32be when u32_gte u 2, s <- s32be };
 let _ : fun (_ : { u : U32, s : S32 }) -> { u : U32, s : S32 } = fun n => n;
 {} : {}
 '''

--- a/tests/succeed/format-overlap/field-refinements.snap
+++ b/tests/succeed/format-overlap/field-refinements.snap
@@ -1,5 +1,5 @@
 stdout = '''
-let number : _ = overlap { u <- u32be when u32_gte u 2, s <- s32be };
+let number : _ = overlap { u <- u32be where u32_gte u 2, s <- s32be };
 let _ : fun (_ : { u : U32, s : S32 }) -> { u : U32, s : S32 } = fun n => n;
 {} : {}
 '''

--- a/tests/succeed/format-overlap/field-refinements.snap
+++ b/tests/succeed/format-overlap/field-refinements.snap
@@ -1,0 +1,6 @@
+stdout = '''
+let number : _ = overlap { u <- { u <- u32be | u32_gte u 2 }, s <- s32be };
+let _ : fun (_ : { u : U32, s : S32 }) -> { u : U32, s : S32 } = fun n => n;
+{} : {}
+'''
+stderr = ''

--- a/tests/succeed/format-record/field-refinements.fathom
+++ b/tests/succeed/format-record/field-refinements.fathom
@@ -1,6 +1,6 @@
 let format = {
-    magic <- u64le when u64_eq magic 0x00ffffffffffff00,
-    len <- u8 when u8_lte len 16,
+    magic <- u64le where u64_eq magic 0x00ffffffffffff00,
+    len <- u8 where u8_lte len 16,
     data <- array8 len u8,
 };
 

--- a/tests/succeed/format-record/field-refinements.fathom
+++ b/tests/succeed/format-record/field-refinements.fathom
@@ -1,0 +1,10 @@
+let format = {
+    magic <- u64le when u64_eq magic 0x00ffffffffffff00,
+    len <- u8 when u8_lte len 16,
+    data <- array8 len u8,
+};
+
+let _ : Repr format -> { magic : U64, len : U8, data : Array8 len U8 } =
+    fun x => x;
+
+{}

--- a/tests/succeed/format-record/field-refinements.snap
+++ b/tests/succeed/format-record/field-refinements.snap
@@ -1,7 +1,7 @@
 stdout = '''
 let format : _ = {
-    magic <- u64le when u64_eq magic 0xffffffffffff00,
-    len <- u8 when u8_lte len 16,
+    magic <- u64le where u64_eq magic 0xffffffffffff00,
+    len <- u8 where u8_lte len 16,
     data <- array8 len u8,
 };
 let _ : fun (_ : { magic : U64, len : U8, data : Array8 len U8 }) -> {

--- a/tests/succeed/format-record/field-refinements.snap
+++ b/tests/succeed/format-record/field-refinements.snap
@@ -1,7 +1,7 @@
 stdout = '''
 let format : _ = {
-    magic <- { magic <- u64le | u64_eq magic 0xffffffffffff00 },
-    len <- { len <- u8 | u8_lte len 16 },
+    magic <- u64le when u64_eq magic 0xffffffffffff00,
+    len <- u8 when u8_lte len 16,
     data <- array8 len u8,
 };
 let _ : fun (_ : { magic : U64, len : U8, data : Array8 len U8 }) -> {

--- a/tests/succeed/format-record/field-refinements.snap
+++ b/tests/succeed/format-record/field-refinements.snap
@@ -1,0 +1,14 @@
+stdout = '''
+let format : _ = {
+    magic <- { magic <- u64le | u64_eq magic 0xffffffffffff00 },
+    len <- { len <- u8 | u8_lte len 16 },
+    data <- array8 len u8,
+};
+let _ : fun (_ : { magic : U64, len : U8, data : Array8 len U8 }) -> {
+    magic : U64,
+    len : U8,
+    data : Array8 len U8,
+} = fun x => x;
+{} : {}
+'''
+stderr = ''


### PR DESCRIPTION
This implements some short-hand sugar for refining fields with predicates. Closes #368.

```
{
    magic <- u32be where u32_eq magic "icns",
    ⋮
}
```

These are turned into conditional formats during elaboration. I went with calling them ’field refinements’ as if felt like ‘conditional fields’ could be interpreted as being optional. Another name for them could be ‘field guards’, perhaps.

I also found a bug in the implementation of `Repr` for conditional fields in the process!