### PR TITLE
Add surface syntax for computed fields

### DIFF
--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -200,13 +200,26 @@ impl<'arena> Term<'arena, ByteRange> {
 
 /// A field declaration in a record and offset format
 #[derive(Debug, Clone)]
-pub struct FormatField<'arena, Range> {
-    /// Label identifying the field
-    label: (Range, StringId),
-    /// The format that this field will be parsed with
-    format: Term<'arena, Range>,
-    /// An optional predicate that refines the format field
-    pred: Option<Term<'arena, Range>>,
+pub enum FormatField<'arena, Range> {
+    /// Regular format field
+    Format {
+        /// Label identifying the field
+        label: (Range, StringId),
+        /// The format that this field will be parsed with
+        format: Term<'arena, Range>,
+        /// An optional predicate that refines the format field
+        pred: Option<Term<'arena, Range>>,
+    },
+    /// Computed format field
+    Computed {
+        /// Label identifying the field
+        label: (Range, StringId),
+        /// Optional type annotation
+        // FIXME: raw identifiers in LALRPOP grammars https://github.com/lalrpop/lalrpop/issues/613
+        type_: Option<Term<'arena, Range>>,
+        /// The expression that this field compute
+        expr: Term<'arena, Range>,
+    },
 }
 
 /// A field declaration in a record type

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -174,7 +174,10 @@ AtomicTerm: Term<'arena, ByteRange> = {
 
 FormatField: FormatField<'arena, ByteRange> = {
     <label: RangedName> "<-" <format: Term> <pred: ("where" <Term>)?> => {
-        FormatField { label, format, pred }
+        FormatField::Format { label, format, pred }
+    },
+    "let" <label: RangedName> <type_: (":" <Term>)?> "=" <expr: Term> => {
+        FormatField::Computed { label, type_, expr }
     },
 };
 

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -268,22 +268,46 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         &'arena self,
         format_field: &FormatField<'_, Range>,
     ) -> DocBuilder<'arena, Self> {
-        self.concat([
-            self.string_id(format_field.label.1),
-            self.space(),
-            self.text("<-"),
-            self.space(),
-            self.term_prec(Prec::Top, &format_field.format),
-            match &format_field.pred {
-                Some(pred) => self.concat([
-                    self.space(),
-                    self.text("where"),
-                    self.space(),
-                    self.term_prec(Prec::Top, &pred),
-                ]),
-                None => self.nil(),
-            },
-        ])
+        match format_field {
+            FormatField::Format {
+                label,
+                format,
+                pred,
+            } => self.concat([
+                self.string_id(label.1),
+                self.space(),
+                self.text("<-"),
+                self.space(),
+                self.term_prec(Prec::Top, format),
+                match pred {
+                    Some(pred) => self.concat([
+                        self.space(),
+                        self.text("where"),
+                        self.space(),
+                        self.term_prec(Prec::Top, pred),
+                    ]),
+                    None => self.nil(),
+                },
+            ]),
+            FormatField::Computed { label, type_, expr } => self.concat([
+                self.text("let"),
+                self.space(),
+                self.string_id(label.1),
+                match type_ {
+                    Some(r#type) => self.concat([
+                        self.space(),
+                        self.text(":"),
+                        self.space(),
+                        self.term_prec(Prec::Top, r#type),
+                    ]),
+                    None => self.nil(),
+                },
+                self.space(),
+                self.text("="),
+                self.space(),
+                self.term_prec(Prec::Top, expr),
+            ]),
+        }
     }
 
     /// Wrap a document in parens.

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -615,7 +615,8 @@ let cmap_subtable_format4 = fun (platform : Repr platform_id) => {
     language <- cmap_language_id platform,
     /// 2 × segCount.
     seg_count_x2 <- u16be,
-    seg_count <- succeed _ (u16_div seg_count_x2 2),
+    /// Number of contiguous ranges of character codes
+    let seg_count = u16_div seg_count_x2 2,
     /// Maximum power of 2 less than or equal to segCount, times 2 ((2**floor(log₂(segCount))) * 2,
     /// where “**” is an exponentiation operator)
     search_range <- u16be,

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -146,7 +146,7 @@ let cmap_subtable_format4 : _ = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     seg_count_x2 <- u16be,
-    seg_count <- succeed (_ platform length language seg_count_x2) (u16_div seg_count_x2 2),
+    let seg_count : U16 = u16_div seg_count_x2 2,
     search_range <- u16be,
     entry_selector <- u16be,
     range_shift <- u16be,

--- a/tests/fail/parse/error-recovery.snap
+++ b/tests/fail/parse/error-recovery.snap
@@ -6,7 +6,7 @@ error: unexpected token ;
 3 │ let x : Type = {;
   │                 ^ unexpected token
   │
-  = expected "name" or "}"
+  = expected "let", "name" or "}"
 
 error: mismatched types
   ┌─ tests/fail/parse/error-recovery.fathom:5:1

--- a/tests/succeed/format-record/computed-fields.fathom
+++ b/tests/succeed/format-record/computed-fields.fathom
@@ -1,0 +1,27 @@
+let format = {
+    /// 2 × seg_count.
+    seg_count_x2 <- u16be,
+
+    /// Number of contiguous ranges of character codes
+    let seg_count = u16_div seg_count_x2 2,
+
+    start_code <- array16 seg_count u16be,
+    id_delta <- array16 seg_count s16be,
+};
+
+let _ : Repr format -> {
+    seg_count_x2 : U16,
+    seg_count : U16,
+    start_code : Array16 seg_count U16,
+    id_delta : Array16 seg_count S16,
+} = fun x => x;
+
+let format = {
+    // test annotation
+    let x : U32 = 256,
+};
+
+let _ : Repr format -> { x : U32 } =
+    fun x => x;
+
+{}

--- a/tests/succeed/format-record/computed-fields.snap
+++ b/tests/succeed/format-record/computed-fields.snap
@@ -1,0 +1,23 @@
+stdout = '''
+let format : _ = {
+    seg_count_x2 <- u16be,
+    let seg_count : U16 = u16_div seg_count_x2 2,
+    start_code <- array16 seg_count u16be,
+    id_delta <- array16 seg_count s16be,
+};
+let _ : fun (_ : {
+    seg_count_x2 : U16,
+    seg_count : U16,
+    start_code : Array16 seg_count U16,
+    id_delta : Array16 seg_count S16,
+}) -> {
+    seg_count_x2 : U16,
+    seg_count : U16,
+    start_code : Array16 seg_count U16,
+    id_delta : Array16 seg_count S16,
+} = fun x => x;
+let format : _ = { let x : U32 = 256 };
+let _ : fun (_ : { x : U32 }) -> { x : U32 } = fun x => x;
+{} : {}
+'''
+stderr = ''


### PR DESCRIPTION
This implements some shorthand syntax for adding pure computations into a record format. For example:

```fathom
{
    /// 2 × seg_count.
    seg_count_x2 <- u16be,

    /// Number of contiguous ranges of character codes
    let seg_count = u16_div seg_count_x2 2,
    //  ▲
    //  └─── the value computed for `seg_count` will be
    //       available for use in subsequent fields

    ⋮

    start_code <- array16 seg_count u16be,
    id_delta <- array16 seg_count s16be,
    //                  ▲
    //                  └──── `seg_count` is used here
}
```

This is translated to a `succeed` format during elaboration.