### PR TITLE
Provide more information in SetOffsetOutsideBuffer error

### DIFF
--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -444,11 +444,24 @@ impl From<ReadError> for Diagnostic<usize> {
                 .with_notes(vec![format!(
                     "The end of the buffer was reached before all data could be read."
                 )]),
-            ReadError::SetOffsetOutsideBuffer(offset) => Diagnostic::error()
+            ReadError::SetOffsetBeforeStartOfBuffer { offset } => Diagnostic::error()
+                .with_message(err.to_string())
+                .with_notes(vec![format!(
+                    "The offset {} is before the start of the buffer.",
+                    offset
+                )]),
+            ReadError::SetOffsetAfterEndOfBuffer {
+                offset: Some(offset),
+            } => Diagnostic::error()
                 .with_message(err.to_string())
                 .with_notes(vec![format!(
                     "The offset {} is beyond the end of the buffer.",
                     offset
+                )]),
+            ReadError::SetOffsetAfterEndOfBuffer { offset: None } => Diagnostic::error()
+                .with_message(err.to_string())
+                .with_notes(vec![format!(
+                    "The offset is beyond the end of the buffer (overflow).",
                 )]),
             ReadError::InvalidFormat
             | ReadError::InvalidValue

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -444,11 +444,16 @@ impl From<ReadError> for Diagnostic<usize> {
                 .with_notes(vec![format!(
                     "The end of the buffer was reached before all data could be read."
                 )]),
+            ReadError::SetOffsetOutsideBuffer(offset) => Diagnostic::error()
+                .with_message(err.to_string())
+                .with_notes(vec![format!(
+                    "The offset {} is beyond the end of the buffer.",
+                    offset
+                )]),
             ReadError::InvalidFormat
             | ReadError::InvalidValue
             | ReadError::UnknownItem
-            | ReadError::PositionOverflow
-            | ReadError::SetOffsetOutsideBuffer => Diagnostic::bug()
+            | ReadError::PositionOverflow => Diagnostic::bug()
                 .with_message(format!("unexpected error '{}'", err))
                 .with_notes(vec![format!(
                     "please file a bug report at: {}",


### PR DESCRIPTION
I ran into this error when I was working on adding `GPOS` to the OpenType definition and wished there was more info in it. I've added the bad offset to the error, which may or may not actually be useful. I've also moved it out of the `bug` reporting branch when reporting errors since it can be triggered with bad data or bad format description.