### PR TITLE
Avoid allocating Vec every time we add to reference cache

### DIFF
--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -530,7 +530,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
         // Store the parsed reference in the reference cache
         self.cached_refs
             .entry(pos)
-            .or_insert(Vec::with_capacity(1))
+            .or_insert_with(|| Vec::with_capacity(1))
             .push(ParsedRef {
                 format: format.clone(),
                 expr: expr.clone(),


### PR DESCRIPTION
Noticed this doing some other research. Prior to this change the `Vec` was allocated every time, even if the entry was already populated.