### PR TITLE
Distill `core::Term::FunType` to `surface::Term::Arrow` if `input_name` is not bound in `output_type`

### DIFF
--- a/formats/gif.snap
+++ b/formats/gif.snap
@@ -8,7 +8,7 @@ def logical_screen_descriptor : Format = {
 };
 def header : Format = { magic <- array8 3 u8, version <- array8 3 u8 };
 def color_table_entry : Format = { red <- u8, green <- u8, blue <- u8 };
-def global_color_table : fun (len : U16) -> Format = fun len => {
+def global_color_table : U16 -> Format = fun len => {
     entries <- array16 len color_table_entry,
 };
 def main : Format = { header <- header, screen <- logical_screen_descriptor };

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -6,31 +6,29 @@ def table_record : Format = {
     offset <- u32be,
     length <- u32be,
 };
-def find_table : fun (num_tables : U16) -> fun (table_records :
-Array16 num_tables {
+def find_table : fun (num_tables : U16) -> Array16 num_tables {
     table_id : U32,
     checksum : U32,
     offset : U32,
     length : U32,
-}) -> fun (table_id : U32) -> Option {
+} -> U32 -> Option {
     table_id : U32,
     checksum : U32,
     offset : U32,
     length : U32,
 } =
 fun num_tables => fun table_records => fun table_id => array16_find (_ num_tables table_records table_id) (Repr table_record) (fun table_record => table_record.table_id == table_id) table_records;
-def link_table : fun (file_start : Pos) -> fun (table_record : {
+def link_table : Pos -> {
     table_id : U32,
     checksum : U32,
     offset : U32,
     length : U32,
-}) -> fun (table_format : Format) -> Format =
+} -> Format -> Format =
 fun file_start => fun table_record => fun table_format => link (pos_add_u32 file_start table_record.offset) (limit32 table_record.length table_format);
 def platform_id : Format = u16be;
-def encoding_id : fun (platform : U16) -> Format = fun platform => u16be;
+def encoding_id : U16 -> Format = fun platform => u16be;
 def empty : Format = {};
-def offset32 : fun (base : Pos) -> fun (format : Format) -> Format =
-fun base => fun format => {
+def offset32 : Pos -> Format -> Format = fun base => fun format => {
     offset <- u32be,
     link <- match offset {
         0 => empty,
@@ -38,22 +36,21 @@ fun base => fun format => {
     },
 };
 def language_id : Format = u16be;
-def cmap_language_id : fun (platform : U16) -> Format =
-fun platform => language_id;
+def cmap_language_id : U16 -> Format = fun platform => language_id;
 def small_glyph_id : Format = u8;
-def cmap_subtable_format0 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format0 : U16 -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     glyph_id_array <- array16 256 small_glyph_id,
 };
-def cmap_subtable_format2 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format2 : U16 -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     sub_header_keys <- array16 256 u16be,
 };
-def reserved : fun (format : Format) -> fun (default : Repr format) -> Format =
+def reserved : fun (format : Format) -> Repr format -> Format =
 fun format => fun default => format;
-def cmap_subtable_format4 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format4 : U16 -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     seg_count_x2 <- u16be,
@@ -67,7 +64,7 @@ def cmap_subtable_format4 : fun (platform : U16) -> Format = fun platform => {
     id_delta <- array16 seg_count s16be,
     id_range_offsets <- array16 seg_count u16be,
 };
-def cmap_subtable_format6 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format6 : U16 -> Format = fun platform => {
     length <- u16be,
     language <- cmap_language_id platform,
     first_code <- u16be,
@@ -75,14 +72,13 @@ def cmap_subtable_format6 : fun (platform : U16) -> Format = fun platform => {
     glyph_id_array <- array16 entry_count u16be,
 };
 def language_id32 : Format = u32be;
-def cmap_language_id32 : fun (platform : U16) -> Format =
-fun platform => language_id32;
+def cmap_language_id32 : U16 -> Format = fun platform => language_id32;
 def sequential_map_group : Format = {
     start_char_code <- u32be,
     end_char_code <- u32be,
     start_glyph_id <- u32be,
 };
-def cmap_subtable_format8 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format8 : U16 -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
@@ -90,7 +86,7 @@ def cmap_subtable_format8 : fun (platform : U16) -> Format = fun platform => {
     num_groups <- u32be,
     groups <- array32 num_groups sequential_map_group,
 };
-def cmap_subtable_format10 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format10 : U16 -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
@@ -98,7 +94,7 @@ def cmap_subtable_format10 : fun (platform : U16) -> Format = fun platform => {
     num_chars <- u32be,
     glyph_id_array <- array32 num_chars u16be,
 };
-def cmap_subtable_format12 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format12 : U16 -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
@@ -106,7 +102,7 @@ def cmap_subtable_format12 : fun (platform : U16) -> Format = fun platform => {
     groups <- array32 num_groups sequential_map_group,
 };
 def constant_map_group : Format = sequential_map_group;
-def cmap_subtable_format13 : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable_format13 : U16 -> Format = fun platform => {
     _reserved <- reserved u16be 0,
     length <- u32be,
     language <- cmap_language_id32 platform,
@@ -127,20 +123,19 @@ def non_default_uvs_table : Format = {
     num_uvs_mappings <- u32be,
     uvs_mappings <- array32 num_uvs_mappings uvs_mapping,
 };
-def variation_selector : fun (table_start : Pos) -> Format =
-fun table_start => {
+def variation_selector : Pos -> Format = fun table_start => {
     var_selector <- u24be,
     default_uvs_offset <- offset32 table_start default_uvs_table,
     non_default_uvs_offset <- offset32 table_start non_default_uvs_table,
 };
-def cmap_subtable_format14 : fun (platform : U16) -> fun (table_start : Pos) ->
-Format = fun platform => fun table_start => {
+def cmap_subtable_format14 : U16 -> Pos -> Format =
+fun platform => fun table_start => {
     length <- u32be,
     num_var_selector_records <- u32be,
     var_selector <- array32 num_var_selector_records (variation_selector table_start),
 };
 def unknown_table : Format = {};
-def cmap_subtable : fun (platform : U16) -> Format = fun platform => {
+def cmap_subtable : U16 -> Format = fun platform => {
     table_start <- stream_pos,
     format <- u16be,
     data <- match format {
@@ -156,7 +151,7 @@ def cmap_subtable : fun (platform : U16) -> Format = fun platform => {
         _ => unknown_table,
     },
 };
-def encoding_record : fun (table_start : Pos) -> Format = fun table_start => {
+def encoding_record : Pos -> Format = fun table_start => {
     platform <- platform_id,
     encoding <- encoding_id platform,
     subtable_offset <- offset32 table_start (cmap_subtable platform),
@@ -169,8 +164,8 @@ def cmap_table : Format = {
 };
 def fixed : Format = u32be;
 def long_date_time : Format = s64be;
-def deprecated : fun (format : Format) -> fun (default : Repr format) ->
-Format = fun format => fun default => format;
+def deprecated : fun (format : Format) -> Repr format -> Format =
+fun format => fun default => format;
 def head_table : Format = {
     major_version <- u16be where major_version == (1 : U16),
     minor_version <- u16be,
@@ -240,21 +235,19 @@ def long_horizontal_metric : Format = {
     advance_width <- u16be,
     left_side_bearing <- s16be,
 };
-def htmx_table : fun (number_of_long_horizontal_metrics : U16) ->
-fun (num_glyphs : U16) -> Format =
+def htmx_table : U16 -> U16 -> Format =
 fun number_of_long_horizontal_metrics => fun num_glyphs => {
     h_metrics <- array16 number_of_long_horizontal_metrics long_horizontal_metric,
     left_side_bearings <- array16 (u16_sub num_glyphs number_of_long_horizontal_metrics) s16be,
 };
-def offset16 : fun (base : Pos) -> fun (format : Format) -> Format =
-fun base => fun format => {
+def offset16 : Pos -> Format -> Format = fun base => fun format => {
     offset <- u16be,
     link <- match offset {
         0 => empty,
         _ => link (pos_add_u16 base offset) format,
     },
 };
-def name_record : fun (storage_start : Pos) -> Format = fun storage_start => {
+def name_record : Pos -> Format = fun storage_start => {
     platform <- platform_id,
     encoding <- encoding_id platform,
     language <- language_id,
@@ -262,13 +255,11 @@ def name_record : fun (storage_start : Pos) -> Format = fun storage_start => {
     length <- u16be,
     offset <- offset16 storage_start (array16 length u8),
 };
-def lang_tag_record : fun (storage_start : Pos) -> Format =
-fun storage_start => {
+def lang_tag_record : Pos -> Format = fun storage_start => {
     length <- u16be,
     offset <- offset16 storage_start (array16 length u8),
 };
-def name_version_1 : fun (storage_start : Pos) -> Format =
-fun storage_start => {
+def name_version_1 : Pos -> Format = fun storage_start => {
     lang_tag_count <- u16be,
     lang_tag_records <- array16 lang_tag_count (lang_tag_record storage_start),
 };
@@ -309,7 +300,7 @@ def os2_version_5 : Format = {
     usLowerOpticalPointSize <- u16be,
     usUpperOpticalPointSize <- u16be,
 };
-def os2_table : fun (table_length : U32) -> Format = fun table_length => {
+def os2_table : U32 -> Format = fun table_length => {
     version <- u16be,
     x_avg_char_width <- s16be,
     us_weight_class <- u16be,
@@ -377,10 +368,9 @@ def glyph_header : Format = {
     x_max <- s16be,
     y_max <- s16be,
 };
-def args_are_signed : fun (flags : U16) -> Bool =
-fun flags => u16_and flags 0x2 != (0 : U16);
-def arg_format : fun (flags : U16) -> Format =
-fun flags => match (u16_and flags 0x1 != (0 : U16)) {
+def args_are_signed : U16 -> Bool = fun flags => u16_and flags 0x2 != (0 : U16);
+def arg_format : U16 -> Format = fun flags => match (u16_and flags 0x1 != (0 :
+U16)) {
     false => match (args_are_signed flags) { false => u8, true => s8 },
     true => match (args_are_signed flags) { false => u16be, true => s16be },
 };
@@ -390,8 +380,7 @@ def composite_glyph : Format = {
     argument1 <- arg_format flags,
     argument2 <- arg_format flags,
 };
-def simple_glyph : fun (number_of_contours : U16) -> Format =
-fun number_of_contours => {
+def simple_glyph : U16 -> Format = fun number_of_contours => {
     end_pts_of_contours <- array16 number_of_contours u16be,
     instruction_length <- u16be,
     instructions <- array16 instruction_length u8,
@@ -403,11 +392,11 @@ def glyph : Format = {
         true => composite_glyph,
     },
 };
-def glyf_table : fun (num_glyphs : U16) -> Format = fun num_glyphs => {
+def glyf_table : U16 -> Format = fun num_glyphs => {
     glyphs <- array16 num_glyphs glyph,
 };
-def loca_table : fun (num_glyphs : U16) -> fun (index_to_loc_format : S16) ->
-Format = fun num_glyphs => fun index_to_loc_format => {
+def loca_table : U16 -> S16 -> Format =
+fun num_glyphs => fun index_to_loc_format => {
     offsets <- match index_to_loc_format {
         0 => array16 (u16_add num_glyphs 1) u16be,
         1 => array16 (u16_add num_glyphs 1) u32be,
@@ -562,7 +551,7 @@ def lang_sys : Format = {
     feature_index_count <- u16be,
     feature_indices <- array16 feature_index_count u16be,
 };
-def lang_sys_record : fun (script_start : Pos) -> Format = fun script_start => {
+def lang_sys_record : Pos -> Format = fun script_start => {
     lang_sys_tag <- tag,
     lang_sys <- offset16 script_start lang_sys,
 };
@@ -772,7 +761,7 @@ def extension_substitution : Format = let extension_subst_format1 : _ = {
         _ => unknown_table,
     },
 };
-def value_record : fun (table_start : Pos) -> fun (flags : U16) -> Format =
+def value_record : Pos -> U16 -> Format =
 fun table_start => fun flags => let X_PLACEMENT : U16 = 0x1;
 let Y_PLACEMENT : U16 = 0x2;
 let X_ADVANCE : U16 = 0x4;
@@ -817,8 +806,8 @@ let single_pos_format2 : _ = fun table_start => {
         _ => unknown_table,
     },
 };
-def optional_value_record : fun (table_start : Pos) -> fun (flags : U16) ->
-Format = fun table_start => fun flags => match (flags == (0 : U16)) {
+def optional_value_record : Pos -> U16 -> Format =
+fun table_start => fun flags => match (flags == (0 : U16)) {
     false => value_record table_start flags,
     true => empty,
 };
@@ -989,8 +978,8 @@ def extension_positioning : Format = let extension_pos_format1 : _ = {
         _ => unknown_table,
     },
 };
-def lookup_table : fun (tag : U32) -> Format =
-fun tag => let USE_MARK_FILTERING_SET : U16 = 0x10;
+def lookup_table : U32 -> Format = fun tag => let USE_MARK_FILTERING_SET : U16 =
+0x10;
 let lookup_subtable : _ tag = fun tag => fun lookup_type => match tag {
     "GPOS" => match lookup_type {
         1 => single_adjustment,
@@ -1029,12 +1018,12 @@ let lookup_subtable : _ tag = fun tag => fun lookup_type => match tag {
         true => u16be,
     },
 };
-def lookup_list : fun (tag : U32) -> Format = fun tag => {
+def lookup_list : U32 -> Format = fun tag => {
     table_start <- stream_pos,
     lookup_count <- u16be,
     lookups <- array16 lookup_count (offset16 table_start (lookup_table tag)),
 };
-def layout_table : fun (tag : U32) -> Format = fun tag => {
+def layout_table : U32 -> Format = fun tag => {
     table_start <- stream_pos,
     major_version <- u16be where major_version == (1 : U16),
     minor_version <- u16be,
@@ -1046,7 +1035,7 @@ def gpos_table : Format = layout_table "GPOS";
 def gsub_table : Format = layout_table "GSUB";
 def jstf_table : Format = unknown_table;
 def math_table : Format = unknown_table;
-def table_directory : fun (file_start : Pos) -> Format = fun file_start => {
+def table_directory : Pos -> Format = fun file_start => {
     sfnt_version <- u32be where bool_or (sfnt_version == (0x10000 :
     U32)) (sfnt_version == ("OTTO" : U32)),
     num_tables <- u16be,
@@ -1133,8 +1122,8 @@ def table_directory : fun (file_start : Pos) -> Format = fun file_start => {
         vmtx <- optional_table "vmtx" unknown_table,
     },
 };
-def ttc_header : fun (start : Pos) -> Format = fun start => let ttc_header1 :
-_ start = fun start => {
+def ttc_header : Pos -> Format = fun start => let ttc_header1 : _ start =
+fun start => {
     num_fonts <- u32be,
     table_directories <- array32 num_fonts (offset32 start (table_directory start)),
 };

--- a/tests/cmd/fathom-data.md
+++ b/tests/cmd/fathom-data.md
@@ -278,9 +278,9 @@ error: mismatched types
   ┌─ <FORMAT>:1:1
   │
 1 │ offset16
-  │ ^^^^^^^^ type mismatch, expected `fun (base : Pos) -> fun (format : Format) -> Format`, found `Format`
+  │ ^^^^^^^^ type mismatch, expected `Pos -> Format -> Format`, found `Format`
   │
-  = expected `fun (base : Pos) -> fun (format : Format) -> Format`
+  = expected `Pos -> Format -> Format`
        found `Format`
 
 

--- a/tests/cmd/fathom-norm.md
+++ b/tests/cmd/fathom-norm.md
@@ -44,7 +44,7 @@ Terms can be normalised with `--term`
 
 ```console
 $ fathom norm --term tests/succeed/fun-elim/ann-identity-poly-1.fathom
-fun a => a : fun (_ : Type) -> Type
+fun a => a : Type -> Type
 
 ```
 

--- a/tests/fail/parse/error-recovery.snap
+++ b/tests/fail/parse/error-recovery.snap
@@ -12,9 +12,9 @@ error: mismatched types
   ┌─ tests/fail/parse/error-recovery.fathom:5:1
   │
 5 │ x : Type -> Type
-  │ ^ type mismatch, expected `Type`, found `fun (_ : Type) -> Type`
+  │ ^ type mismatch, expected `Type`, found `Type -> Type`
   │
   = expected `Type`
-       found `fun (_ : Type) -> Type`
+       found `Type -> Type`
 
 '''

--- a/tests/succeed/ann/arrow-type-type.snap
+++ b/tests/succeed/ann/arrow-type-type.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (_ : Type) -> Type : Type
+Type -> Type : Type
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-literal-identity-mono-input-ann-placeholder.snap
+++ b/tests/succeed/ann/fun-literal-identity-mono-input-ann-placeholder.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun a => a : fun (_ : Type) -> Type
+fun a => a : Type -> Type
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-literal-identity-mono-input-ann-type.snap
+++ b/tests/succeed/ann/fun-literal-identity-mono-input-ann-type.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun a => a : fun (_ : Type) -> Type
+fun a => a : Type -> Type
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-literal-identity-mono.snap
+++ b/tests/succeed/ann/fun-literal-identity-mono.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun a => a : fun (_ : Type) -> Type
+fun a => a : Type -> Type
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-literal-identity-poly-input-placeholder.snap
+++ b/tests/succeed/ann/fun-literal-identity-poly-input-placeholder.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun _ => fun a => a : fun (A : Type) -> fun (_ : A) -> A
+fun _ => fun a => a : fun (A : Type) -> A -> A
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-literal-identity-poly.snap
+++ b/tests/succeed/ann/fun-literal-identity-poly.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun A => fun a => a : fun (A : Type) -> fun (_ : A) -> A
+fun A => fun a => a : fun (A : Type) -> A -> A
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-type-identity-mono.snap
+++ b/tests/succeed/ann/fun-type-identity-mono.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : Type) -> Type : Type
+Type -> Type : Type
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-type-identity-poly-hole.snap
+++ b/tests/succeed/ann/fun-type-identity-poly-hole.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : _) -> fun (_ : A) -> A : Type
+fun (A : _) -> A -> A : Type
 '''
 stderr = ''

--- a/tests/succeed/ann/fun-type-identity-poly.snap
+++ b/tests/succeed/ann/fun-type-identity-poly.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : Type) -> fun (_ : A) -> A : Type
+fun (A : Type) -> A -> A : Type
 '''
 stderr = ''

--- a/tests/succeed/arrow/identity.snap
+++ b/tests/succeed/arrow/identity.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (_ : Type) -> Type : Type
+Type -> Type : Type
 '''
 stderr = ''

--- a/tests/succeed/equality.snap
+++ b/tests/succeed/equality.snap
@@ -1,46 +1,37 @@
 stdout = '''
-let id : fun (A : Type) -> fun (_ : A) -> A = fun A => fun a => a;
-let Eq : fun (A : Type) -> fun (_ : A) -> fun (_ : A) -> Type =
-fun A => fun a0 => fun a1 => fun (P : fun (_ : A) -> Type) -> fun (_ : P a0) ->
-P a1;
-let refl : fun (A : Type) -> fun (a : A) -> fun (P : fun (_ : A) -> Type) ->
-fun (_ : P a) -> P a = fun A => fun a => fun P => id (P a);
-let fun_eta_left : fun (f : fun (_ : Type) -> Type) -> fun (P : fun (_ :
-fun (_ : Type) -> Type) -> Type) -> fun (_ : P f) -> P (fun x => f x) =
+let id : fun (A : Type) -> A -> A = fun A => fun a => a;
+let Eq : fun (A : Type) -> A -> A -> Type =
+fun A => fun a0 => fun a1 => fun (P : A -> Type) -> P a0 -> P a1;
+let refl : fun (A : Type) -> fun (a : A) -> fun (P : A -> Type) -> P a -> P a =
+fun A => fun a => fun P => id (P a);
+let fun_eta_left : fun (f : Type -> Type) -> fun (P : (Type -> Type) -> Type) ->
+P f -> P (fun x => f x) = fun f => refl (_ f) f;
+let fun_eta_right : fun (f : Type -> Type) -> fun (P : (Type -> Type) ->
+Type) -> P (fun x => f x) -> P f = fun f => refl (_ f) f;
+let fun_eta_left : fun (f : Type -> Type -> Type) -> fun (P : (Type -> Type ->
+Type) -> Type) -> P f -> P (fun x => f x) = fun f => refl (_ f) f;
+let fun_eta_right : fun (f : Type -> Type -> Type) -> fun (P : (Type -> Type ->
+Type) -> Type) -> P (fun x => f x) -> P f = fun f => refl (_ f) f;
+let fun_eta_left : fun (f : Type -> Type -> Type) -> fun (P : (Type -> Type ->
+Type) -> Type) -> P f -> P (fun x => fun y => f x y) = fun f => refl (_ f) f;
+let fun_eta_right : fun (f : Type -> Type -> Type) -> fun (P : (Type -> Type ->
+Type) -> Type) -> P (fun x => fun y => f x y) -> P f = fun f => refl (_ f) f;
+let fun_eta_left : fun (f : Type -> Type -> Type) -> fun (P : (Type -> Type ->
+Type) -> Type) -> P (fun x => f x) -> P (fun x => fun y => f x y) =
 fun f => refl (_ f) f;
-let fun_eta_right : fun (f : fun (_ : Type) -> Type) -> fun (P : fun (_ :
-fun (x : Type) -> Type) -> Type) -> fun (_ : P (fun x => f x)) -> P f =
+let fun_eta_right : fun (f : Type -> Type -> Type) -> fun (P : (Type -> Type ->
+Type) -> Type) -> P (fun x => fun y => f x y) -> P (fun x => f x) =
 fun f => refl (_ f) f;
-let fun_eta_left : fun (f : fun (_ : Type) -> fun (_ : Type) -> Type) ->
-fun (P : fun (_ : fun (_ : Type) -> fun (_ : Type) -> Type) -> Type) -> fun (_ :
-P f) -> P (fun x => f x) = fun f => refl (_ f) f;
-let fun_eta_right : fun (f : fun (_ : Type) -> fun (_ : Type) -> Type) ->
-fun (P : fun (_ : fun (x : Type) -> fun (_ : Type) -> Type) -> Type) -> fun (_ :
-P (fun x => f x)) -> P f = fun f => refl (_ f) f;
-let fun_eta_left : fun (f : fun (_ : Type) -> fun (_ : Type) -> Type) ->
-fun (P : fun (_ : fun (_ : Type) -> fun (_ : Type) -> Type) -> Type) -> fun (_ :
-P f) -> P (fun x => fun y => f x y) = fun f => refl (_ f) f;
-let fun_eta_right : fun (f : fun (_ : Type) -> fun (_ : Type) -> Type) ->
-fun (P : fun (_ : fun (x : Type) -> fun (y : Type) -> Type) -> Type) -> fun (_ :
-P (fun x => fun y => f x y)) -> P f = fun f => refl (_ f) f;
-let fun_eta_left : fun (f : fun (_ : Type) -> fun (_ : Type) -> Type) ->
-fun (P : fun (_ : fun (x : Type) -> fun (_ : Type) -> Type) -> Type) -> fun (_ :
-P (fun x => f x)) -> P (fun x => fun y => f x y) = fun f => refl (_ f) f;
-let fun_eta_right : fun (f : fun (_ : Type) -> fun (_ : Type) -> Type) ->
-fun (P : fun (_ : fun (x : Type) -> fun (y : Type) -> Type) -> Type) -> fun (_ :
-P (fun x => fun y => f x y)) -> P (fun x => f x) = fun f => refl (_ f) f;
-let record_eta_left : fun (r : { x : Type, y : Type }) -> fun (P : fun (_ : {
+let record_eta_left : fun (r : { x : Type, y : Type }) -> fun (P : {
     x : Type,
     y : Type,
-}) -> Type) -> fun (_ : P r) -> P { x = r.x, y = r.y } = fun r => refl (_ r) r;
-let record_eta_right : fun (r : { x : Type, y : Type }) -> fun (P : fun (_ : {
+} -> Type) -> P r -> P { x = r.x, y = r.y } = fun r => refl (_ r) r;
+let record_eta_right : fun (r : { x : Type, y : Type }) -> fun (P : {
     x : Type,
     y : Type,
-}) -> Type) -> fun (_ : P { x = r.x, y = r.y }) -> P r = fun r => refl (_ r) r;
-let four_chars : fun (P : fun (_ : U32) -> Type) -> fun (_ : P "beng") ->
-P 1650814567 = refl _ _;
-let three_chars : fun (P : fun (_ : U32) -> Type) -> fun (_ : P "BEN ") ->
-P 1111838240 = refl _ _;
+} -> Type) -> P { x = r.x, y = r.y } -> P r = fun r => refl (_ r) r;
+let four_chars : fun (P : U32 -> Type) -> P "beng" -> P 1650814567 = refl _ _;
+let three_chars : fun (P : U32 -> Type) -> P "BEN " -> P 1111838240 = refl _ _;
 Type : Type
 '''
 stderr = ''

--- a/tests/succeed/format-cond/simple.snap
+++ b/tests/succeed/format-cond/simple.snap
@@ -2,7 +2,7 @@ stdout = '''
 let format : _ = {
     sfnt_version <- { version <- u32be | u32_eq version 0xffff },
 };
-let _ : fun (_ : { sfnt_version : U32 }) -> { sfnt_version : U32 } = fun x => x;
+let _ : { sfnt_version : U32 } -> { sfnt_version : U32 } = fun x => x;
 {} : {}
 '''
 stderr = ''

--- a/tests/succeed/format-overlap/dependent.snap
+++ b/tests/succeed/format-overlap/dependent.snap
@@ -5,10 +5,10 @@ let silly : _ = overlap {
     record0 <- record0,
     record1 <- record1 record0.length,
 };
-let _ : fun (_ : {
+let _ : {
     record0 : { length : U8 },
     record1 : { _length : U8, data : Array8 record0.length U8 },
-}) -> {
+} -> {
     record0 : { length : U8 },
     record1 : { _length : U8, data : Array8 record0.length U8 },
 } = fun silly => silly;

--- a/tests/succeed/format-overlap/field-refinements.snap
+++ b/tests/succeed/format-overlap/field-refinements.snap
@@ -1,6 +1,6 @@
 stdout = '''
 let number : _ = overlap { u <- u32be where u32_gte u 2, s <- s32be };
-let _ : fun (_ : { u : U32, s : S32 }) -> { u : U32, s : S32 } = fun n => n;
+let _ : { u : U32, s : S32 } -> { u : U32, s : S32 } = fun n => n;
 {} : {}
 '''
 stderr = ''

--- a/tests/succeed/format-overlap/numbers.snap
+++ b/tests/succeed/format-overlap/numbers.snap
@@ -1,6 +1,6 @@
 stdout = '''
 let number : _ = overlap { u <- u32be, s <- s32be };
-let _ : fun (_ : { u : U32, s : S32 }) -> { u : U32, s : S32 } = fun n => n;
+let _ : { u : U32, s : S32 } -> { u : U32, s : S32 } = fun n => n;
 {} : {}
 '''
 stderr = ''

--- a/tests/succeed/format-record/computed-fields.snap
+++ b/tests/succeed/format-record/computed-fields.snap
@@ -5,19 +5,19 @@ let format : _ = {
     start_code <- array16 seg_count u16be,
     id_delta <- array16 seg_count s16be,
 };
-let _ : fun (_ : {
+let _ : {
     seg_count_x2 : U16,
     seg_count : U16,
     start_code : Array16 seg_count U16,
     id_delta : Array16 seg_count S16,
-}) -> {
+} -> {
     seg_count_x2 : U16,
     seg_count : U16,
     start_code : Array16 seg_count U16,
     id_delta : Array16 seg_count S16,
 } = fun x => x;
 let format : _ = { let x : U32 = 256 };
-let _ : fun (_ : { x : U32 }) -> { x : U32 } = fun x => x;
+let _ : { x : U32 } -> { x : U32 } = fun x => x;
 {} : {}
 '''
 stderr = ''

--- a/tests/succeed/format-record/field-refinements.snap
+++ b/tests/succeed/format-record/field-refinements.snap
@@ -4,7 +4,7 @@ let format : _ = {
     len <- u8 where u8_lte len 16,
     data <- array8 len u8,
 };
-let _ : fun (_ : { magic : U64, len : U8, data : Array8 len U8 }) -> {
+let _ : { magic : U64, len : U8, data : Array8 len U8 } -> {
     magic : U64,
     len : U8,
     data : Array8 len U8,

--- a/tests/succeed/format-record/pair-dependent.snap
+++ b/tests/succeed/format-record/pair-dependent.snap
@@ -1,6 +1,5 @@
 stdout = '''
-let array32 : fun (_ : U32) -> fun (_ : Format) -> Format =
-fun len => fun Elem => Elem;
+let array32 : U32 -> Format -> Format = fun len => fun Elem => Elem;
 let pair : _ = { len <- u32be, data <- array32 len u32be };
 pair : Format
 '''

--- a/tests/succeed/format-repr/pair-dependent.snap
+++ b/tests/succeed/format-repr/pair-dependent.snap
@@ -1,11 +1,8 @@
 stdout = '''
-let array32 : fun (_ : U32) -> fun (_ : Format) -> Format =
-fun len => fun Elem => Elem;
+let array32 : U32 -> Format -> Format = fun len => fun Elem => Elem;
 let pair : _ = { len <- u32be, data <- array32 len u32be };
-let test_pair : fun (_ : { len : U32, data : U32 }) -> {
-    len : U32,
-    data : U32,
-} = fun p => p;
+let test_pair : { len : U32, data : U32 } -> { len : U32, data : U32 } =
+fun p => p;
 pair : Format
 '''
 stderr = ''

--- a/tests/succeed/format-repr/primitives.snap
+++ b/tests/succeed/format-repr/primitives.snap
@@ -1,48 +1,48 @@
 stdout = '''
-let test_u8_repr : fun (_ : U8) -> U8 = fun x => x;
-let test_u16be_repr : fun (_ : U16) -> U16 = fun x => x;
-let test_u16le_repr : fun (_ : U16) -> U16 = fun x => x;
-let test_u32be_repr : fun (_ : U32) -> U32 = fun x => x;
-let test_u32le_repr : fun (_ : U32) -> U32 = fun x => x;
-let test_u64be_repr : fun (_ : U64) -> U64 = fun x => x;
-let test_u64le_repr : fun (_ : U64) -> U64 = fun x => x;
-let test_s8_repr : fun (_ : S8) -> S8 = fun x => x;
-let test_s16be_repr : fun (_ : S16) -> S16 = fun x => x;
-let test_s16le_repr : fun (_ : S16) -> S16 = fun x => x;
-let test_s32be_repr : fun (_ : S32) -> S32 = fun x => x;
-let test_s32le_repr : fun (_ : S32) -> S32 = fun x => x;
-let test_s64be_repr : fun (_ : S64) -> S64 = fun x => x;
-let test_s64le_repr : fun (_ : S64) -> S64 = fun x => x;
-let test_f32be_repr : fun (_ : F32) -> F32 = fun x => x;
-let test_f32le_repr : fun (_ : F32) -> F32 = fun x => x;
-let test_f64be_repr : fun (_ : F64) -> F64 = fun x => x;
-let test_f64le_repr : fun (_ : F64) -> F64 = fun x => x;
-let test_array8 : fun (n : U8) -> fun (f : Format) -> fun (_ :
-Array8 n (Repr f)) -> Array8 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_array16 : fun (n : U16) -> fun (f : Format) -> fun (_ :
-Array16 n (Repr f)) -> Array16 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_array32 : fun (n : U32) -> fun (f : Format) -> fun (_ :
-Array32 n (Repr f)) -> Array32 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_array64 : fun (n : U64) -> fun (f : Format) -> fun (_ :
-Array64 n (Repr f)) -> Array64 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_repeat_until_end : fun (f : Format) -> fun (_ : Array (Repr f)) ->
+let test_u8_repr : U8 -> U8 = fun x => x;
+let test_u16be_repr : U16 -> U16 = fun x => x;
+let test_u16le_repr : U16 -> U16 = fun x => x;
+let test_u32be_repr : U32 -> U32 = fun x => x;
+let test_u32le_repr : U32 -> U32 = fun x => x;
+let test_u64be_repr : U64 -> U64 = fun x => x;
+let test_u64le_repr : U64 -> U64 = fun x => x;
+let test_s8_repr : S8 -> S8 = fun x => x;
+let test_s16be_repr : S16 -> S16 = fun x => x;
+let test_s16le_repr : S16 -> S16 = fun x => x;
+let test_s32be_repr : S32 -> S32 = fun x => x;
+let test_s32le_repr : S32 -> S32 = fun x => x;
+let test_s64be_repr : S64 -> S64 = fun x => x;
+let test_s64le_repr : S64 -> S64 = fun x => x;
+let test_f32be_repr : F32 -> F32 = fun x => x;
+let test_f32le_repr : F32 -> F32 = fun x => x;
+let test_f64be_repr : F64 -> F64 = fun x => x;
+let test_f64le_repr : F64 -> F64 = fun x => x;
+let test_array8 : fun (n : U8) -> fun (f : Format) -> Array8 n (Repr f) ->
+Array8 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array16 : fun (n : U16) -> fun (f : Format) -> Array16 n (Repr f) ->
+Array16 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array32 : fun (n : U32) -> fun (f : Format) -> Array32 n (Repr f) ->
+Array32 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array64 : fun (n : U64) -> fun (f : Format) -> Array64 n (Repr f) ->
+Array64 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_repeat_until_end : fun (f : Format) -> Array (Repr f) ->
 Array (Repr f) = fun _ => fun x => x;
-let test_limit8 : fun (n : U8) -> fun (f : Format) -> fun (_ : Repr f) ->
-Repr f = fun _ => fun _ => fun x => x;
-let test_limit16 : fun (n : U16) -> fun (f : Format) -> fun (_ : Repr f) ->
-Repr f = fun _ => fun _ => fun x => x;
-let test_limit32 : fun (n : U32) -> fun (f : Format) -> fun (_ : Repr f) ->
-Repr f = fun _ => fun _ => fun x => x;
-let test_limit64 : fun (n : U64) -> fun (f : Format) -> fun (_ : Repr f) ->
-Repr f = fun _ => fun _ => fun x => x;
-let test_link : fun (pos : Pos) -> fun (f : Format) -> fun (_ : Ref f) ->
-Ref f = fun _ => fun _ => fun x => x;
-let test_deref : fun (f : Format) -> fun (ref : Ref f) -> fun (_ : Repr f) ->
-Repr f = fun _ => fun _ => fun x => x;
-let test_stream_pos : fun (_ : Pos) -> Pos = fun x => x;
-let test_succeed : fun (_ : S32) -> S32 = fun x => x;
-let test_fail : fun (_ : Void) -> Void = fun x => x;
-let test_unwrap : fun (A : Type) -> fun (opt_a : Option A) -> fun (_ : A) -> A =
+let test_limit8 : U8 -> fun (f : Format) -> Repr f -> Repr f =
+fun _ => fun _ => fun x => x;
+let test_limit16 : U16 -> fun (f : Format) -> Repr f -> Repr f =
+fun _ => fun _ => fun x => x;
+let test_limit32 : U32 -> fun (f : Format) -> Repr f -> Repr f =
+fun _ => fun _ => fun x => x;
+let test_limit64 : U64 -> fun (f : Format) -> Repr f -> Repr f =
+fun _ => fun _ => fun x => x;
+let test_link : Pos -> fun (f : Format) -> Ref f -> Ref f =
+fun _ => fun _ => fun x => x;
+let test_deref : fun (f : Format) -> Ref f -> Repr f -> Repr f =
+fun _ => fun _ => fun x => x;
+let test_stream_pos : Pos -> Pos = fun x => x;
+let test_succeed : S32 -> S32 = fun x => x;
+let test_fail : Void -> Void = fun x => x;
+let test_unwrap : fun (A : Type) -> Option A -> A -> A =
 fun _ => fun _ => fun x => x;
 Type : Type
 '''

--- a/tests/succeed/format-repr/record.snap
+++ b/tests/succeed/format-repr/record.snap
@@ -1,8 +1,8 @@
 stdout = '''
 let pair : _ = { fst <- u32be, snd <- u32be };
-let test_pair : fun (_ : { fst : U32, snd : U32 }) -> { fst : U32, snd : U32 } =
+let test_pair : { fst : U32, snd : U32 } -> { fst : U32, snd : U32 } =
 fun p => p;
-let test_pair : fun (_ : { fst : U32, snd : U32 }) -> { fst : U32, snd : U32 } =
+let test_pair : { fst : U32, snd : U32 } -> { fst : U32, snd : U32 } =
 fun p => { fst = p.fst, snd = p.snd };
 pair : Format
 '''

--- a/tests/succeed/format-repr/unit-literal.snap
+++ b/tests/succeed/format-repr/unit-literal.snap
@@ -1,7 +1,7 @@
 stdout = '''
 let unit : Format = {};
-let test_unit : fun (_ : {}) -> {} = fun p => p;
-let test_unit : fun (_ : {}) -> {} = fun p => {};
+let test_unit : {} -> {} = fun p => p;
+let test_unit : {} -> {} = fun p => {};
 unit : Format
 '''
 stderr = ''

--- a/tests/succeed/fun-elim/ann-identity-mono-0.snap
+++ b/tests/succeed/fun-elim/ann-identity-mono-0.snap
@@ -1,4 +1,4 @@
 stdout = '''
-(fun a => a : fun (_ : Type) -> Type) Type : Type
+(fun a => a : Type -> Type) Type : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-elim/ann-identity-mono-1.snap
+++ b/tests/succeed/fun-elim/ann-identity-mono-1.snap
@@ -1,5 +1,4 @@
 stdout = '''
-(fun a => a : fun (_ : fun (_ : Type) -> Type) -> fun (_ : Type) ->
-Type) (fun a => a) Type : Type
+(fun a => a : (Type -> Type) -> Type -> Type) (fun a => a) Type : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-elim/ann-identity-mono-2.snap
+++ b/tests/succeed/fun-elim/ann-identity-mono-2.snap
@@ -1,4 +1,4 @@
 stdout = '''
-(fun a => a : fun (_ : fun (_ : Type) -> Type) -> _ _) (fun a => a) Type : Type
+(fun a => a : (Type -> Type) -> _ _) (fun a => a) Type : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-elim/ann-identity-poly-0.snap
+++ b/tests/succeed/fun-elim/ann-identity-poly-0.snap
@@ -1,4 +1,4 @@
 stdout = '''
-(fun A => fun a => a : fun (A : Type) -> fun (_ : A) -> A) Type Type : Type
+(fun A => fun a => a : fun (A : Type) -> A -> A) Type Type : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-elim/ann-identity-poly-1.snap
+++ b/tests/succeed/fun-elim/ann-identity-poly-1.snap
@@ -1,5 +1,5 @@
 stdout = '''
-(fun A => fun a => a : fun (A : Type) -> fun (_ : A) -> A) (fun (_ : Type) ->
-Type) (fun a => a) : fun (_ : Type) -> Type
+(fun A => fun a => a : fun (A : Type) -> A -> A) (Type -> Type) (fun a => a) :
+Type -> Type
 '''
 stderr = ''

--- a/tests/succeed/fun-literal/identity-mono.snap
+++ b/tests/succeed/fun-literal/identity-mono.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun a => a : fun (a : Type) -> Type
+fun a => a : Type -> Type
 '''
 stderr = ''

--- a/tests/succeed/fun-literal/identity-poly.snap
+++ b/tests/succeed/fun-literal/identity-poly.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun A => fun a => a : fun (A : Type) -> fun (a : A) -> A
+fun A => fun a => a : fun (A : Type) -> A -> A
 '''
 stderr = ''

--- a/tests/succeed/fun-type/identity-mono.snap
+++ b/tests/succeed/fun-type/identity-mono.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : Type) -> Type : Type
+Type -> Type : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-type/identity-poly-arrow.snap
+++ b/tests/succeed/fun-type/identity-poly-arrow.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : Type) -> fun (_ : A) -> A : Type
+fun (A : Type) -> A -> A : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-type/identity-poly-input-ann-placeholder.snap
+++ b/tests/succeed/fun-type/identity-poly-input-ann-placeholder.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : _) -> fun (_ : A) -> A : Type
+fun (A : _) -> A -> A : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-type/identity-poly-input-placeholder.snap
+++ b/tests/succeed/fun-type/identity-poly-input-placeholder.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : Type) -> fun (_ : A) -> A : Type
+fun (A : Type) -> A -> A : Type
 '''
 stderr = ''

--- a/tests/succeed/fun-type/identity-poly.snap
+++ b/tests/succeed/fun-type/identity-poly.snap
@@ -1,4 +1,4 @@
 stdout = '''
-fun (A : Type) -> fun (a : A) -> A : Type
+fun (A : Type) -> A -> A : Type
 '''
 stderr = ''

--- a/tests/succeed/hole/hole-1.snap
+++ b/tests/succeed/hole/hole-1.snap
@@ -8,6 +8,6 @@ note: solution found for hole `?fun_type`
 1 │ (fun a => a : ?fun_type) Type
   │               ^^^^^^^^^ solution found
   │
-  = hole `?fun_type` can be replaced with `fun (a : Type) -> Type`
+  = hole `?fun_type` can be replaced with `Type -> Type`
 
 '''

--- a/tests/succeed/let/id-type.snap
+++ b/tests/succeed/let/id-type.snap
@@ -1,6 +1,6 @@
 stdout = '''
-let Id : fun (_ : Type) -> Type = fun A => A;
-let test_id : fun (A : Type) -> fun (_ : A) -> A = fun A => fun a => a;
+let Id : Type -> Type = fun A => A;
+let test_id : fun (A : Type) -> A -> A = fun A => fun a => a;
 Type : Type
 '''
 stderr = ''

--- a/tests/succeed/let/identity-placeholders.snap
+++ b/tests/succeed/let/identity-placeholders.snap
@@ -1,6 +1,6 @@
 stdout = '''
-let id : fun (A : Type) -> fun (_ : A) -> A = fun A => fun a => a;
-let test_id_check0 : fun (_ : Type) -> Type = id _;
+let id : fun (A : Type) -> A -> A = fun A => fun a => a;
+let test_id_check0 : Type -> Type = id _;
 let test_id_check1 : Type = id _ Type;
 let test_id_synth : _ = id _ Type;
 Type : Type

--- a/tests/succeed/let/identity.snap
+++ b/tests/succeed/let/identity.snap
@@ -1,6 +1,6 @@
 stdout = '''
-let id : fun (A : Type) -> fun (_ : A) -> A = fun A => fun a => a;
-let test_id_check0 : fun (_ : Type) -> Type = id Type;
+let id : fun (A : Type) -> A -> A = fun A => fun a => a;
+let test_id_check0 : Type -> Type = id Type;
 let test_id_check1 : Type = id Type Type;
 let test_id_synth : _ = id Type Type;
 Type : Type

--- a/tests/succeed/prelude.snap
+++ b/tests/succeed/prelude.snap
@@ -1,113 +1,87 @@
 stdout = '''
-let id : fun (A : Type) -> fun (_ : A) -> A = fun _ => fun a => a;
-let always : fun (A : Type) -> fun (B : Type) -> fun (_ : A) -> fun (_ : B) ->
-A = fun _ => fun _ => fun a => fun _ => a;
-let compose : fun (A : Type) -> fun (B : Type) -> fun (C : Type) -> fun (_ :
-fun (_ : A) -> B) -> fun (_ : fun (_ : B) -> C) -> fun (_ : A) -> C =
+let id : fun (A : Type) -> A -> A = fun _ => fun a => a;
+let always : fun (A : Type) -> fun (B : Type) -> A -> B -> A =
+fun _ => fun _ => fun a => fun _ => a;
+let compose : fun (A : Type) -> fun (B : Type) -> fun (C : Type) -> (A -> B) ->
+(B -> C) -> A -> C =
 fun _ => fun _ => fun _ => fun ab => fun bc => fun a => bc (ab a);
-let Nat : Type = fun (Nat : _) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat;
-let zero : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero :
-Nat) -> Nat = fun Nat => fun succ => fun zero => zero;
-let succ : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> fun (Nat : Type) -> fun (succ : fun (_ : Nat) ->
-Nat) -> fun (zero : Nat) -> Nat =
+let Nat : Type = fun (Nat : _) -> (Nat -> Nat) -> Nat -> Nat;
+let zero : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat =
+fun Nat => fun succ => fun zero => zero;
+let succ : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> fun (Nat :
+Type) -> (Nat -> Nat) -> Nat -> Nat =
 fun prev => fun Nat => fun succ => fun zero => succ (prev (_ prev Nat succ zero) succ zero);
-let add : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> fun (_ : fun (Nat : Type) -> fun (succ : fun (_ :
-Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat =
+let add : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> (fun (Nat :
+Type) -> (Nat -> Nat) -> Nat -> Nat) -> fun (Nat : Type) -> (Nat -> Nat) -> Nat
+-> Nat =
 fun n0 => fun n1 => fun Nat => fun succ => fun zero => n0 Nat succ (n1 Nat succ zero);
-let mul : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> fun (_ : fun (Nat : Type) -> fun (succ : fun (_ :
-Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat =
+let mul : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> (fun (Nat :
+Type) -> (Nat -> Nat) -> Nat -> Nat) -> fun (Nat : Type) -> (Nat -> Nat) -> Nat
+-> Nat =
 fun n0 => fun n1 => fun Nat => fun succ => fun zero => n0 Nat (n1 Nat succ) zero;
-let List : fun (_ : Type) -> Type = fun Elem => fun (List : _ Elem) ->
-fun (nil : List) -> fun (cons : fun (_ : Elem) -> fun (_ : List) -> List) ->
-List;
-let nil : fun (Elem : Type) -> fun (List : Type) -> fun (nil : List) ->
-fun (cons : fun (_ : Elem) -> fun (_ : List) -> List) -> List =
-fun Elem => fun List => fun nil => fun cons => nil;
-let cons : fun (Elem : Type) -> fun (_ : Elem) -> fun (_ : fun (List : Type) ->
-fun (nil : List) -> fun (cons : fun (_ : Elem) -> fun (_ : List) -> List) ->
-List) -> fun (List : Type) -> fun (nil : List) -> fun (cons : fun (_ : Elem) ->
-fun (_ : List) -> List) -> List =
+let List : Type -> Type = fun Elem => fun (List : _ Elem) -> List -> (Elem ->
+List -> List) -> List;
+let nil : fun (Elem : Type) -> fun (List : Type) -> List -> (Elem -> List ->
+List) -> List = fun Elem => fun List => fun nil => fun cons => nil;
+let cons : fun (Elem : Type) -> Elem -> (fun (List : Type) -> List -> (Elem ->
+List -> List) -> List) -> fun (List : Type) -> List -> (Elem -> List -> List) ->
+List =
 fun Elem => fun head => fun tail => fun List => fun nil => fun cons => cons head (tail (_ Elem head tail List nil cons) nil cons);
-let Vec : fun (_ : Type) -> fun (_ : fun (Nat : Type) -> fun (succ : fun (_ :
-Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> Type =
-fun Elem => fun len => fun (Vec : fun (_ : fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> Type) -> fun (nil :
-Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons : fun (len :
-fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) ->
-Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
+let Vec : Type -> (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Type =
+fun Elem => fun len => fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) -> Nat ->
+Nat) -> Type) -> Vec (fun Nat => fun succ => fun zero => zero) -> (fun (len :
+fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len ->
 Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) -> Vec len;
-let vnil : fun (Elem : Type) -> fun (Vec : fun (_ : fun (Nat : Type) ->
-fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> Type) ->
-fun (nil : Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons :
-fun (len : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero :
-Nat) -> Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
-Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
+let vnil : fun (Elem : Type) -> fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) ->
+Nat -> Nat) -> Type) -> Vec (fun Nat => fun succ => fun zero => zero) ->
+(fun (len : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len
+-> Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
 Vec (fun Nat => fun succ => fun zero => zero) =
 fun Elem => fun Vec => fun nil => fun cons => nil;
-let vcons : fun (Elem : Type) -> fun (len : fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> fun (_ : Elem) -> fun (_ :
-fun (Vec : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> Type) -> fun (nil :
-Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons : fun (len :
-fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) ->
-Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
-Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
-Vec len) -> fun (Vec : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) ->
-Nat) -> fun (zero : Nat) -> Nat) -> Type) -> fun (nil :
-Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons : fun (len :
-fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) ->
-Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
+let vcons : fun (Elem : Type) -> fun (len : fun (Nat : Type) -> (Nat -> Nat) ->
+Nat -> Nat) -> Elem -> (fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) -> Nat ->
+Nat) -> Type) -> Vec (fun Nat => fun succ => fun zero => zero) -> (fun (len :
+fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len ->
+Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) -> Vec len)
+-> fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Type) ->
+Vec (fun Nat => fun succ => fun zero => zero) -> (fun (len : fun (Nat : Type) ->
+(Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len ->
 Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
 Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero)) =
 fun Elem => fun len => fun head => fun tail => fun Vec => fun nil => fun cons => cons (_ Elem len head tail Vec nil cons) head (tail Vec nil cons);
 let Void : Type = fun (Void : Type) -> Void;
-let absurd : fun (A : Type) -> fun (_ : fun (Void : Type) -> Void) -> A =
+let absurd : fun (A : Type) -> (fun (Void : Type) -> Void) -> A =
 fun A => fun void => void A;
-let Unit : Type = fun (Unit : Type) -> fun (unit : Unit) -> Unit;
-let unit : fun (Unit : Type) -> fun (unit : Unit) -> Unit =
-fun Unit => fun unit => unit;
-let Eq : fun (A : Type) -> fun (_ : A) -> fun (_ : A) -> Type =
-fun A => fun a0 => fun a1 => fun (P : fun (_ : A) -> Type) -> fun (_ : P a0) ->
-P a1;
-let refl : fun (A : Type) -> fun (a : A) -> fun (P : fun (_ : A) -> Type) ->
-fun (_ : P a) -> P a = fun A => fun a => fun P => id (P a);
+let Unit : Type = fun (Unit : Type) -> Unit -> Unit;
+let unit : fun (Unit : Type) -> Unit -> Unit = fun Unit => fun unit => unit;
+let Eq : fun (A : Type) -> A -> A -> Type =
+fun A => fun a0 => fun a1 => fun (P : A -> Type) -> P a0 -> P a1;
+let refl : fun (A : Type) -> fun (a : A) -> fun (P : A -> Type) -> P a -> P a =
+fun A => fun a => fun P => id (P a);
 let trans : fun (A : Type) -> fun (a0 : A) -> fun (a1 : A) -> fun (a2 : A) ->
-fun (_ : fun (P : fun (_ : A) -> Type) -> fun (_ : P a0) -> P a1) -> fun (_ :
-fun (P : fun (_ : A) -> Type) -> fun (_ : P a1) -> P a2) -> fun (P : fun (_ :
-A) -> Type) -> fun (_ : P a0) -> P a2 =
+(fun (P : A -> Type) -> P a0 -> P a1) -> (fun (P : A -> Type) -> P a1 -> P a2)
+-> fun (P : A -> Type) -> P a0 -> P a2 =
 fun _ => fun a0 => fun a1 => fun a2 => fun p0 => fun p1 => fun P => compose (_ _ a0 a1 a2 p0 p1 P) (_ _ a0 a1 a2 p0 p1 P) (_ _ a0 a1 a2 p0 p1 P) (p0 P) (p1 P);
-let sym : fun (A : Type) -> fun (a0 : A) -> fun (a1 : A) -> fun (_ : fun (P :
-fun (_ : A) -> Type) -> fun (_ : P a0) -> P a1) -> fun (P : fun (_ : A) ->
-Type) -> fun (_ : P a1) -> P a0 =
+let sym : fun (A : Type) -> fun (a0 : A) -> fun (a1 : A) -> (fun (P : A ->
+Type) -> P a0 -> P a1) -> fun (P : A -> Type) -> P a1 -> P a0 =
 fun _ => fun a0 => fun a1 => fun p => p (fun a1 => Eq (_ _ a0 a1 p a1) a1 a0) (refl (_ _ a0 a1 p) (_ _ a0 a1 p));
 let id_apply_type : _ = (fun a => a) Type;
-let list1 : fun (List : Type) -> fun (nil : List) -> fun (cons : fun (_ :
-Bool) -> fun (_ : List) -> List) -> List = cons _ (id _ true) (nil _);
-let five : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero :
-Nat) -> Nat = succ (succ (succ (succ (succ zero))));
-let ten : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero :
-Nat) -> Nat = add five five;
-let hundred : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat = mul ten ten;
-let thousand : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat = mul ten hundred;
-let eq_test : fun (P : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) ->
-Nat) -> fun (zero : Nat) -> Nat) -> Type) -> fun (_ :
-P (fun Nat => fun succ => fun zero => succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) ->
+let list1 : fun (List : Type) -> List -> (Bool -> List -> List) -> List =
+cons _ (id _ true) (nil _);
+let five : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat =
+succ (succ (succ (succ (succ zero))));
+let ten : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat = add five five;
+let hundred : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat = mul ten ten;
+let thousand : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat = mul ten hundred;
+let eq_test : fun (P : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) ->
+Type) ->
+P (fun Nat => fun succ => fun zero => succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+->
 P (fun Nat => fun succ => fun zero => succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) =
 refl _ _;
-let eq_id_apply_type : fun (P : fun (_ : Type) -> Type) -> fun (_ : P Type) ->
-P Type = refl _ _;
-let eq_id_apply_true : fun (P : fun (_ : Bool) -> Type) -> fun (_ : P true) ->
-P true = refl _ _;
-let eq_id_apply_false : fun (P : fun (_ : Bool) -> Type) -> fun (_ : P false) ->
-P false = refl _ _;
+let eq_id_apply_type : fun (P : Type -> Type) -> P Type -> P Type = refl _ _;
+let eq_id_apply_true : fun (P : Bool -> Type) -> P true -> P true = refl _ _;
+let eq_id_apply_false : fun (P : Bool -> Type) -> P false -> P false = refl _ _;
 Type : Type
 '''
 stderr = ''

--- a/tests/succeed/primitive-ops.snap
+++ b/tests/succeed/primitive-ops.snap
@@ -1,12 +1,12 @@
 stdout = '''
-let test : fun (_ : Array8 3 {}) -> Array8 3 {} = fun x => x;
-let test : fun (_ : Array16 3 {}) -> Array16 3 {} = fun x => x;
-let test : fun (_ : Array32 3 {}) -> Array32 3 {} = fun x => x;
-let test : fun (_ : Array64 3 {}) -> Array64 3 {} = fun x => x;
-let test : fun (_ : Array8 2 {}) -> Array8 2 {} = fun x => x;
-let test : fun (_ : Array16 2 {}) -> Array16 2 {} = fun x => x;
-let test : fun (_ : Array32 2 {}) -> Array32 2 {} = fun x => x;
-let test : fun (_ : Array64 2 {}) -> Array64 2 {} = fun x => x;
+let test : Array8 3 {} -> Array8 3 {} = fun x => x;
+let test : Array16 3 {} -> Array16 3 {} = fun x => x;
+let test : Array32 3 {} -> Array32 3 {} = fun x => x;
+let test : Array64 3 {} -> Array64 3 {} = fun x => x;
+let test : Array8 2 {} -> Array8 2 {} = fun x => x;
+let test : Array16 2 {} -> Array16 2 {} = fun x => x;
+let test : Array32 2 {} -> Array32 2 {} = fun x => x;
+let test : Array64 2 {} -> Array64 2 {} = fun x => x;
 Type : Type
 '''
 stderr = ''

--- a/tests/succeed/record-type/generic-point.snap
+++ b/tests/succeed/record-type/generic-point.snap
@@ -1,9 +1,7 @@
 stdout = '''
-let Point : fun (_ : Type) -> Type = fun A => { x : A, y : A };
-let test_point : fun (A : Type) -> fun (_ : { x : A, y : A }) -> {
-    x : A,
-    y : A,
-} = fun A => fun p => p;
+let Point : Type -> Type = fun A => { x : A, y : A };
+let test_point : fun (A : Type) -> { x : A, y : A } -> { x : A, y : A } =
+fun A => fun p => p;
 Type : Type
 '''
 stderr = ''

--- a/tests/succeed/record-type/generic-singleton.snap
+++ b/tests/succeed/record-type/generic-singleton.snap
@@ -1,7 +1,6 @@
 stdout = '''
-let Singleton : fun (_ : Type) -> Type = fun A => { x : A };
-let test_point : fun (A : Type) -> fun (_ : { x : A }) -> { x : A } =
-fun A => fun p => p;
+let Singleton : Type -> Type = fun A => { x : A };
+let test_point : fun (A : Type) -> { x : A } -> { x : A } = fun A => fun p => p;
 Type : Type
 '''
 stderr = ''

--- a/tests/succeed/stress.snap
+++ b/tests/succeed/stress.snap
@@ -1,24 +1,20 @@
 stdout = '''
-let id : fun (A : Type) -> fun (_ : A) -> A = fun A => fun a => a;
-let id_test : fun (A : Type) -> fun (_ : A) -> A =
+let id : fun (A : Type) -> A -> A = fun A => fun a => a;
+let id_test : fun (A : Type) -> A -> A =
 id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id _ id;
-let Nat : Type = fun (Nat : _) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat;
-let zero : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero :
-Nat) -> Nat = fun Nat => fun succ => fun zero => zero;
-let succ : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> fun (Nat : Type) -> fun (succ : fun (_ : Nat) ->
-Nat) -> fun (zero : Nat) -> Nat =
+let Nat : Type = fun (Nat : _) -> (Nat -> Nat) -> Nat -> Nat;
+let zero : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat =
+fun Nat => fun succ => fun zero => zero;
+let succ : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> fun (Nat :
+Type) -> (Nat -> Nat) -> Nat -> Nat =
 fun prev => fun Nat => fun succ => fun zero => succ (prev (_ prev Nat succ zero) succ zero);
-let add : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> fun (_ : fun (Nat : Type) -> fun (succ : fun (_ :
-Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat =
+let add : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> (fun (Nat :
+Type) -> (Nat -> Nat) -> Nat -> Nat) -> fun (Nat : Type) -> (Nat -> Nat) -> Nat
+-> Nat =
 fun n0 => fun n1 => fun Nat => fun succ => fun zero => n0 Nat succ (n1 Nat succ zero);
-let mul : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> fun (_ : fun (Nat : Type) -> fun (succ : fun (_ :
-Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat =
+let mul : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> (fun (Nat :
+Type) -> (Nat -> Nat) -> Nat -> Nat) -> fun (Nat : Type) -> (Nat -> Nat) -> Nat
+-> Nat =
 fun n0 => fun n1 => fun Nat => fun succ => fun zero => n0 Nat (n1 Nat succ) zero;
 let n0 : _ = zero;
 let n1 : _ = succ n0;
@@ -32,35 +28,25 @@ let n8 : _ = succ n7;
 let n9 : _ = succ n8;
 let n10 : _ = succ n9;
 let n3000 : _ = mul n10 (mul n10 (mul n10 n3));
-let Vec : fun (_ : Type) -> fun (_ : fun (Nat : Type) -> fun (succ : fun (_ :
-Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> Type =
-fun Elem => fun len => fun (Vec : fun (_ : fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> Type) -> fun (nil :
-Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons : fun (len :
-fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) ->
-Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
+let Vec : Type -> (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Type =
+fun Elem => fun len => fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) -> Nat ->
+Nat) -> Type) -> Vec (fun Nat => fun succ => fun zero => zero) -> (fun (len :
+fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len ->
 Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) -> Vec len;
-let vnil : fun (Elem : Type) -> fun (Vec : fun (_ : fun (Nat : Type) ->
-fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> Type) ->
-fun (nil : Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons :
-fun (len : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero :
-Nat) -> Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
-Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
+let vnil : fun (Elem : Type) -> fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) ->
+Nat -> Nat) -> Type) -> Vec (fun Nat => fun succ => fun zero => zero) ->
+(fun (len : fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len
+-> Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
 Vec (fun Nat => fun succ => fun zero => zero) =
 fun Elem => fun Vec => fun nil => fun cons => nil;
-let vcons : fun (Elem : Type) -> fun (len : fun (Nat : Type) -> fun (succ :
-fun (_ : Nat) -> Nat) -> fun (zero : Nat) -> Nat) -> fun (_ : Elem) -> fun (_ :
-fun (Vec : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) ->
-fun (zero : Nat) -> Nat) -> Type) -> fun (nil :
-Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons : fun (len :
-fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) ->
-Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
-Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
-Vec len) -> fun (Vec : fun (_ : fun (Nat : Type) -> fun (succ : fun (_ : Nat) ->
-Nat) -> fun (zero : Nat) -> Nat) -> Type) -> fun (nil :
-Vec (fun Nat => fun succ => fun zero => zero)) -> fun (cons : fun (len :
-fun (Nat : Type) -> fun (succ : fun (_ : Nat) -> Nat) -> fun (zero : Nat) ->
-Nat) -> fun (_ : Elem) -> fun (_ : Vec len) ->
+let vcons : fun (Elem : Type) -> fun (len : fun (Nat : Type) -> (Nat -> Nat) ->
+Nat -> Nat) -> Elem -> (fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) -> Nat ->
+Nat) -> Type) -> Vec (fun Nat => fun succ => fun zero => zero) -> (fun (len :
+fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len ->
+Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) -> Vec len)
+-> fun (Vec : (fun (Nat : Type) -> (Nat -> Nat) -> Nat -> Nat) -> Type) ->
+Vec (fun Nat => fun succ => fun zero => zero) -> (fun (len : fun (Nat : Type) ->
+(Nat -> Nat) -> Nat -> Nat) -> Elem -> Vec len ->
 Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero))) ->
 Vec (fun Nat => fun succ => fun zero => succ (len Nat succ zero)) =
 fun Elem => fun len => fun head => fun tail => fun Vec => fun nil => fun cons => cons len head (tail Vec nil cons);


### PR DESCRIPTION
Results in more readable pretty-printing when printing non-dependent function types (eg `fun (_: Type) -> Type` is now rendered as `Type -> Type`