### PR TITLE
Track source locations in core::Term and Values

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -212,7 +212,7 @@ pub enum Term<'arena> {
     FormatOverlap(Span, &'arena [StringId], &'arena [Term<'arena>]),
 
     /// Primitives.
-    Prim(Prim),
+    Prim(Span, Prim),
 
     /// Constant literals.
     ConstLit(Const),
@@ -636,7 +636,7 @@ impl<'arena> Term<'arena> {
             | Term::FlexibleVar(_, _)
             | Term::FlexibleInsertion(_, _, _)
             | Term::Universe(_)
-            | Term::Prim(_)
+            | Term::Prim(_, _)
             | Term::ConstLit(_) => false,
 
             Term::Ann(_, term, r#type) => term.contains_free(var) || r#type.contains_free(var),

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -56,11 +56,11 @@ impl Span {
             | Value::FunLit(span, _, _)
             | Value::RecordType(span, _, _)
             | Value::RecordLit(span, _, _)
-            | Value::ArrayLit(span, _) => *span,
-            Value::FormatRecord(_, _)
-            | Value::FormatCond(_, _, _)
-            | Value::FormatOverlap(_, _)
-            | Value::ConstLit(_) => Span::fixme(),
+            | Value::ArrayLit(span, _)
+            | Value::FormatRecord(span, _, _) => *span,
+            Value::FormatCond(_, _, _) | Value::FormatOverlap(_, _) | Value::ConstLit(_) => {
+                Span::fixme()
+            }
         }
     }
 }

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -1,6 +1,6 @@
 //! Core language.
 
-use crate::core::semantics::ArcValue;
+use crate::core::semantics::Value;
 use crate::env::{GlobalVar, LocalVar};
 use crate::source::ByteRange;
 use crate::StringId;
@@ -47,10 +47,20 @@ pub enum Span {
 }
 
 impl Span {
-    pub(crate) fn from_value(_value: &ArcValue) -> Span {
-        // Placeholder for when values have Spans. When the do this can return the span of the
-        // Value.
-        Span::fixme()
+    pub(crate) fn from_value(value: &Value) -> Span {
+        match value {
+            Value::Stuck(span, _, _) => *span,
+            Value::Universe
+            | Value::FunType(_, _, _)
+            | Value::FunLit(_, _)
+            | Value::RecordType(_, _)
+            | Value::RecordLit(_, _)
+            | Value::ArrayLit(_)
+            | Value::FormatRecord(_, _)
+            | Value::FormatCond(_, _, _)
+            | Value::FormatOverlap(_, _)
+            | Value::ConstLit(_) => Span::fixme(),
+        }
     }
 }
 

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -198,7 +198,7 @@ pub enum Term<'arena> {
     /// Record literals.
     RecordLit(Span, &'arena [StringId], &'arena [Term<'arena>]),
     /// Record projections.
-    RecordProj(&'arena Term<'arena>, StringId),
+    RecordProj(Span, &'arena Term<'arena>, StringId),
 
     /// Array literals.
     ArrayLit(&'arena [Term<'arena>]),
@@ -658,7 +658,7 @@ impl<'arena> Term<'arena> {
                 var = var.prev();
                 result
             }),
-            Term::RecordProj(term, _) => term.contains_free(var),
+            Term::RecordProj(_, term, _) => term.contains_free(var),
             Term::ArrayLit(terms) => terms.iter().any(|term| term.contains_free(var)),
             Term::FormatCond(_, t1, t2) => t1.contains_free(var) || t2.contains_free(var),
             Term::ConstMatch(scrut, branches, default) => {

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -164,7 +164,7 @@ pub enum Term<'arena> {
     // - https://lib.rs/crates/bit-vec
     FlexibleInsertion(Span, GlobalVar, &'arena [EntryInfo]),
     /// Annotated expressions.
-    Ann(&'arena Term<'arena>, &'arena Term<'arena>),
+    Ann(Span, &'arena Term<'arena>, &'arena Term<'arena>),
     /// Let expressions.
     Let(
         Option<StringId>,
@@ -633,7 +633,7 @@ impl<'arena> Term<'arena> {
             | Term::Prim(_)
             | Term::ConstLit(_) => false,
 
-            Term::Ann(term, r#type) => term.contains_free(var) || r#type.contains_free(var),
+            Term::Ann(_, term, r#type) => term.contains_free(var) || r#type.contains_free(var),
             Term::Let(_, r#type, def, body) => {
                 r#type.contains_free(var)
                     || def.contains_free(var)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -189,7 +189,7 @@ pub enum Term<'arena> {
     /// Function literals.
     ///
     /// Also known as: lambda expressions, anonymous functions.
-    FunLit(Option<StringId>, &'arena Term<'arena>),
+    FunLit(Span, Option<StringId>, &'arena Term<'arena>),
     /// Function applications.
     FunApp(&'arena Term<'arena>, &'arena Term<'arena>),
 
@@ -648,7 +648,7 @@ impl<'arena> Term<'arena> {
             Term::FunType(_, _, input_type, output_type) => {
                 input_type.contains_free(var) || output_type.contains_free(var.prev())
             }
-            Term::FunLit(_, body) => body.contains_free(var.prev()),
+            Term::FunLit(_, _, body) => body.contains_free(var.prev()),
             Term::FunApp(head, arg) => head.contains_free(var) || arg.contains_free(var),
             Term::RecordType(_, terms)
             | Term::RecordLit(_, terms)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -58,8 +58,9 @@ impl Span {
             | Value::RecordLit(span, _, _)
             | Value::ArrayLit(span, _)
             | Value::FormatRecord(span, _, _)
-            | Value::FormatCond(span, _, _, _) => *span,
-            Value::FormatOverlap(_, _) | Value::ConstLit(_) => Span::fixme(),
+            | Value::FormatCond(span, _, _, _)
+            | Value::FormatOverlap(span, _, _) => *span,
+            Value::ConstLit(_) => Span::fixme(),
         }
     }
 }

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -220,6 +220,7 @@ pub enum Term<'arena> {
     ///
     /// (head_expr, pattern_branches, default_expr)
     ConstMatch(
+        Span,
         &'arena Term<'arena>,
         &'arena [(Const, Term<'arena>)],
         Option<&'arena Term<'arena>>,
@@ -661,7 +662,7 @@ impl<'arena> Term<'arena> {
             Term::RecordProj(_, term, _) => term.contains_free(var),
             Term::ArrayLit(_, terms) => terms.iter().any(|term| term.contains_free(var)),
             Term::FormatCond(_, _, t1, t2) => t1.contains_free(var) || t2.contains_free(var),
-            Term::ConstMatch(scrut, branches, default) => {
+            Term::ConstMatch(_, scrut, branches, default) => {
                 scrut.contains_free(var)
                     || branches.iter().any(|(_, term)| term.contains_free(var))
                     || default.map(|term| term.contains_free(var)).unwrap_or(false)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -215,7 +215,7 @@ pub enum Term<'arena> {
     Prim(Span, Prim),
 
     /// Constant literals.
-    ConstLit(Const),
+    ConstLit(Span, Const),
     /// Match on a constant.
     ///
     /// (head_expr, pattern_branches, default_expr)
@@ -637,7 +637,7 @@ impl<'arena> Term<'arena> {
             | Term::FlexibleInsertion(_, _, _)
             | Term::Universe(_)
             | Term::Prim(_, _)
-            | Term::ConstLit(_) => false,
+            | Term::ConstLit(_, _) => false,
 
             Term::Ann(_, term, r#type) => term.contains_free(var) || r#type.contains_free(var),
             Term::Let(_, _, r#type, def, body) => {

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -209,7 +209,7 @@ pub enum Term<'arena> {
     FormatCond(Span, StringId, &'arena Term<'arena>, &'arena Term<'arena>),
     /// Overlap formats, consisting of a list of dependent formats, overlapping
     /// in memory.
-    FormatOverlap(&'arena [StringId], &'arena [Term<'arena>]),
+    FormatOverlap(Span, &'arena [StringId], &'arena [Term<'arena>]),
 
     /// Primitives.
     Prim(Prim),
@@ -653,7 +653,7 @@ impl<'arena> Term<'arena> {
             Term::RecordType(_, _, terms)
             | Term::RecordLit(_, _, terms)
             | Term::FormatRecord(_, _, terms)
-            | Term::FormatOverlap(_, terms) => terms.iter().any(|term| {
+            | Term::FormatOverlap(_, _, terms) => terms.iter().any(|term| {
                 let result = term.contains_free(var);
                 var = var.prev();
                 result

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -167,7 +167,7 @@ pub enum Term<'arena> {
     Ann(Span, &'arena Term<'arena>, &'arena Term<'arena>),
     /// Let expressions.
     Let(
-        // TODO: Allow fetching Let span by merging the term spans
+        Span,
         Option<StringId>,
         &'arena Term<'arena>,
         &'arena Term<'arena>,
@@ -635,7 +635,7 @@ impl<'arena> Term<'arena> {
             | Term::ConstLit(_) => false,
 
             Term::Ann(_, term, r#type) => term.contains_free(var) || r#type.contains_free(var),
-            Term::Let(_, r#type, def, body) => {
+            Term::Let(_, _, r#type, def, body) => {
                 r#type.contains_free(var)
                     || def.contains_free(var)
                     || body.contains_free(var.prev())

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -194,7 +194,7 @@ pub enum Term<'arena> {
     FunApp(Span, &'arena Term<'arena>, &'arena Term<'arena>),
 
     /// Dependent record types.
-    RecordType(&'arena [StringId], &'arena [Term<'arena>]),
+    RecordType(Span, &'arena [StringId], &'arena [Term<'arena>]),
     /// Record literals.
     RecordLit(&'arena [StringId], &'arena [Term<'arena>]),
     /// Record projections.
@@ -650,7 +650,7 @@ impl<'arena> Term<'arena> {
             }
             Term::FunLit(_, _, body) => body.contains_free(var.prev()),
             Term::FunApp(_, head, arg) => head.contains_free(var) || arg.contains_free(var),
-            Term::RecordType(_, terms)
+            Term::RecordType(_, _, terms)
             | Term::RecordLit(_, terms)
             | Term::FormatRecord(_, terms)
             | Term::FormatOverlap(_, terms) => terms.iter().any(|term| {

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -191,7 +191,7 @@ pub enum Term<'arena> {
     /// Also known as: lambda expressions, anonymous functions.
     FunLit(Span, Option<StringId>, &'arena Term<'arena>),
     /// Function applications.
-    FunApp(&'arena Term<'arena>, &'arena Term<'arena>),
+    FunApp(Span, &'arena Term<'arena>, &'arena Term<'arena>),
 
     /// Dependent record types.
     RecordType(&'arena [StringId], &'arena [Term<'arena>]),
@@ -649,7 +649,7 @@ impl<'arena> Term<'arena> {
                 input_type.contains_free(var) || output_type.contains_free(var.prev())
             }
             Term::FunLit(_, _, body) => body.contains_free(var.prev()),
-            Term::FunApp(head, arg) => head.contains_free(var) || arg.contains_free(var),
+            Term::FunApp(_, head, arg) => head.contains_free(var) || arg.contains_free(var),
             Term::RecordType(_, terms)
             | Term::RecordLit(_, terms)
             | Term::FormatRecord(_, terms)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -1,6 +1,5 @@
 //! Core language.
 
-use crate::core::semantics::Value;
 use crate::env::{GlobalVar, LocalVar};
 use crate::source::ByteRange;
 use crate::StringId;
@@ -44,25 +43,6 @@ pub enum EntryInfo {
 pub enum Span {
     Range(ByteRange),
     Empty,
-}
-
-impl Span {
-    // TODO: Delete this when all values have a span
-    pub(crate) fn from_value(value: &Value) -> Span {
-        match value {
-            Value::Stuck(span, _, _)
-            | Value::Universe(span)
-            | Value::FunType(span, _, _, _)
-            | Value::FunLit(span, _, _)
-            | Value::RecordType(span, _, _)
-            | Value::RecordLit(span, _, _)
-            | Value::ArrayLit(span, _)
-            | Value::FormatRecord(span, _, _)
-            | Value::FormatCond(span, _, _, _)
-            | Value::FormatOverlap(span, _, _)
-            | Value::ConstLit(span, _) => *span,
-        }
-    }
 }
 
 impl Span {

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -167,6 +167,7 @@ pub enum Term<'arena> {
     Ann(Span, &'arena Term<'arena>, &'arena Term<'arena>),
     /// Let expressions.
     Let(
+        // TODO: Allow fetching Let span by merging the term spans
         Option<StringId>,
         &'arena Term<'arena>,
         &'arena Term<'arena>,
@@ -174,7 +175,7 @@ pub enum Term<'arena> {
     ),
 
     /// The type of types.
-    Universe,
+    Universe(Span),
 
     /// Dependent function types.
     ///
@@ -629,7 +630,7 @@ impl<'arena> Term<'arena> {
             Term::ItemVar(_, _)
             | Term::FlexibleVar(_, _)
             | Term::FlexibleInsertion(_, _, _)
-            | Term::Universe
+            | Term::Universe(_)
             | Term::Prim(_)
             | Term::ConstLit(_) => false,
 

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -50,11 +50,11 @@ impl Span {
     // TODO: Delete this when all values have a span
     pub(crate) fn from_value(value: &Value) -> Span {
         match value {
-            Value::Stuck(span, _, _) | Value::Universe(span) | Value::FunType(span, _, _, _) => {
-                *span
-            }
-            Value::FunLit(_, _)
-            | Value::RecordType(_, _)
+            Value::Stuck(span, _, _)
+            | Value::Universe(span)
+            | Value::FunType(span, _, _, _)
+            | Value::FunLit(span, _, _) => *span,
+            Value::RecordType(_, _)
             | Value::RecordLit(_, _)
             | Value::ArrayLit(_)
             | Value::FormatRecord(_, _)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -54,9 +54,9 @@ impl Span {
             | Value::Universe(span)
             | Value::FunType(span, _, _, _)
             | Value::FunLit(span, _, _)
-            | Value::RecordType(span, _, _) => *span,
-            Value::RecordLit(_, _)
-            | Value::ArrayLit(_)
+            | Value::RecordType(span, _, _)
+            | Value::RecordLit(span, _, _) => *span,
+            Value::ArrayLit(_)
             | Value::FormatRecord(_, _)
             | Value::FormatCond(_, _, _)
             | Value::FormatOverlap(_, _)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -59,8 +59,8 @@ impl Span {
             | Value::ArrayLit(span, _)
             | Value::FormatRecord(span, _, _)
             | Value::FormatCond(span, _, _, _)
-            | Value::FormatOverlap(span, _, _) => *span,
-            Value::ConstLit(_) => Span::fixme(),
+            | Value::FormatOverlap(span, _, _)
+            | Value::ConstLit(span, _) => *span,
         }
     }
 }

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -180,7 +180,12 @@ pub enum Term<'arena> {
     /// Dependent function types.
     ///
     /// Also known as: pi types, dependent product types.
-    FunType(Option<StringId>, &'arena Term<'arena>, &'arena Term<'arena>),
+    FunType(
+        Span,
+        Option<StringId>,
+        &'arena Term<'arena>,
+        &'arena Term<'arena>,
+    ),
     /// Function literals.
     ///
     /// Also known as: lambda expressions, anonymous functions.
@@ -640,7 +645,7 @@ impl<'arena> Term<'arena> {
                     || def.contains_free(var)
                     || body.contains_free(var.prev())
             }
-            Term::FunType(_, input_type, output_type) => {
+            Term::FunType(_, _, input_type, output_type) => {
                 input_type.contains_free(var) || output_type.contains_free(var.prev())
             }
             Term::FunLit(_, body) => body.contains_free(var.prev()),

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -53,9 +53,9 @@ impl Span {
             Value::Stuck(span, _, _)
             | Value::Universe(span)
             | Value::FunType(span, _, _, _)
-            | Value::FunLit(span, _, _) => *span,
-            Value::RecordType(_, _)
-            | Value::RecordLit(_, _)
+            | Value::FunLit(span, _, _)
+            | Value::RecordType(span, _, _) => *span,
+            Value::RecordLit(_, _)
             | Value::ArrayLit(_)
             | Value::FormatRecord(_, _)
             | Value::FormatCond(_, _, _)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -206,7 +206,7 @@ pub enum Term<'arena> {
     /// Record formats, consisting of a list of dependent formats.
     FormatRecord(Span, &'arena [StringId], &'arena [Term<'arena>]),
     /// Conditional format, consisting of a format and predicate.
-    FormatCond(StringId, &'arena Term<'arena>, &'arena Term<'arena>),
+    FormatCond(Span, StringId, &'arena Term<'arena>, &'arena Term<'arena>),
     /// Overlap formats, consisting of a list of dependent formats, overlapping
     /// in memory.
     FormatOverlap(&'arena [StringId], &'arena [Term<'arena>]),
@@ -660,7 +660,7 @@ impl<'arena> Term<'arena> {
             }),
             Term::RecordProj(_, term, _) => term.contains_free(var),
             Term::ArrayLit(_, terms) => terms.iter().any(|term| term.contains_free(var)),
-            Term::FormatCond(_, t1, t2) => t1.contains_free(var) || t2.contains_free(var),
+            Term::FormatCond(_, _, t1, t2) => t1.contains_free(var) || t2.contains_free(var),
             Term::ConstMatch(scrut, branches, default) => {
                 scrut.contains_free(var)
                     || branches.iter().any(|(_, term)| term.contains_free(var))

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -50,9 +50,10 @@ impl Span {
     // TODO: Delete this when all values have a span
     pub(crate) fn from_value(value: &Value) -> Span {
         match value {
-            Value::Stuck(span, _, _) | Value::Universe(span) => *span,
-            Value::FunType(_, _, _)
-            | Value::FunLit(_, _)
+            Value::Stuck(span, _, _) | Value::Universe(span) | Value::FunType(span, _, _, _) => {
+                *span
+            }
+            Value::FunLit(_, _)
             | Value::RecordType(_, _)
             | Value::RecordLit(_, _)
             | Value::ArrayLit(_)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -47,11 +47,11 @@ pub enum Span {
 }
 
 impl Span {
+    // TODO: Delete this when all values have a span
     pub(crate) fn from_value(value: &Value) -> Span {
         match value {
-            Value::Stuck(span, _, _) => *span,
-            Value::Universe
-            | Value::FunType(_, _, _)
+            Value::Stuck(span, _, _) | Value::Universe(span) => *span,
+            Value::FunType(_, _, _)
             | Value::FunLit(_, _)
             | Value::RecordType(_, _)
             | Value::RecordLit(_, _)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -57,10 +57,9 @@ impl Span {
             | Value::RecordType(span, _, _)
             | Value::RecordLit(span, _, _)
             | Value::ArrayLit(span, _)
-            | Value::FormatRecord(span, _, _) => *span,
-            Value::FormatCond(_, _, _) | Value::FormatOverlap(_, _) | Value::ConstLit(_) => {
-                Span::fixme()
-            }
+            | Value::FormatRecord(span, _, _)
+            | Value::FormatCond(span, _, _, _) => *span,
+            Value::FormatOverlap(_, _) | Value::ConstLit(_) => Span::fixme(),
         }
     }
 }
@@ -236,6 +235,34 @@ pub enum Term<'arena> {
         &'arena [(Const, Term<'arena>)],
         Option<&'arena Term<'arena>>,
     ),
+}
+
+impl<'arena> Term<'arena> {
+    /// Get the source span of the term.
+    pub fn span(&self) -> Span {
+        match self {
+            Term::ItemVar(span, _)
+            | Term::RigidVar(span, _)
+            | Term::FlexibleVar(span, _)
+            | Term::FlexibleInsertion(span, _, _)
+            | Term::Ann(span, _, _)
+            | Term::Let(span, _, _, _, _)
+            | Term::Universe(span)
+            | Term::FunType(span, _, _, _)
+            | Term::FunLit(span, _, _)
+            | Term::FunApp(span, _, _)
+            | Term::RecordType(span, _, _)
+            | Term::RecordLit(span, _, _)
+            | Term::RecordProj(span, _, _)
+            | Term::ArrayLit(span, _)
+            | Term::FormatRecord(span, _, _)
+            | Term::FormatCond(span, _, _, _)
+            | Term::FormatOverlap(span, _, _)
+            | Term::Prim(span, _)
+            | Term::ConstLit(span, _)
+            | Term::ConstMatch(span, _, _, _) => *span,
+        }
+    }
 }
 
 macro_rules! def_prims {

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -196,7 +196,7 @@ pub enum Term<'arena> {
     /// Dependent record types.
     RecordType(Span, &'arena [StringId], &'arena [Term<'arena>]),
     /// Record literals.
-    RecordLit(&'arena [StringId], &'arena [Term<'arena>]),
+    RecordLit(Span, &'arena [StringId], &'arena [Term<'arena>]),
     /// Record projections.
     RecordProj(&'arena Term<'arena>, StringId),
 
@@ -651,7 +651,7 @@ impl<'arena> Term<'arena> {
             Term::FunLit(_, _, body) => body.contains_free(var.prev()),
             Term::FunApp(_, head, arg) => head.contains_free(var) || arg.contains_free(var),
             Term::RecordType(_, _, terms)
-            | Term::RecordLit(_, terms)
+            | Term::RecordLit(_, _, terms)
             | Term::FormatRecord(_, terms)
             | Term::FormatOverlap(_, terms) => terms.iter().any(|term| {
                 let result = term.contains_free(var);

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -1,7 +1,7 @@
 //! Core language.
 
 use crate::env::{GlobalVar, LocalVar};
-use crate::source::ByteRange;
+use crate::source::Span;
 use crate::StringId;
 
 pub mod binary;
@@ -36,35 +36,6 @@ pub enum EntryInfo {
     Definition,
     /// The entry was bound as a parameter in the environment
     Parameter,
-}
-
-// TODO: Better name?
-#[derive(Debug, Copy, Clone)]
-pub enum Span {
-    Range(ByteRange),
-    Empty,
-}
-
-impl Span {
-    pub const fn fixme() -> Span {
-        Span::Empty
-    }
-
-    pub fn range_todo(self) {
-        // placeholder function for when we should build a span from a ByteRange
-        // but the current location is expecting a range of (). Eventually this
-        // should be renamed range and return Option<ByteRange>?
-        // match self {
-        //     Span::Range(range) => Some(range),
-        //     Span::Empty => None
-        // }
-    }
-}
-
-impl From<&ByteRange> for Span {
-    fn from(range: &ByteRange) -> Self {
-        Span::Range(*range)
-    }
 }
 
 /// Core language terms.

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -201,7 +201,7 @@ pub enum Term<'arena> {
     RecordProj(Span, &'arena Term<'arena>, StringId),
 
     /// Array literals.
-    ArrayLit(&'arena [Term<'arena>]),
+    ArrayLit(Span, &'arena [Term<'arena>]),
 
     /// Record formats, consisting of a list of dependent formats.
     FormatRecord(&'arena [StringId], &'arena [Term<'arena>]),
@@ -659,7 +659,7 @@ impl<'arena> Term<'arena> {
                 result
             }),
             Term::RecordProj(_, term, _) => term.contains_free(var),
-            Term::ArrayLit(terms) => terms.iter().any(|term| term.contains_free(var)),
+            Term::ArrayLit(_, terms) => terms.iter().any(|term| term.contains_free(var)),
             Term::FormatCond(_, t1, t2) => t1.contains_free(var) || t2.contains_free(var),
             Term::ConstMatch(scrut, branches, default) => {
                 scrut.contains_free(var)

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -204,7 +204,7 @@ pub enum Term<'arena> {
     ArrayLit(Span, &'arena [Term<'arena>]),
 
     /// Record formats, consisting of a list of dependent formats.
-    FormatRecord(&'arena [StringId], &'arena [Term<'arena>]),
+    FormatRecord(Span, &'arena [StringId], &'arena [Term<'arena>]),
     /// Conditional format, consisting of a format and predicate.
     FormatCond(StringId, &'arena Term<'arena>, &'arena Term<'arena>),
     /// Overlap formats, consisting of a list of dependent formats, overlapping
@@ -652,7 +652,7 @@ impl<'arena> Term<'arena> {
             Term::FunApp(_, head, arg) => head.contains_free(var) || arg.contains_free(var),
             Term::RecordType(_, _, terms)
             | Term::RecordLit(_, _, terms)
-            | Term::FormatRecord(_, terms)
+            | Term::FormatRecord(_, _, terms)
             | Term::FormatOverlap(_, terms) => terms.iter().any(|term| {
                 let result = term.contains_free(var);
                 var = var.prev();

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -55,9 +55,9 @@ impl Span {
             | Value::FunType(span, _, _, _)
             | Value::FunLit(span, _, _)
             | Value::RecordType(span, _, _)
-            | Value::RecordLit(span, _, _) => *span,
-            Value::ArrayLit(_)
-            | Value::FormatRecord(_, _)
+            | Value::RecordLit(span, _, _)
+            | Value::ArrayLit(span, _) => *span,
+            Value::FormatRecord(_, _)
             | Value::FormatCond(_, _, _)
             | Value::FormatOverlap(_, _)
             | Value::ConstLit(_) => Span::fixme(),

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -339,9 +339,9 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Stuck(span, Head::RigidVar(_), _)
             | Value::Stuck(span, Head::FlexibleVar(_), _)
             | Value::Universe(span)
-            | Value::FunType(span, _, _, _) => Err(ReadError::InvalidFormat(*span)),
-            Value::FunLit(_, _)
-            | Value::RecordType(_, _)
+            | Value::FunType(span, _, _, _)
+            | Value::FunLit(span, _, _) => Err(ReadError::InvalidFormat(*span)),
+            Value::RecordType(_, _)
             | Value::RecordLit(_, _)
             | Value::ArrayLit(_)
             | Value::ConstLit(_) => Err(ReadError::InvalidFormat(Span::fixme())),

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -338,7 +338,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     }
                 }
             }
-            Value::FormatOverlap(span, labels, formats) => {
+            Value::FormatOverlap(labels, formats) => {
                 let mut max_relative_offset = reader.relative_offset();
 
                 let mut formats = formats.clone();
@@ -361,7 +361,10 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                 // reached in loop above.
                 reader.set_relative_offset(max_relative_offset).unwrap();
 
-                Ok(SpanValue(*span, Arc::new(Value::RecordLit(labels, exprs))))
+                Ok(SpanValue(
+                    format_span,
+                    Arc::new(Value::RecordLit(labels, exprs)),
+                ))
             }
 
             Value::Stuck(Head::RigidVar(_), _) | Value::Stuck(Head::FlexibleVar(_), _) => {

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -410,10 +410,10 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             (Prim::FormatF32Le, []) => read_const(reader, span, read_f32le, Const::F32),
             (Prim::FormatF64Be, []) => read_const(reader, span, read_f64be, Const::F64),
             (Prim::FormatF64Le, []) => read_const(reader, span, read_f64le, Const::F64),
-            (Prim::FormatArray8, [FunApp(len), FunApp(format)]) => self.read_array(reader, len, format),
-            (Prim::FormatArray16, [FunApp(len), FunApp(format)]) => self.read_array(reader, len, format),
-            (Prim::FormatArray32, [FunApp(len), FunApp(format)]) => self.read_array(reader, len, format),
-            (Prim::FormatArray64, [FunApp(len), FunApp(format)]) => self.read_array(reader, len, format),
+            (Prim::FormatArray8, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
+            (Prim::FormatArray16, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
+            (Prim::FormatArray32, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
+            (Prim::FormatArray64, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
             (Prim::FormatRepeatUntilEnd, [FunApp(format)]) => self.read_repeat_until_end(reader, format),
             (Prim::FormatLimit8, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
             (Prim::FormatLimit16, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
@@ -436,6 +436,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
     fn read_array(
         &mut self,
         reader: &mut BufferReader<'data>,
+        span: Span,
         len: &ArcValue<'arena>,
         elem_format: &ArcValue<'arena>,
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
@@ -451,10 +452,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             .map(|_| self.read_format(reader, elem_format))
             .collect::<Result<_, _>>()?;
 
-        Ok(SpanValue(
-            elem_format.span(),
-            Arc::new(Value::ArrayLit(elem_exprs)),
-        ))
+        Ok(SpanValue(span, Arc::new(Value::ArrayLit(elem_exprs))))
     }
 
     fn read_repeat_until_end(

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -370,9 +370,10 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Stuck(Head::RigidVar(_), _) | Value::Stuck(Head::FlexibleVar(_), _) => {
                 Err(ReadError::InvalidFormat(format_span))
             }
-            Value::Universe | Value::FunType(_, _, _) => Err(ReadError::InvalidFormat(format_span)),
-            Value::FunLit(span, _, _)
-            | Value::RecordType(span, _, _)
+            Value::Universe | Value::FunType(_, _, _) | Value::FunLit(_, _) => {
+                Err(ReadError::InvalidFormat(format_span))
+            }
+            Value::RecordType(span, _, _)
             | Value::RecordLit(span, _, _)
             | Value::ArrayLit(span, _)
             | Value::ConstLit(span, _) => Err(ReadError::InvalidFormat(*span)),

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -338,9 +338,9 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
 
             Value::Stuck(span, Head::RigidVar(_), _)
             | Value::Stuck(span, Head::FlexibleVar(_), _)
-            | Value::Universe(span) => Err(ReadError::InvalidFormat(*span)),
-            Value::FunType(_, _, _)
-            | Value::FunLit(_, _)
+            | Value::Universe(span)
+            | Value::FunType(span, _, _, _) => Err(ReadError::InvalidFormat(*span)),
+            Value::FunLit(_, _)
             | Value::RecordType(_, _)
             | Value::RecordLit(_, _)
             | Value::ArrayLit(_)

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -306,7 +306,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Stuck(Head::Prim(prim), slice) => {
                 self.read_prim(reader, *prim, slice, format_span)
             }
-            Value::FormatRecord(span, labels, formats) => {
+            Value::FormatRecord(labels, formats) => {
                 let mut formats = formats.clone();
                 let mut exprs = Vec::with_capacity(formats.len());
 
@@ -318,7 +318,10 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     formats = next_formats(expr);
                 }
 
-                Ok(SpanValue(*span, Arc::new(Value::RecordLit(labels, exprs))))
+                Ok(SpanValue(
+                    format_span,
+                    Arc::new(Value::RecordLit(labels, exprs)),
+                ))
             }
             Value::FormatCond(_span, _label, format, cond) => {
                 let value = self.read_format(reader, &format)?;

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -280,7 +280,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Stuck(span, Head::Prim(prim), slice) => {
                 self.read_prim(reader, *prim, slice, *span)
             }
-            Value::FormatRecord(labels, formats) => {
+            Value::FormatRecord(span, labels, formats) => {
                 let mut formats = formats.clone();
                 let mut exprs = Vec::with_capacity(formats.len());
 
@@ -292,7 +292,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     formats = next_formats(expr);
                 }
 
-                Ok(Arc::new(Value::RecordLit(Span::fixme(), labels, exprs)))
+                Ok(Arc::new(Value::RecordLit(*span, labels, exprs)))
             }
             Value::FormatCond(_label, format, cond) => {
                 let value = self.read_format(reader, &format)?;

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -323,7 +323,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     Arc::new(Value::RecordLit(labels, exprs)),
                 ))
             }
-            Value::FormatCond(_span, _label, format, cond) => {
+            Value::FormatCond(_label, format, cond) => {
                 let value = self.read_format(reader, &format)?;
                 let SpanValue(_, cond_res) = self.elim_context().apply_closure(cond, value.clone());
 

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -7,8 +7,9 @@ use std::slice::SliceIndex;
 use std::sync::Arc;
 
 use crate::core::semantics::{self, ArcValue, Elim, Head, Value};
-use crate::core::{Const, Prim, Span, UIntStyle};
+use crate::core::{Const, Prim, UIntStyle};
 use crate::env::{EnvLen, SliceEnv};
+use crate::source::Span;
 
 #[derive(Clone, Debug)]
 pub enum ReadError {

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -292,7 +292,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     formats = next_formats(expr);
                 }
 
-                Ok(Arc::new(Value::RecordLit(labels, exprs)))
+                Ok(Arc::new(Value::RecordLit(Span::fixme(), labels, exprs)))
             }
             Value::FormatCond(_label, format, cond) => {
                 let value = self.read_format(reader, &format)?;
@@ -333,7 +333,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                 // reached in loop above.
                 reader.set_relative_offset(max_relative_offset).unwrap();
 
-                Ok(Arc::new(Value::RecordLit(labels, exprs)))
+                Ok(Arc::new(Value::RecordLit(Span::fixme(), labels, exprs)))
             }
 
             Value::Stuck(span, Head::RigidVar(_), _)
@@ -341,10 +341,9 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             | Value::Universe(span)
             | Value::FunType(span, _, _, _)
             | Value::FunLit(span, _, _)
-            | Value::RecordType(span, _, _) => Err(ReadError::InvalidFormat(*span)),
-            Value::RecordLit(_, _) | Value::ArrayLit(_) | Value::ConstLit(_) => {
-                Err(ReadError::InvalidFormat(Span::fixme()))
-            }
+            | Value::RecordType(span, _, _)
+            | Value::RecordLit(span, _, _) => Err(ReadError::InvalidFormat(*span)),
+            Value::ArrayLit(_) | Value::ConstLit(_) => Err(ReadError::InvalidFormat(Span::fixme())),
         }
     }
 

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -7,10 +7,10 @@ use std::fmt::Debug;
 use std::slice::SliceIndex;
 use std::sync::Arc;
 
-use crate::core::semantics::{self, ArcValue, Elim, Head, Spanned, Value};
+use crate::core::semantics::{self, ArcValue, Elim, Head, Value};
 use crate::core::{Const, Prim, UIntStyle};
 use crate::env::{EnvLen, SliceEnv};
-use crate::source::Span;
+use crate::source::{Span, Spanned};
 
 #[derive(Clone, Debug)]
 pub enum ReadError<'arena> {

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -318,10 +318,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     formats = next_formats(expr);
                 }
 
-                Ok(SpanValue(
-                    *span,
-                    Arc::new(Value::RecordLit(*span, labels, exprs)),
-                ))
+                Ok(SpanValue(*span, Arc::new(Value::RecordLit(labels, exprs))))
             }
             Value::FormatCond(_span, _label, format, cond) => {
                 let value = self.read_format(reader, &format)?;
@@ -361,10 +358,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                 // reached in loop above.
                 reader.set_relative_offset(max_relative_offset).unwrap();
 
-                Ok(SpanValue(
-                    *span,
-                    Arc::new(Value::RecordLit(*span, labels, exprs)),
-                ))
+                Ok(SpanValue(*span, Arc::new(Value::RecordLit(labels, exprs))))
             }
 
             Value::Stuck(Head::RigidVar(_), _) | Value::Stuck(Head::FlexibleVar(_), _) => {
@@ -373,8 +367,9 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Universe
             | Value::FunType(_, _, _)
             | Value::FunLit(_, _)
-            | Value::RecordType(_, _) => Err(ReadError::InvalidFormat(format_span)),
-            Value::RecordLit(span, _, _) | Value::ArrayLit(span, _) | Value::ConstLit(span, _) => {
+            | Value::RecordType(_, _)
+            | Value::RecordLit(_, _) => Err(ReadError::InvalidFormat(format_span)),
+            Value::ArrayLit(span, _) | Value::ConstLit(span, _) => {
                 Err(ReadError::InvalidFormat(*span))
             }
         }

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -370,8 +370,8 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Stuck(Head::RigidVar(_), _) | Value::Stuck(Head::FlexibleVar(_), _) => {
                 Err(ReadError::InvalidFormat(format_span))
             }
-            Value::Universe(span)
-            | Value::FunType(span, _, _, _)
+            Value::Universe => Err(ReadError::InvalidFormat(format_span)),
+            Value::FunType(span, _, _, _)
             | Value::FunLit(span, _, _)
             | Value::RecordType(span, _, _)
             | Value::RecordLit(span, _, _)

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -368,10 +368,9 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             | Value::FunType(_, _, _)
             | Value::FunLit(_, _)
             | Value::RecordType(_, _)
-            | Value::RecordLit(_, _) => Err(ReadError::InvalidFormat(format_span)),
-            Value::ArrayLit(span, _) | Value::ConstLit(span, _) => {
-                Err(ReadError::InvalidFormat(*span))
-            }
+            | Value::RecordLit(_, _)
+            | Value::ArrayLit(_) => Err(ReadError::InvalidFormat(format_span)),
+            Value::ConstLit(span, _) => Err(ReadError::InvalidFormat(*span)),
         }
     }
 
@@ -445,10 +444,10 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             .map(|_| self.read_format(reader, elem_format))
             .collect::<Result<_, _>>()?;
 
-        Ok(SpanValue::fixme(Arc::new(Value::ArrayLit(
+        Ok(SpanValue(
             elem_format.span(),
-            elem_exprs,
-        ))))
+            Arc::new(Value::ArrayLit(elem_exprs)),
+        ))
     }
 
     fn read_repeat_until_end(
@@ -469,10 +468,10 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     // unwrap shouldn't panic as we're rewinding to a known good offset
                     // Should this be set to the end of the current buffer?
                     reader.set_relative_offset(current_offset).unwrap();
-                    return Ok(SpanValue::fixme(Arc::new(Value::ArrayLit(
+                    return Ok(SpanValue(
                         elem_format.span(),
-                        elems,
-                    ))));
+                        Arc::new(Value::ArrayLit(elems)),
+                    ));
                 }
                 Err(err) => return Err(err),
             };

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -340,11 +340,11 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             | Value::Stuck(span, Head::FlexibleVar(_), _)
             | Value::Universe(span)
             | Value::FunType(span, _, _, _)
-            | Value::FunLit(span, _, _) => Err(ReadError::InvalidFormat(*span)),
-            Value::RecordType(_, _)
-            | Value::RecordLit(_, _)
-            | Value::ArrayLit(_)
-            | Value::ConstLit(_) => Err(ReadError::InvalidFormat(Span::fixme())),
+            | Value::FunLit(span, _, _)
+            | Value::RecordType(span, _, _) => Err(ReadError::InvalidFormat(*span)),
+            Value::RecordLit(_, _) | Value::ArrayLit(_) | Value::ConstLit(_) => {
+                Err(ReadError::InvalidFormat(Span::fixme()))
+            }
         }
     }
 

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -423,7 +423,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             (Prim::FormatLimit16, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
             (Prim::FormatLimit32, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
             (Prim::FormatLimit64, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
-            (Prim::FormatLink, [FunApp(pos), FunApp(format)]) => self.read_link(pos, format),
+            (Prim::FormatLink, [FunApp(pos), FunApp(format)]) => self.read_link(span, pos, format),
             (Prim::FormatDeref, [FunApp(format), FunApp(r#ref)]) => self.read_deref(format, r#ref),
             (Prim::FormatStreamPos, []) => read_stream_pos(reader, span),
             (Prim::FormatSucceed, [_, FunApp(elem)]) => Ok(elem.clone()),
@@ -513,6 +513,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
 
     fn read_link(
         &mut self,
+        span: Span,
         pos_value: &ArcValue<'arena>,
         elem_format: &ArcValue<'arena>,
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
@@ -523,10 +524,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
 
         self.pending_formats.push((pos, elem_format.clone()));
 
-        Ok(SpanValue(
-            pos_value.span(),
-            Arc::new(Value::ConstLit(Const::Ref(pos))),
-        ))
+        Ok(SpanValue(span, Arc::new(Value::ConstLit(Const::Ref(pos)))))
     }
 
     fn read_deref(

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -334,7 +334,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     }
                     _ => {
                         // This shouldn't happen since we check that the cond type is Bool earlier
-                        Err(ReadError::InvalidValue(cond_res.span()))
+                        Err(ReadError::InvalidValue(Span::Empty))
                     }
                 }
             }
@@ -510,7 +510,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
         let pos = match self.elim_context().force(pos_value).1.as_ref() {
             Value::ConstLit(Const::Pos(pos)) => *pos,
-            value => return Err(ReadError::InvalidValue(value.span())),
+            _ => return Err(ReadError::InvalidValue(pos_value.span())),
         };
 
         self.pending_formats.push((pos, elem_format.clone()));
@@ -528,7 +528,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
         let pos = match self.elim_context().force(r#ref).1.as_ref() {
             Value::ConstLit(Const::Ref(pos)) => *pos,
-            value => return Err(ReadError::InvalidValue(value.span())),
+            _ => return Err(ReadError::InvalidValue(r#ref.span())),
         };
 
         self.lookup_or_read_ref(pos, format)

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -370,9 +370,8 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Stuck(Head::RigidVar(_), _) | Value::Stuck(Head::FlexibleVar(_), _) => {
                 Err(ReadError::InvalidFormat(format_span))
             }
-            Value::Universe => Err(ReadError::InvalidFormat(format_span)),
-            Value::FunType(span, _, _, _)
-            | Value::FunLit(span, _, _)
+            Value::Universe | Value::FunType(_, _, _) => Err(ReadError::InvalidFormat(format_span)),
+            Value::FunLit(span, _, _)
             | Value::RecordType(span, _, _)
             | Value::RecordLit(span, _, _)
             | Value::ArrayLit(span, _)

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -450,7 +450,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
         len: &ArcValue<'arena>,
         elem_format: &ArcValue<'arena>,
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
-        let len = match self.elim_context().force(len).inner.as_ref() {
+        let len = match self.elim_context().force(len).as_ref() {
             Value::ConstLit(Const::U8(len, _)) => u64::from(*len),
             Value::ConstLit(Const::U16(len, _)) => u64::from(*len),
             Value::ConstLit(Const::U32(len, _)) => u64::from(*len),
@@ -503,7 +503,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
         elem_format: &ArcValue<'arena>,
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
         let len_span = len.span();
-        let len = match self.elim_context().force(len).inner.as_ref() {
+        let len = match self.elim_context().force(len).as_ref() {
             Value::ConstLit(Const::U8(len, _)) => Some(usize::from(*len)),
             Value::ConstLit(Const::U16(len, _)) => Some(usize::from(*len)),
             Value::ConstLit(Const::U32(len, _)) => usize::try_from(*len).ok(),
@@ -526,7 +526,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
         pos_value: &ArcValue<'arena>,
         elem_format: &ArcValue<'arena>,
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
-        let pos = match self.elim_context().force(pos_value).inner.as_ref() {
+        let pos = match self.elim_context().force(pos_value).as_ref() {
             Value::ConstLit(Const::Pos(pos)) => *pos,
             _ => return Err(ReadError::InvalidValue(pos_value.span())),
         };
@@ -544,7 +544,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
         format: &ArcValue<'arena>,
         r#ref: &ArcValue<'arena>,
     ) -> Result<ArcValue<'arena>, ReadError<'arena>> {
-        let pos = match self.elim_context().force(r#ref).inner.as_ref() {
+        let pos = match self.elim_context().force(r#ref).as_ref() {
             Value::ConstLit(Const::Ref(pos)) => *pos,
             _ => return Err(ReadError::InvalidValue(r#ref.span())),
         };

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -307,7 +307,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                     }
                 }
             }
-            Value::FormatOverlap(labels, formats) => {
+            Value::FormatOverlap(span, labels, formats) => {
                 let mut max_relative_offset = reader.relative_offset();
 
                 let mut formats = formats.clone();
@@ -330,7 +330,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
                 // reached in loop above.
                 reader.set_relative_offset(max_relative_offset).unwrap();
 
-                Ok(Arc::new(Value::RecordLit(Span::fixme(), labels, exprs)))
+                Ok(Arc::new(Value::RecordLit(*span, labels, exprs)))
             }
 
             Value::Stuck(span, Head::RigidVar(_), _)

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -337,9 +337,9 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             }
 
             Value::Stuck(span, Head::RigidVar(_), _)
-            | Value::Stuck(span, Head::FlexibleVar(_), _) => Err(ReadError::InvalidFormat(*span)),
-            Value::Universe
-            | Value::FunType(_, _, _)
+            | Value::Stuck(span, Head::FlexibleVar(_), _)
+            | Value::Universe(span) => Err(ReadError::InvalidFormat(*span)),
+            Value::FunType(_, _, _)
             | Value::FunLit(_, _)
             | Value::RecordType(_, _)
             | Value::RecordLit(_, _)

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -370,13 +370,13 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::Stuck(Head::RigidVar(_), _) | Value::Stuck(Head::FlexibleVar(_), _) => {
                 Err(ReadError::InvalidFormat(format_span))
             }
-            Value::Universe | Value::FunType(_, _, _) | Value::FunLit(_, _) => {
-                Err(ReadError::InvalidFormat(format_span))
+            Value::Universe
+            | Value::FunType(_, _, _)
+            | Value::FunLit(_, _)
+            | Value::RecordType(_, _) => Err(ReadError::InvalidFormat(format_span)),
+            Value::RecordLit(span, _, _) | Value::ArrayLit(span, _) | Value::ConstLit(span, _) => {
+                Err(ReadError::InvalidFormat(*span))
             }
-            Value::RecordType(span, _, _)
-            | Value::RecordLit(span, _, _)
-            | Value::ArrayLit(span, _)
-            | Value::ConstLit(span, _) => Err(ReadError::InvalidFormat(*span)),
         }
     }
 

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -410,7 +410,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::ConstLit(_, Const::U16(len, _)) => u64::from(*len),
             Value::ConstLit(_, Const::U32(len, _)) => u64::from(*len),
             Value::ConstLit(_, Const::U64(len, _)) => u64::from(*len),
-            _ => return Err(ReadError::InvalidValue(Span::fixme())),
+            _ => return Err(ReadError::InvalidValue(len.span())),
         };
 
         let elem_exprs = (0..len)
@@ -456,7 +456,7 @@ impl<'arena, 'env, 'data> Context<'arena, 'env, 'data> {
             Value::ConstLit(_, Const::U16(len, _)) => Some(usize::from(*len)),
             Value::ConstLit(_, Const::U32(len, _)) => usize::try_from(*len).ok(),
             Value::ConstLit(_, Const::U64(len, _)) => usize::try_from(*len).ok(),
-            _ => return Err(ReadError::InvalidValue(Span::fixme())),
+            _ => return Err(ReadError::InvalidValue(len.span())),
         }
         .ok_or(ReadError::PositionOverflow)?;
 

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -13,28 +13,42 @@ use crate::StringId;
 
 /// Atomically reference counted values. We use reference counting to increase
 /// the amount of sharing we can achieve during evaluation.
-pub type ArcValue<'arena> = SpanValue<'arena>;
+pub type ArcValue<'arena> = Spanned<Arc<Value<'arena>>>;
 
 #[derive(Debug, Clone)]
-pub struct SpanValue<'arena>(pub Span, pub Arc<Value<'arena>>);
+pub struct Spanned<T> {
+    pub span: Span,
+    pub inner: T,
+}
 
-impl<'arena> SpanValue<'arena> {
+impl<T> Spanned<T> {
     pub fn span(&self) -> Span {
-        self.0
+        self.span
     }
 
-    pub fn empty(val: Arc<Value<'arena>>) -> Self {
-        SpanValue(Span::Empty, val)
+    pub fn empty(inner: T) -> Self {
+        Spanned {
+            span: Span::Empty,
+            inner,
+        }
     }
 
     /// Merge the supplied span and the span of value and return value wrapped in that span.
-    pub fn merge(span: Span, value: ArcValue<'arena>) -> ArcValue<'arena> {
-        let SpanValue(value_span, value) = value;
-        SpanValue(span.merge(&value_span), value)
+    pub fn merge(span: Span, other: Spanned<T>) -> Spanned<T> {
+        let Spanned {
+            span: other_span,
+            inner,
+        } = other;
+        Spanned {
+            span: span.merge(&other_span),
+            inner,
+        }
     }
+}
 
+impl<'arena> ArcValue<'arena> {
     pub fn match_prim_spine(&self) -> Option<(Prim, &[Elim<'arena>])> {
-        self.1.match_prim_spine()
+        self.inner.match_prim_spine()
     }
 }
 
@@ -99,7 +113,7 @@ impl<'arena> Value<'arena> {
     /// Create a new `Arc<Value::Universe>` with no associated span.
     pub fn arc_universe() -> ArcValue<'arena> {
         // TODO: Can we share a single instance of this?
-        SpanValue::empty(Arc::new(Value::Universe))
+        Spanned::empty(Arc::new(Value::Universe))
     }
 }
 
@@ -313,16 +327,28 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
     pub fn eval(&mut self, term: &Term<'arena>) -> ArcValue<'arena> {
         match term {
             Term::ItemVar(span, var) => match self.item_exprs.get_global(*var) {
-                Some(value) => SpanValue(*span, value.1.clone()),
+                Some(value) => Spanned {
+                    span: *span,
+                    inner: value.inner.clone(),
+                },
                 None => panic_any(Error::InvalidItemVar),
             },
             Term::RigidVar(span, var) => match self.rigid_exprs.get_local(*var) {
-                Some(value) => SpanValue(*span, value.1.clone()),
+                Some(value) => Spanned {
+                    span: *span,
+                    inner: value.inner.clone(),
+                },
                 None => panic_any(Error::InvalidRigidVar),
             },
             Term::FlexibleVar(span, var) => match self.flexible_exprs.get_global(*var) {
-                Some(Some(value)) => SpanValue(*span, value.1.clone()),
-                Some(None) => SpanValue(*span, Arc::new(Value::flexible_var(*var))),
+                Some(Some(value)) => Spanned {
+                    span: *span,
+                    inner: value.inner.clone(),
+                },
+                Some(None) => Spanned {
+                    span: *span,
+                    inner: Arc::new(Value::flexible_var(*var)),
+                },
                 None => panic_any(Error::InvalidFlexibleVar),
             },
             Term::FlexibleInsertion(span, var, rigid_infos) => {
@@ -337,79 +363,106 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 }
                 head_expr
             }
-            Term::Ann(span, expr, _) => SpanValue::merge(*span, self.eval(expr)),
+            Term::Ann(span, expr, _) => Spanned::merge(*span, self.eval(expr)),
             Term::Let(span, _, _, def_expr, output_expr) => {
                 let def_expr = self.eval(def_expr);
                 self.rigid_exprs.push(def_expr);
                 let output_expr = self.eval(output_expr);
                 self.rigid_exprs.pop();
-                SpanValue::merge(*span, output_expr)
+                Spanned::merge(*span, output_expr)
             }
 
-            Term::Universe(span) => SpanValue(*span, Arc::new(Value::Universe)),
+            Term::Universe(span) => Spanned {
+                span: *span,
+                inner: Arc::new(Value::Universe),
+            },
 
-            Term::FunType(span, input_name, input_type, output_type) => SpanValue(
-                *span,
-                Arc::new(Value::FunType(
+            Term::FunType(span, input_name, input_type, output_type) => Spanned {
+                span: *span,
+                inner: Arc::new(Value::FunType(
                     *input_name,
                     self.eval(input_type),
                     Closure::new(self.rigid_exprs.clone(), output_type),
                 )),
-            ),
-            Term::FunLit(span, input_name, output_expr) => SpanValue(
-                *span,
-                Arc::new(Value::FunLit(
+            },
+            Term::FunLit(span, input_name, output_expr) => Spanned {
+                span: *span,
+                inner: Arc::new(Value::FunLit(
                     *input_name,
                     Closure::new(self.rigid_exprs.clone(), output_expr),
                 )),
-            ),
+            },
             Term::FunApp(span, head_expr, input_expr) => {
                 let head_expr = self.eval(head_expr);
                 let input_expr = self.eval(input_expr);
-                SpanValue::merge(*span, self.elim_context().fun_app(head_expr, input_expr))
+                Spanned::merge(*span, self.elim_context().fun_app(head_expr, input_expr))
             }
 
             Term::RecordType(span, labels, types) => {
                 let types = Telescope::new(self.rigid_exprs.clone(), types);
-                SpanValue(*span, Arc::new(Value::RecordType(labels, types)))
+                Spanned {
+                    span: *span,
+                    inner: Arc::new(Value::RecordType(labels, types)),
+                }
             }
             Term::RecordLit(span, labels, exprs) => {
                 let exprs = exprs.iter().map(|expr| self.eval(expr)).collect();
-                SpanValue(*span, Arc::new(Value::RecordLit(labels, exprs)))
+                Spanned {
+                    span: *span,
+                    inner: Arc::new(Value::RecordLit(labels, exprs)),
+                }
             }
             Term::RecordProj(span, head_expr, label) => {
                 let head_expr = self.eval(head_expr);
-                SpanValue::merge(*span, self.elim_context().record_proj(head_expr, *label))
+                Spanned::merge(*span, self.elim_context().record_proj(head_expr, *label))
             }
 
             Term::ArrayLit(span, elem_exprs) => {
                 let elem_exprs = (elem_exprs.iter())
                     .map(|elem_expr| self.eval(elem_expr))
                     .collect();
-                SpanValue(*span, Arc::new(Value::ArrayLit(elem_exprs)))
+                Spanned {
+                    span: *span,
+                    inner: Arc::new(Value::ArrayLit(elem_exprs)),
+                }
             }
 
             Term::FormatRecord(span, labels, formats) => {
                 let formats = Telescope::new(self.rigid_exprs.clone(), formats);
-                SpanValue(*span, Arc::new(Value::FormatRecord(labels, formats)))
+                Spanned {
+                    span: *span,
+                    inner: Arc::new(Value::FormatRecord(labels, formats)),
+                }
             }
             Term::FormatCond(span, name, format, cond) => {
                 let format = self.eval(format);
                 let cond_expr = Closure::new(self.rigid_exprs.clone(), cond);
-                SpanValue(*span, Arc::new(Value::FormatCond(*name, format, cond_expr)))
+                Spanned {
+                    span: *span,
+                    inner: Arc::new(Value::FormatCond(*name, format, cond_expr)),
+                }
             }
             Term::FormatOverlap(span, labels, formats) => {
                 let formats = Telescope::new(self.rigid_exprs.clone(), formats);
-                SpanValue(*span, Arc::new(Value::FormatOverlap(labels, formats)))
+                Spanned {
+                    span: *span,
+                    inner: Arc::new(Value::FormatOverlap(labels, formats)),
+                }
             }
 
-            Term::Prim(span, prim) => SpanValue(*span, Arc::new(Value::prim(*prim, []))),
+            Term::Prim(span, prim) => Spanned {
+                span: *span,
+                inner: Arc::new(Value::prim(*prim, [])),
+            },
 
-            Term::ConstLit(span, r#const) => SpanValue(*span, Arc::new(Value::ConstLit(*r#const))),
+            Term::ConstLit(span, r#const) => Spanned {
+                span: *span,
+                inner: Arc::new(Value::ConstLit(*r#const)),
+            },
             Term::ConstMatch(span, head_expr, branches, default_expr) => {
                 let head_expr = self.eval(head_expr);
                 let branches = Branches::new(self.rigid_exprs.clone(), branches, *default_expr);
-                SpanValue::merge(*span, self.elim_context().const_match(head_expr, branches))
+                Spanned::merge(*span, self.elim_context().const_match(head_expr, branches))
             }
         }
     }
@@ -431,14 +484,14 @@ macro_rules! step {
 // TODO: Should we merge the spans of the input idents to produce the output span?
 macro_rules! const_step {
     ([$($input:ident : $Input:ident),*] => $output:expr) => {
-        step!(_, [$($input),*] => match ($($input.1.as_ref(),)*) {
-            ($(Value::ConstLit(Const::$Input($input, ..)),)*) => SpanValue::empty(Arc::new(Value::ConstLit($output))),
+        step!(_, [$($input),*] => match ($($input.inner.as_ref(),)*) {
+            ($(Value::ConstLit(Const::$Input($input, ..)),)*) => Spanned::empty(Arc::new(Value::ConstLit($output))),
             _ => return None,
         })
     };
     ([$($input:ident , $style:ident : $Input:ident),*] => $output:expr) => {
-        step!(_, [$($input),*] => match ($($input.1.as_ref(),)*) {
-            ($(Value::ConstLit(Const::$Input($input, $style)),)*) => SpanValue::empty(Arc::new(Value::ConstLit($output))),
+        step!(_, [$($input),*] => match ($($input.inner.as_ref(),)*) {
+            ($(Value::ConstLit(Const::$Input($input, $style)),)*) => Spanned::empty(Arc::new(Value::ConstLit($output))),
             _ => return None,
         })
     };
@@ -595,19 +648,19 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
         }),
 
         Prim::Array8Find | Prim::Array16Find | Prim::Array32Find | Prim::Array64Find => {
-            step!(context, [_, _, pred, array] => match array.1.as_ref() {
+            step!(context, [_, _, pred, array] => match array.inner.as_ref() {
                 Value::ArrayLit(elems) => {
                     for elem in elems {
-                        match context.fun_app(pred.clone(), elem.clone()).1.as_ref() {
+                        match context.fun_app(pred.clone(), elem.clone()).inner.as_ref() {
                             Value::ConstLit(Const::Bool(true)) => {
                                 // TODO: Is elem.span right here?
-                                return Some(SpanValue(elem.span(), Arc::new(Value::prim(Prim::OptionSome, [elem.clone()]))))
+                                return Some(Spanned{ span: elem.span(), inner: Arc::new(Value::prim(Prim::OptionSome, [elem.clone()])) })
                             },
                             Value::ConstLit(Const::Bool(false)) => {}
                             _ => return None,
                         }
                     }
-                    SpanValue::empty(Arc::new(Value::prim(Prim::OptionNone, [])))
+                    Spanned::empty(Arc::new(Value::prim(Prim::OptionNone, [])))
                 }
                 _ => return None,
             })
@@ -654,7 +707,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
     pub fn force(&self, value: &ArcValue<'arena>) -> ArcValue<'arena> {
         let mut forced_value = value.clone();
         // Attempt to force flexible values until we don't see any more.
-        while let Value::Stuck(Head::FlexibleVar(var), spine) = forced_value.1.as_ref() {
+        while let Value::Stuck(Head::FlexibleVar(var), spine) = forced_value.inner.as_ref() {
             match self.flexible_exprs.get_global(*var) {
                 // Apply the spine to the solution. This might uncover another
                 // flexible value so we'll continue looping.
@@ -730,7 +783,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
         mut head_expr: ArcValue<'arena>,
         input_expr: ArcValue<'arena>,
     ) -> ArcValue<'arena> {
-        match Arc::make_mut(&mut head_expr.1) {
+        match Arc::make_mut(&mut head_expr.inner) {
             // Beta-reduction
             Value::FunLit(_, output_expr) => self.apply_closure(output_expr, input_expr), // FIXME: use span from head/input exprs?
             // The computation is stuck, preventing further reduction
@@ -757,7 +810,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
         mut head_expr: ArcValue<'arena>,
         label: StringId,
     ) -> ArcValue<'arena> {
-        match Arc::make_mut(&mut head_expr.1) {
+        match Arc::make_mut(&mut head_expr.inner) {
             // Beta-reduction
             Value::RecordLit(labels, exprs) => (labels.iter())
                 .position(|current_label| *current_label == label)
@@ -781,7 +834,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
         mut head_expr: ArcValue<'arena>,
         mut branches: Branches<'arena, Const>,
     ) -> ArcValue<'arena> {
-        match Arc::make_mut(&mut head_expr.1) {
+        match Arc::make_mut(&mut head_expr.inner) {
             Value::ConstLit(r#const) => {
                 // Try each branch
                 for (branch_const, output_expr) in branches.pattern_branches {
@@ -819,97 +872,115 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
 
     /// Find the representation type of a format description.
     pub fn format_repr(&self, format: &ArcValue<'arena>) -> ArcValue<'arena> {
-        match format.1.as_ref() {
+        match format.inner.as_ref() {
             Value::FormatRecord(labels, formats) | Value::FormatOverlap(labels, formats) => {
-                SpanValue(
-                    format.span(),
-                    Arc::new(Value::RecordType(labels, formats.clone().apply_repr())),
-                )
+                Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::RecordType(labels, formats.clone().apply_repr())),
+                }
             }
             Value::FormatCond(_, format, _) => self.format_repr(format),
             Value::Stuck(Head::Prim(prim), spine) => match (prim, &spine[..]) {
-                (Prim::FormatU8, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::U8Type, [])))
-                }
-                (Prim::FormatU16Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::U16Type, [])))
-                }
-                (Prim::FormatU16Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::U16Type, [])))
-                }
-                (Prim::FormatU32Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::U32Type, [])))
-                }
-                (Prim::FormatU32Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::U32Type, [])))
-                }
-                (Prim::FormatU64Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::U64Type, [])))
-                }
-                (Prim::FormatU64Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::U64Type, [])))
-                }
-                (Prim::FormatS8, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::S8Type, [])))
-                }
-                (Prim::FormatS16Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::S16Type, [])))
-                }
-                (Prim::FormatS16Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::S16Type, [])))
-                }
-                (Prim::FormatS32Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::S32Type, [])))
-                }
-                (Prim::FormatS32Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::S32Type, [])))
-                }
-                (Prim::FormatS64Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::S64Type, [])))
-                }
-                (Prim::FormatS64Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::S64Type, [])))
-                }
-                (Prim::FormatF32Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::F32Type, [])))
-                }
-                (Prim::FormatF32Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::F32Type, [])))
-                }
-                (Prim::FormatF64Be, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::F64Type, [])))
-                }
-                (Prim::FormatF64Le, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::F64Type, [])))
-                }
-                (Prim::FormatArray8, [Elim::FunApp(len), Elim::FunApp(elem)]) => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(
+                (Prim::FormatU8, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::U8Type, [])),
+                },
+                (Prim::FormatU16Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::U16Type, [])),
+                },
+                (Prim::FormatU16Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::U16Type, [])),
+                },
+                (Prim::FormatU32Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::U32Type, [])),
+                },
+                (Prim::FormatU32Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::U32Type, [])),
+                },
+                (Prim::FormatU64Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::U64Type, [])),
+                },
+                (Prim::FormatU64Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::U64Type, [])),
+                },
+                (Prim::FormatS8, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::S8Type, [])),
+                },
+                (Prim::FormatS16Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::S16Type, [])),
+                },
+                (Prim::FormatS16Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::S16Type, [])),
+                },
+                (Prim::FormatS32Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::S32Type, [])),
+                },
+                (Prim::FormatS32Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::S32Type, [])),
+                },
+                (Prim::FormatS64Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::S64Type, [])),
+                },
+                (Prim::FormatS64Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::S64Type, [])),
+                },
+                (Prim::FormatF32Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::F32Type, [])),
+                },
+                (Prim::FormatF32Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::F32Type, [])),
+                },
+                (Prim::FormatF64Be, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::F64Type, [])),
+                },
+                (Prim::FormatF64Le, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::F64Type, [])),
+                },
+                (Prim::FormatArray8, [Elim::FunApp(len), Elim::FunApp(elem)]) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(
                         Prim::Array8Type,
                         [len.clone(), self.format_repr(elem)],
                     )),
-                ),
-                (Prim::FormatArray16, [Elim::FunApp(len), Elim::FunApp(elem)]) => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(
+                },
+                (Prim::FormatArray16, [Elim::FunApp(len), Elim::FunApp(elem)]) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(
                         Prim::Array16Type,
                         [len.clone(), self.format_repr(elem)],
                     )),
-                ),
-                (Prim::FormatArray32, [Elim::FunApp(len), Elim::FunApp(elem)]) => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(
+                },
+                (Prim::FormatArray32, [Elim::FunApp(len), Elim::FunApp(elem)]) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(
                         Prim::Array32Type,
                         [len.clone(), self.format_repr(elem)],
                     )),
-                ),
-                (Prim::FormatArray64, [Elim::FunApp(len), Elim::FunApp(elem)]) => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(
+                },
+                (Prim::FormatArray64, [Elim::FunApp(len), Elim::FunApp(elem)]) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(
                         Prim::Array64Type,
                         [len.clone(), self.format_repr(elem)],
                     )),
-                ),
+                },
                 (Prim::FormatLimit8, [Elim::FunApp(_), Elim::FunApp(elem)]) => {
                     self.format_repr(elem)
                 }
@@ -922,38 +993,40 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
                 (Prim::FormatLimit64, [Elim::FunApp(_), Elim::FunApp(elem)]) => {
                     self.format_repr(elem)
                 }
-                (Prim::FormatRepeatUntilEnd, [Elim::FunApp(elem)]) => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(Prim::ArrayType, [self.format_repr(elem)])),
-                ),
-                (Prim::FormatLink, [Elim::FunApp(_), Elim::FunApp(elem)]) => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(Prim::RefType, [elem.clone()])),
-                ),
+                (Prim::FormatRepeatUntilEnd, [Elim::FunApp(elem)]) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::ArrayType, [self.format_repr(elem)])),
+                },
+                (Prim::FormatLink, [Elim::FunApp(_), Elim::FunApp(elem)]) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::RefType, [elem.clone()])),
+                },
                 (Prim::FormatDeref, [Elim::FunApp(elem), Elim::FunApp(_)]) => {
                     self.format_repr(elem)
                 }
-                (Prim::FormatStreamPos, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::PosType, [])))
-                }
+                (Prim::FormatStreamPos, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::PosType, [])),
+                },
                 (Prim::FormatSucceed, [Elim::FunApp(elem), _]) => elem.clone(),
-                (Prim::FormatFail, []) => {
-                    SpanValue(format.span(), Arc::new(Value::prim(Prim::VoidType, [])))
-                }
+                (Prim::FormatFail, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::VoidType, [])),
+                },
                 (Prim::FormatUnwrap, [Elim::FunApp(elem), _]) => elem.clone(),
-                (Prim::ReportedError, []) => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(Prim::ReportedError, [])),
-                ),
-                _ => SpanValue(
-                    format.span(),
-                    Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
-                ),
+                (Prim::ReportedError, []) => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::ReportedError, [])),
+                },
+                _ => Spanned {
+                    span: format.span(),
+                    inner: Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
+                },
             },
-            Value::Stuck(_, _) => SpanValue(
-                format.span(),
-                Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
-            ),
+            Value::Stuck(_, _) => Spanned {
+                span: format.span(),
+                inner: Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
+            },
             _ => panic_any(Error::InvalidFormatRepr),
         }
     }
@@ -1002,7 +1075,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
     pub fn quote(&mut self, value: &ArcValue<'in_arena>) -> Term<'out_arena> {
         let value = self.elim_context().force(value);
         let span = value.span();
-        match value.1.as_ref() {
+        match value.inner.as_ref() {
             Value::Stuck(head, spine) => {
                 let head_expr = match head {
                     Head::Prim(prim) => Term::Prim(span, *prim),
@@ -1121,7 +1194,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
         let var = Arc::new(Value::rigid_var(self.rigid_exprs.next_global()));
         let value = self
             .elim_context()
-            .apply_closure(closure, SpanValue::empty(var));
+            .apply_closure(closure, Spanned::empty(var));
 
         self.push_rigid();
         let term = self.quote(&value);
@@ -1141,7 +1214,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
 
         while let Some((value, next_telescope)) = self.elim_context().split_telescope(telescope) {
             let var = Arc::new(Value::rigid_var(self.rigid_exprs.next_global()));
-            telescope = next_telescope(SpanValue::empty(var));
+            telescope = next_telescope(Spanned::empty(var));
             terms.push(self.quote(&value));
             self.rigid_exprs.push();
         }
@@ -1199,7 +1272,7 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
         let value0 = self.elim_context().force(value0);
         let value1 = self.elim_context().force(value1);
 
-        match (value0.1.as_ref(), value1.1.as_ref()) {
+        match (value0.inner.as_ref(), value1.inner.as_ref()) {
             // `ReportedError`s result from errors that have already been
             // reported, so we prevent them from triggering more errors.
             (Value::Stuck(Head::Prim(Prim::ReportedError), _), _)
@@ -1278,7 +1351,7 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
 
     /// Check that two [closures][Closure] are equal.
     pub fn is_equal_closures(&mut self, closure0: &Closure<'_>, closure1: &Closure<'_>) -> bool {
-        let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+        let var = Spanned::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
         let value0 = self.elim_context().apply_closure(closure0, var.clone());
         let value1 = self.elim_context().apply_closure(closure1, var);
 
@@ -1312,7 +1385,7 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
                 return false;
             }
 
-            let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+            let var = Spanned::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
             telescope0 = next_telescope0(var.clone());
             telescope1 = next_telescope1(var);
             self.rigid_exprs.push();
@@ -1360,7 +1433,7 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
     /// (fun x => f x) = f
     /// ```
     fn is_equal_fun_lit(&mut self, output_expr: &Closure<'_>, value: &ArcValue<'_>) -> bool {
-        let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+        let var = Spanned::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
         let value = self.elim_context().fun_app(value.clone(), var.clone());
         let output_expr = self.elim_context().apply_closure(output_expr, var);
 

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -23,10 +23,6 @@ impl<'arena> SpanValue<'arena> {
         self.0
     }
 
-    pub fn empty_fixme(val: Arc<Value<'arena>>) -> Self {
-        SpanValue::empty(val)
-    }
-
     pub fn empty(val: Arc<Value<'arena>>) -> Self {
         SpanValue(Span::Empty, val)
     }
@@ -436,13 +432,13 @@ macro_rules! step {
 macro_rules! const_step {
     ([$($input:ident : $Input:ident),*] => $output:expr) => {
         step!(_, [$($input),*] => match ($($input.1.as_ref(),)*) {
-            ($(Value::ConstLit(Const::$Input($input, ..)),)*) => SpanValue::empty_fixme(Arc::new(Value::ConstLit($output))),
+            ($(Value::ConstLit(Const::$Input($input, ..)),)*) => SpanValue::empty(Arc::new(Value::ConstLit($output))),
             _ => return None,
         })
     };
     ([$($input:ident , $style:ident : $Input:ident),*] => $output:expr) => {
         step!(_, [$($input),*] => match ($($input.1.as_ref(),)*) {
-            ($(Value::ConstLit(Const::$Input($input, $style)),)*) => SpanValue::empty_fixme(Arc::new(Value::ConstLit($output))),
+            ($(Value::ConstLit(Const::$Input($input, $style)),)*) => SpanValue::empty(Arc::new(Value::ConstLit($output))),
             _ => return None,
         })
     };
@@ -611,7 +607,7 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
                             _ => return None,
                         }
                     }
-                    SpanValue::empty_fixme(Arc::new(Value::prim(Prim::OptionNone, [])))
+                    SpanValue::empty(Arc::new(Value::prim(Prim::OptionNone, [])))
                 }
                 _ => return None,
             })
@@ -1125,7 +1121,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
         let var = Arc::new(Value::rigid_var(self.rigid_exprs.next_global()));
         let value = self
             .elim_context()
-            .apply_closure(closure, SpanValue::empty_fixme(var));
+            .apply_closure(closure, SpanValue::empty(var));
 
         self.push_rigid();
         let term = self.quote(&value);
@@ -1145,7 +1141,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
 
         while let Some((value, next_telescope)) = self.elim_context().split_telescope(telescope) {
             let var = Arc::new(Value::rigid_var(self.rigid_exprs.next_global()));
-            telescope = next_telescope(SpanValue::empty_fixme(var));
+            telescope = next_telescope(SpanValue::empty(var));
             terms.push(self.quote(&value));
             self.rigid_exprs.push();
         }
@@ -1316,8 +1312,7 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
                 return false;
             }
 
-            let var =
-                SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+            let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
             telescope0 = next_telescope0(var.clone());
             telescope1 = next_telescope1(var);
             self.rigid_exprs.push();

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -6,8 +6,9 @@ use std::panic::panic_any;
 use std::sync::Arc;
 
 use crate::alloc::SliceVec;
-use crate::core::{Const, EntryInfo, Prim, Span, Term, UIntStyle};
+use crate::core::{Const, EntryInfo, Prim, Term, UIntStyle};
 use crate::env::{EnvLen, GlobalVar, SharedEnv, SliceEnv};
+use crate::source::Span;
 use crate::StringId;
 
 /// Atomically reference counted values. We use reference counting to increase

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -45,7 +45,7 @@ pub enum Value<'arena> {
     FormatCond(Span, StringId, ArcValue<'arena>, Closure<'arena>),
     /// Overlap formats, consisting of a list of dependent formats, overlapping
     /// in memory.
-    FormatOverlap(&'arena [StringId], Telescope<'arena>),
+    FormatOverlap(Span, &'arena [StringId], Telescope<'arena>),
 
     /// Constant literals.
     ConstLit(Const),
@@ -371,10 +371,9 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 let cond_expr = Closure::new(self.rigid_exprs.clone(), cond);
                 Arc::new(Value::FormatCond(*span, *name, format, cond_expr))
             }
-            Term::FormatOverlap(_span, labels, formats) => {
+            Term::FormatOverlap(span, labels, formats) => {
                 let formats = Telescope::new(self.rigid_exprs.clone(), formats);
-                // TODO: set span of Value
-                Arc::new(Value::FormatOverlap(labels, formats))
+                Arc::new(Value::FormatOverlap(*span, labels, formats))
             }
 
             Term::Prim(_span, prim) => {
@@ -800,7 +799,7 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
     /// Find the representation type of a format description.
     pub fn format_repr(&self, format: &ArcValue<'arena>) -> ArcValue<'arena> {
         match format.as_ref() {
-            Value::FormatRecord(_, labels, formats) | Value::FormatOverlap(labels, formats) => {
+            Value::FormatRecord(_, labels, formats) | Value::FormatOverlap(_, labels, formats) => {
                 Arc::new(Value::RecordType(
                     Span::Empty,
                     labels,
@@ -1021,11 +1020,11 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                     self.scope.to_scope(cond),
                 )
             }
-            Value::FormatOverlap(labels, formats) => {
+            Value::FormatOverlap(span, labels, formats) => {
                 let labels = self.scope.to_scope_from_iter(labels.iter().copied()); // FIXME: avoid copy if this is the same arena?
                 let formats = self.quote_telescope(formats);
 
-                Term::FormatOverlap(Span::from_value(&value), labels, formats)
+                Term::FormatOverlap(*span, labels, formats)
             }
 
             Value::ConstLit(r#const) => Term::ConstLit(Span::from_value(&value), *r#const),
@@ -1174,9 +1173,10 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
                 Value::FormatRecord(_, labels0, formats0),
                 Value::FormatRecord(_, labels1, formats1),
             )
-            | (Value::FormatOverlap(labels0, formats0), Value::FormatOverlap(labels1, formats1)) => {
-                labels0 == labels1 && self.is_equal_telescopes(formats0, formats1)
-            }
+            | (
+                Value::FormatOverlap(_, labels0, formats0),
+                Value::FormatOverlap(_, labels1, formats1),
+            ) => labels0 == labels1 && self.is_equal_telescopes(formats0, formats1),
 
             (
                 Value::FormatCond(_, label0, format0, cond0),
@@ -1333,7 +1333,7 @@ mod tests {
             Value::ArrayLit(_, _) => {}
             Value::FormatRecord(_, _, _) => {}
             Value::FormatCond(_, _, _, _) => {}
-            Value::FormatOverlap(_, _) => {}
+            Value::FormatOverlap(_, _, _) => {}
             Value::ConstLit(_) => {}
         }
     }

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -352,10 +352,11 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 self.elim_context().record_proj(head_expr, *label)
             }
 
-            Term::ArrayLit(elem_exprs) => {
+            Term::ArrayLit(_span, elem_exprs) => {
                 let elem_exprs = (elem_exprs.iter())
                     .map(|elem_expr| self.eval(elem_expr))
                     .collect();
+                // TODO: set span of Value
                 Arc::new(Value::ArrayLit(elem_exprs))
             }
 
@@ -991,7 +992,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let elem_exprs = (self.scope)
                     .to_scope_from_iter(elem_exprs.iter().map(|elem_expr| self.quote(elem_expr)));
 
-                Term::ArrayLit(elem_exprs)
+                Term::ArrayLit(Span::from_value(&value), elem_exprs)
             }
 
             Value::FormatRecord(labels, formats) => {

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -303,7 +303,7 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 }
                 head_expr
             }
-            Term::Ann(expr, _) => self.eval(expr),
+            Term::Ann(_span, expr, _) => self.eval(expr), // TODO: Should the span be passed down?
             Term::Let(_, _, def_expr, output_expr) => {
                 let def_expr = self.eval(def_expr);
                 self.rigid_exprs.push(def_expr);

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -341,8 +341,9 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 // TODO: set span of Value
                 Arc::new(Value::RecordType(labels, types))
             }
-            Term::RecordLit(labels, exprs) => {
+            Term::RecordLit(_span, labels, exprs) => {
                 let exprs = exprs.iter().map(|expr| self.eval(expr)).collect();
+                // TODO: set span of Value
                 Arc::new(Value::RecordLit(labels, exprs))
             }
             Term::RecordProj(head_expr, label) => {
@@ -981,7 +982,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let exprs =
                     (self.scope).to_scope_from_iter(exprs.iter().map(|expr| self.quote(expr)));
 
-                Term::RecordLit(labels, exprs)
+                Term::RecordLit(Span::from_value(&value), labels, exprs)
             }
             Value::ArrayLit(elem_exprs) => {
                 let elem_exprs = (self.scope)

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -365,9 +365,10 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 // TODO: set span of Value
                 Arc::new(Value::FormatRecord(labels, formats))
             }
-            Term::FormatCond(name, format, cond) => {
+            Term::FormatCond(_span, name, format, cond) => {
                 let format = self.eval(format);
                 let cond_expr = Closure::new(self.rigid_exprs.clone(), cond);
+                // TODO: set span of Value
                 Arc::new(Value::FormatCond(*name, format, cond_expr))
             }
             Term::FormatOverlap(labels, formats) => {
@@ -1006,6 +1007,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let format = self.quote(format);
                 let cond = self.quote_closure(cond);
                 Term::FormatCond(
+                    Span::from_value(&value),
                     *label,
                     self.scope.to_scope(format),
                     self.scope.to_scope(cond),

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -596,13 +596,13 @@ fn prim_step(prim: Prim) -> Option<PrimStep> {
 
         Prim::Array8Find | Prim::Array16Find | Prim::Array32Find | Prim::Array64Find => {
             step!(context, [_, _, pred, array] => match array.as_ref() {
-                Value::ArrayLit(_span, elems) => { // TODO: Use the span for the result of the find?
+                Value::ArrayLit(_span, elems) => {
                     for elem in elems {
                         match context.fun_app(pred.clone(), elem.clone()).as_ref() {
-                            Value::ConstLit(Span::Empty, Const::Bool(true)) => {
-                                return Some(Arc::new(Value::prim(Prim::OptionSome, [elem.clone()])))
+                            Value::ConstLit(_, Const::Bool(true)) => {
+                                return Some(Arc::new(Value::prim_with_span(elem.span(), Prim::OptionSome, [elem.clone()])))
                             },
-                            Value::ConstLit(Span::Empty, Const::Bool(false)) => {}
+                            Value::ConstLit(_, Const::Bool(false)) => {}
                             _ => return None,
                         }
                     }

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -23,10 +23,6 @@ impl<'arena> SpanValue<'arena> {
         self.0
     }
 
-    pub fn fixme(val: Arc<Value<'arena>>) -> Self {
-        SpanValue(val.span(), val)
-    }
-
     pub fn empty_fixme(val: Arc<Value<'arena>>) -> Self {
         SpanValue::empty(val)
     }
@@ -102,24 +98,6 @@ impl<'arena> Value<'arena> {
     pub fn arc_universe() -> ArcValue<'arena> {
         // TODO: Can we share a single instance of this?
         SpanValue::empty(Arc::new(Value::Universe))
-    }
-
-    pub fn span(&self) -> Span {
-        match self {
-            Value::Stuck(_, _)
-            | Value::Universe
-            | Value::FunType(_, _, _)
-            | Value::FunLit(_, _)
-            | Value::RecordType(_, _)
-            | Value::RecordLit(_, _)
-            | Value::ArrayLit(_)
-            | Value::FormatRecord(_, _)
-            | Value::FormatCond(_, _, _)
-            | Value::FormatOverlap(_, _)
-            | Value::ConstLit(_) => {
-                unreachable!("value has no span")
-            }
-        }
     }
 }
 
@@ -1384,7 +1362,7 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
     /// (fun x => f x) = f
     /// ```
     fn is_equal_fun_lit(&mut self, output_expr: &Closure<'_>, value: &ArcValue<'_>) -> bool {
-        let var = SpanValue::fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+        let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
         let value = self.elim_context().fun_app(value.clone(), var.clone());
         let output_expr = self.elim_context().apply_closure(output_expr, var);
 

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -314,11 +314,14 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
 
             Term::Universe(_span) => Arc::new(Value::Universe), // TODO: pass span to value
 
-            Term::FunType(input_name, input_type, output_type) => Arc::new(Value::FunType(
-                *input_name,
-                self.eval(input_type),
-                Closure::new(self.rigid_exprs.clone(), output_type),
-            )),
+            Term::FunType(_span, input_name, input_type, output_type) => {
+                // TODO: pass span to value
+                Arc::new(Value::FunType(
+                    *input_name,
+                    self.eval(input_type),
+                    Closure::new(self.rigid_exprs.clone(), output_type),
+                ))
+            }
             Term::FunLit(input_name, output_expr) => Arc::new(Value::FunLit(
                 *input_name,
                 Closure::new(self.rigid_exprs.clone(), output_expr),
@@ -945,6 +948,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let output_type = self.quote_closure(output_type);
 
                 Term::FunType(
+                    Span::from_value(&value),
                     *input_name,
                     self.scope.to_scope(input_type),
                     self.scope.to_scope(output_type),

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -346,8 +346,9 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 // TODO: set span of Value
                 Arc::new(Value::RecordLit(labels, exprs))
             }
-            Term::RecordProj(head_expr, label) => {
+            Term::RecordProj(_span, head_expr, label) => {
                 let head_expr = self.eval(head_expr);
+                // TODO: set span of Value
                 self.elim_context().record_proj(head_expr, *label)
             }
 
@@ -918,9 +919,11 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                         self.scope.to_scope(head_expr),
                         self.scope.to_scope(self.quote(input_expr)),
                     ),
-                    Elim::RecordProj(label) => {
-                        Term::RecordProj(self.scope.to_scope(head_expr), *label)
-                    }
+                    Elim::RecordProj(label) => Term::RecordProj(
+                        Span::from_value(&value),
+                        self.scope.to_scope(head_expr),
+                        *label,
+                    ),
                     Elim::ConstMatch(branches) => {
                         let mut branches = branches.clone();
                         let mut pattern_branches =

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -386,9 +386,10 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 // TODO: set span of Value
                 Arc::new(Value::ConstLit(*r#const))
             }
-            Term::ConstMatch(head_expr, branches, default_expr) => {
+            Term::ConstMatch(_span, head_expr, branches, default_expr) => {
                 let head_expr = self.eval(head_expr);
                 let branches = Branches::new(self.rigid_exprs.clone(), branches, *default_expr);
+                // TODO: set span of Value
                 self.elim_context().const_match(head_expr, branches)
             }
         }
@@ -953,6 +954,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                         };
 
                         Term::ConstMatch(
+                            Span::from_value(&value),
                             self.scope.to_scope(head_expr),
                             pattern_branches.into(),
                             default_expr.map(|expr| self.scope.to_scope(expr) as &_),

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -329,9 +329,10 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                     Closure::new(self.rigid_exprs.clone(), output_expr),
                 ))
             }
-            Term::FunApp(head_expr, input_expr) => {
+            Term::FunApp(_span, head_expr, input_expr) => {
                 let head_expr = self.eval(head_expr);
                 let input_expr = self.eval(input_expr);
+                // TODO: set span of Value
                 self.elim_context().fun_app(head_expr, input_expr)
             }
 
@@ -911,6 +912,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
 
                 spine.iter().fold(head_expr, |head_expr, elim| match elim {
                     Elim::FunApp(input_expr) => Term::FunApp(
+                        Span::from_value(&value),
                         self.scope.to_scope(head_expr),
                         self.scope.to_scope(self.quote(input_expr)),
                     ),

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -382,7 +382,10 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 Arc::new(Value::prim(*prim, []))
             }
 
-            Term::ConstLit(r#const) => Arc::new(Value::ConstLit(*r#const)),
+            Term::ConstLit(_span, r#const) => {
+                // TODO: set span of Value
+                Arc::new(Value::ConstLit(*r#const))
+            }
             Term::ConstMatch(head_expr, branches, default_expr) => {
                 let head_expr = self.eval(head_expr);
                 let branches = Branches::new(self.rigid_exprs.clone(), branches, *default_expr);
@@ -1024,7 +1027,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 Term::FormatOverlap(Span::from_value(&value), labels, formats)
             }
 
-            Value::ConstLit(r#const) => Term::ConstLit(*r#const),
+            Value::ConstLit(r#const) => Term::ConstLit(Span::from_value(&value), *r#const),
         }
     }
 

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -8,43 +8,12 @@ use std::sync::Arc;
 use crate::alloc::SliceVec;
 use crate::core::{Const, EntryInfo, Prim, Term, UIntStyle};
 use crate::env::{EnvLen, GlobalVar, SharedEnv, SliceEnv};
-use crate::source::Span;
+use crate::source::{Span, Spanned};
 use crate::StringId;
 
 /// Atomically reference counted values. We use reference counting to increase
 /// the amount of sharing we can achieve during evaluation.
 pub type ArcValue<'arena> = Spanned<Arc<Value<'arena>>>;
-
-#[derive(Debug, Clone)]
-pub struct Spanned<T> {
-    pub span: Span,
-    pub inner: T,
-}
-
-impl<T> Spanned<T> {
-    pub fn span(&self) -> Span {
-        self.span
-    }
-
-    pub fn empty(inner: T) -> Self {
-        Spanned {
-            span: Span::Empty,
-            inner,
-        }
-    }
-
-    /// Merge the supplied span and the span of value and return value wrapped in that span.
-    pub fn merge(span: Span, other: Spanned<T>) -> Spanned<T> {
-        let Spanned {
-            span: other_span,
-            inner,
-        } = other;
-        Spanned {
-            span: span.merge(&other_span),
-            inner,
-        }
-    }
-}
 
 impl<'arena> ArcValue<'arena> {
     pub fn match_prim_spine(&self) -> Option<(Prim, &[Elim<'arena>])> {

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -312,7 +312,7 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 output_expr
             }
 
-            Term::Universe => Arc::new(Value::Universe),
+            Term::Universe(_span) => Arc::new(Value::Universe), // TODO: pass span to value
 
             Term::FunType(input_name, input_type, output_type) => Arc::new(Value::FunType(
                 *input_name,
@@ -938,7 +938,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 })
             }
 
-            Value::Universe => Term::Universe,
+            Value::Universe => Term::Universe(Span::from_value(&value)),
 
             Value::FunType(input_name, input_type, output_type) => {
                 let input_type = self.quote(input_type);

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -76,6 +76,22 @@ impl<'arena> Value<'arena> {
     pub fn arc_universe() -> ArcValue<'arena> {
         Arc::new(Value::Universe(Span::Empty))
     }
+
+    pub fn span(&self) -> Span {
+        match self {
+            Value::Stuck(span, _, _)
+            | Value::Universe(span)
+            | Value::FunType(span, _, _, _)
+            | Value::FunLit(span, _, _)
+            | Value::RecordType(span, _, _)
+            | Value::RecordLit(span, _, _)
+            | Value::ArrayLit(span, _)
+            | Value::FormatRecord(span, _, _)
+            | Value::FormatCond(span, _, _, _)
+            | Value::FormatOverlap(span, _, _)
+            | Value::ConstLit(span, _) => *span,
+        }
+    }
 }
 
 /// The head of a [stuck value][Value::Stuck].

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -828,37 +828,85 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
                 )) // TODO: Should this copy the span from FormatRecord?
             }
             Value::FormatCond(_, _, format, _) => self.format_repr(format),
-            Value::Stuck(_span, Head::Prim(prim), spine) => match (prim, &spine[..]) {
-                (Prim::FormatU8, []) => Arc::new(Value::prim(Prim::U8Type, [])),
-                (Prim::FormatU16Be, []) => Arc::new(Value::prim(Prim::U16Type, [])),
-                (Prim::FormatU16Le, []) => Arc::new(Value::prim(Prim::U16Type, [])),
-                (Prim::FormatU32Be, []) => Arc::new(Value::prim(Prim::U32Type, [])),
-                (Prim::FormatU32Le, []) => Arc::new(Value::prim(Prim::U32Type, [])),
-                (Prim::FormatU64Be, []) => Arc::new(Value::prim(Prim::U64Type, [])),
-                (Prim::FormatU64Le, []) => Arc::new(Value::prim(Prim::U64Type, [])),
-                (Prim::FormatS8, []) => Arc::new(Value::prim(Prim::S8Type, [])),
-                (Prim::FormatS16Be, []) => Arc::new(Value::prim(Prim::S16Type, [])),
-                (Prim::FormatS16Le, []) => Arc::new(Value::prim(Prim::S16Type, [])),
-                (Prim::FormatS32Be, []) => Arc::new(Value::prim(Prim::S32Type, [])),
-                (Prim::FormatS32Le, []) => Arc::new(Value::prim(Prim::S32Type, [])),
-                (Prim::FormatS64Be, []) => Arc::new(Value::prim(Prim::S64Type, [])),
-                (Prim::FormatS64Le, []) => Arc::new(Value::prim(Prim::S64Type, [])),
-                (Prim::FormatF32Be, []) => Arc::new(Value::prim(Prim::F32Type, [])),
-                (Prim::FormatF32Le, []) => Arc::new(Value::prim(Prim::F32Type, [])),
-                (Prim::FormatF64Be, []) => Arc::new(Value::prim(Prim::F64Type, [])),
-                (Prim::FormatF64Le, []) => Arc::new(Value::prim(Prim::F64Type, [])),
-                (Prim::FormatArray8, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
-                    Value::prim(Prim::Array8Type, [len.clone(), self.format_repr(elem)]),
-                ),
-                (Prim::FormatArray16, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
-                    Value::prim(Prim::Array16Type, [len.clone(), self.format_repr(elem)]),
-                ),
-                (Prim::FormatArray32, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
-                    Value::prim(Prim::Array32Type, [len.clone(), self.format_repr(elem)]),
-                ),
-                (Prim::FormatArray64, [Elim::FunApp(len), Elim::FunApp(elem)]) => Arc::new(
-                    Value::prim(Prim::Array64Type, [len.clone(), self.format_repr(elem)]),
-                ),
+            Value::Stuck(span, Head::Prim(prim), spine) => match (prim, &spine[..]) {
+                (Prim::FormatU8, []) => Arc::new(Value::prim_with_span(*span, Prim::U8Type, [])),
+                (Prim::FormatU16Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::U16Type, []))
+                }
+                (Prim::FormatU16Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::U16Type, []))
+                }
+                (Prim::FormatU32Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::U32Type, []))
+                }
+                (Prim::FormatU32Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::U32Type, []))
+                }
+                (Prim::FormatU64Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::U64Type, []))
+                }
+                (Prim::FormatU64Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::U64Type, []))
+                }
+                (Prim::FormatS8, []) => Arc::new(Value::prim_with_span(*span, Prim::S8Type, [])),
+                (Prim::FormatS16Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::S16Type, []))
+                }
+                (Prim::FormatS16Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::S16Type, []))
+                }
+                (Prim::FormatS32Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::S32Type, []))
+                }
+                (Prim::FormatS32Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::S32Type, []))
+                }
+                (Prim::FormatS64Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::S64Type, []))
+                }
+                (Prim::FormatS64Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::S64Type, []))
+                }
+                (Prim::FormatF32Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::F32Type, []))
+                }
+                (Prim::FormatF32Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::F32Type, []))
+                }
+                (Prim::FormatF64Be, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::F64Type, []))
+                }
+                (Prim::FormatF64Le, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::F64Type, []))
+                }
+                (Prim::FormatArray8, [Elim::FunApp(len), Elim::FunApp(elem)]) => {
+                    Arc::new(Value::prim_with_span(
+                        *span,
+                        Prim::Array8Type,
+                        [len.clone(), self.format_repr(elem)],
+                    ))
+                }
+                (Prim::FormatArray16, [Elim::FunApp(len), Elim::FunApp(elem)]) => {
+                    Arc::new(Value::prim_with_span(
+                        *span,
+                        Prim::Array16Type,
+                        [len.clone(), self.format_repr(elem)],
+                    ))
+                }
+                (Prim::FormatArray32, [Elim::FunApp(len), Elim::FunApp(elem)]) => {
+                    Arc::new(Value::prim_with_span(
+                        *span,
+                        Prim::Array32Type,
+                        [len.clone(), self.format_repr(elem)],
+                    ))
+                }
+                (Prim::FormatArray64, [Elim::FunApp(len), Elim::FunApp(elem)]) => {
+                    Arc::new(Value::prim_with_span(
+                        *span,
+                        Prim::Array64Type,
+                        [len.clone(), self.format_repr(elem)],
+                    ))
+                }
                 (Prim::FormatLimit8, [Elim::FunApp(_), Elim::FunApp(elem)]) => {
                     self.format_repr(elem)
                 }
@@ -871,23 +919,37 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
                 (Prim::FormatLimit64, [Elim::FunApp(_), Elim::FunApp(elem)]) => {
                     self.format_repr(elem)
                 }
-                (Prim::FormatRepeatUntilEnd, [Elim::FunApp(elem)]) => {
-                    Arc::new(Value::prim(Prim::ArrayType, [self.format_repr(elem)]))
-                }
+                (Prim::FormatRepeatUntilEnd, [Elim::FunApp(elem)]) => Arc::new(
+                    Value::prim_with_span(*span, Prim::ArrayType, [self.format_repr(elem)]),
+                ),
                 (Prim::FormatLink, [Elim::FunApp(_), Elim::FunApp(elem)]) => {
-                    Arc::new(Value::prim(Prim::RefType, [elem.clone()]))
+                    Arc::new(Value::prim_with_span(*span, Prim::RefType, [elem.clone()]))
                 }
                 (Prim::FormatDeref, [Elim::FunApp(elem), Elim::FunApp(_)]) => {
                     self.format_repr(elem)
                 }
-                (Prim::FormatStreamPos, []) => Arc::new(Value::prim(Prim::PosType, [])),
+                (Prim::FormatStreamPos, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::PosType, []))
+                }
                 (Prim::FormatSucceed, [Elim::FunApp(elem), _]) => elem.clone(),
-                (Prim::FormatFail, []) => Arc::new(Value::prim(Prim::VoidType, [])),
+                (Prim::FormatFail, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::VoidType, []))
+                }
                 (Prim::FormatUnwrap, [Elim::FunApp(elem), _]) => elem.clone(),
-                (Prim::ReportedError, []) => Arc::new(Value::prim(Prim::ReportedError, [])),
-                _ => Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
+                (Prim::ReportedError, []) => {
+                    Arc::new(Value::prim_with_span(*span, Prim::ReportedError, []))
+                }
+                _ => Arc::new(Value::prim_with_span(
+                    *span,
+                    Prim::FormatRepr,
+                    [format.clone()],
+                )),
             },
-            Value::Stuck(_span, _, _) => Arc::new(Value::prim(Prim::FormatRepr, [format.clone()])),
+            Value::Stuck(span, _, _) => Arc::new(Value::prim_with_span(
+                *span,
+                Prim::FormatRepr,
+                [format.clone()],
+            )),
             _ => panic_any(Error::InvalidFormatRepr),
         }
     }

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -360,8 +360,9 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 Arc::new(Value::ArrayLit(elem_exprs))
             }
 
-            Term::FormatRecord(labels, formats) => {
+            Term::FormatRecord(_span, labels, formats) => {
                 let formats = Telescope::new(self.rigid_exprs.clone(), formats);
+                // TODO: set span of Value
                 Arc::new(Value::FormatRecord(labels, formats))
             }
             Term::FormatCond(name, format, cond) => {
@@ -999,7 +1000,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let labels = self.scope.to_scope_from_iter(labels.iter().copied()); // FIXME: avoid copy if this is the same arena?
                 let formats = self.quote_telescope(formats);
 
-                Term::FormatRecord(labels, formats)
+                Term::FormatRecord(Span::from_value(&value), labels, formats)
             }
             Value::FormatCond(label, format, cond) => {
                 let format = self.quote(format);

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -336,8 +336,9 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 self.elim_context().fun_app(head_expr, input_expr)
             }
 
-            Term::RecordType(labels, types) => {
+            Term::RecordType(_span, labels, types) => {
                 let types = Telescope::new(self.rigid_exprs.clone(), types);
+                // TODO: set span of Value
                 Arc::new(Value::RecordType(labels, types))
             }
             Term::RecordLit(labels, exprs) => {
@@ -973,7 +974,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let labels = self.scope.to_scope_from_iter(labels.iter().copied()); // FIXME: avoid copy if this is the same arena?
                 let types = self.quote_telescope(types);
 
-                Term::RecordType(labels, types)
+                Term::RecordType(Span::from_value(&value), labels, types)
             }
             Value::RecordLit(labels, exprs) => {
                 let labels = self.scope.to_scope_from_iter(labels.iter().copied()); // FIXME: avoid copy if this is the same arena?

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -377,7 +377,10 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 Arc::new(Value::FormatOverlap(labels, formats))
             }
 
-            Term::Prim(prim) => Arc::new(Value::prim(*prim, [])),
+            Term::Prim(_span, prim) => {
+                // TODO: set span of Value
+                Arc::new(Value::prim(*prim, []))
+            }
 
             Term::ConstLit(r#const) => Arc::new(Value::ConstLit(*r#const)),
             Term::ConstMatch(head_expr, branches, default_expr) => {
@@ -906,7 +909,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
         match value.as_ref() {
             Value::Stuck(head, spine) => {
                 let head_expr = match head {
-                    Head::Prim(prim) => Term::Prim(*prim),
+                    Head::Prim(prim) => Term::Prim(Span::fixme(), *prim),
                     Head::RigidVar(var) => {
                         // FIXME: Unwrap
                         Term::RigidVar(

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -29,7 +29,7 @@ pub enum Value<'arena> {
     /// Dependent function types.
     FunType(Span, Option<StringId>, ArcValue<'arena>, Closure<'arena>),
     /// Function literals.
-    FunLit(Option<StringId>, Closure<'arena>),
+    FunLit(Span, Option<StringId>, Closure<'arena>),
 
     /// Record types.
     RecordType(&'arena [StringId], Telescope<'arena>),
@@ -325,13 +325,11 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 self.eval(input_type),
                 Closure::new(self.rigid_exprs.clone(), output_type),
             )),
-            Term::FunLit(_span, input_name, output_expr) => {
-                // TODO: pass span to value
-                Arc::new(Value::FunLit(
-                    *input_name,
-                    Closure::new(self.rigid_exprs.clone(), output_expr),
-                ))
-            }
+            Term::FunLit(span, input_name, output_expr) => Arc::new(Value::FunLit(
+                *span,
+                *input_name,
+                Closure::new(self.rigid_exprs.clone(), output_expr),
+            )),
             Term::FunApp(_span, head_expr, input_expr) => {
                 let head_expr = self.eval(head_expr);
                 let input_expr = self.eval(input_expr);
@@ -714,9 +712,10 @@ impl<'arena, 'env> ElimContext<'arena, 'env> {
     ) -> ArcValue<'arena> {
         match Arc::make_mut(&mut head_expr) {
             // Beta-reduction
-            Value::FunLit(_, output_expr) => self.apply_closure(output_expr, input_expr),
+            Value::FunLit(_span, _, output_expr) => self.apply_closure(output_expr, input_expr), // FIXME: use span?
             // The computation is stuck, preventing further reduction
             Value::Stuck(_span, head, spine) => {
+                // FIXME: use span?
                 spine.push(Elim::FunApp(input_expr));
 
                 match head {
@@ -977,14 +976,10 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                     self.scope.to_scope(output_type),
                 )
             }
-            Value::FunLit(input_name, output_expr) => {
+            Value::FunLit(span, input_name, output_expr) => {
                 let output_expr = self.quote_closure(output_expr);
 
-                Term::FunLit(
-                    Span::from_value(&value),
-                    *input_name,
-                    self.scope.to_scope(output_expr),
-                )
+                Term::FunLit(*span, *input_name, self.scope.to_scope(output_expr))
             }
 
             Value::RecordType(labels, types) => {
@@ -1146,11 +1141,11 @@ impl<'arena, 'env> ConversionContext<'arena, 'env> {
                 self.is_equal(input_type0, input_type1)
                     && self.is_equal_closures(output_type0, output_type1)
             }
-            (Value::FunLit(_, output_expr0), Value::FunLit(_, output_expr1)) => {
+            (Value::FunLit(_, _, output_expr0), Value::FunLit(_, _, output_expr1)) => {
                 self.is_equal_closures(output_expr0, output_expr1)
             }
-            (Value::FunLit(_, output_expr), _) => self.is_equal_fun_lit(output_expr, &value1),
-            (_, Value::FunLit(_, output_expr)) => self.is_equal_fun_lit(output_expr, &value0),
+            (Value::FunLit(_, _, output_expr), _) => self.is_equal_fun_lit(output_expr, &value1),
+            (_, Value::FunLit(_, _, output_expr)) => self.is_equal_fun_lit(output_expr, &value0),
 
             (Value::RecordType(labels0, types0), Value::RecordType(labels1, types1)) => {
                 labels0 == labels1 && self.is_equal_telescopes(types0, types1)
@@ -1326,7 +1321,7 @@ mod tests {
             Value::Stuck(_, _, _) => {}
             Value::Universe(_) => {}
             Value::FunType(_, _, _, _) => {}
-            Value::FunLit(_, _) => {}
+            Value::FunLit(_, _, _) => {}
             Value::RecordType(_, _) => {}
             Value::RecordLit(_, _) => {}
             Value::ArrayLit(_) => {}

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -371,8 +371,9 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 // TODO: set span of Value
                 Arc::new(Value::FormatCond(*name, format, cond_expr))
             }
-            Term::FormatOverlap(labels, formats) => {
+            Term::FormatOverlap(_span, labels, formats) => {
                 let formats = Telescope::new(self.rigid_exprs.clone(), formats);
+                // TODO: set span of Value
                 Arc::new(Value::FormatOverlap(labels, formats))
             }
 
@@ -1017,7 +1018,7 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
                 let labels = self.scope.to_scope_from_iter(labels.iter().copied()); // FIXME: avoid copy if this is the same arena?
                 let formats = self.quote_telescope(formats);
 
-                Term::FormatOverlap(labels, formats)
+                Term::FormatOverlap(Span::from_value(&value), labels, formats)
             }
 
             Value::ConstLit(r#const) => Term::ConstLit(*r#const),

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -304,12 +304,12 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                 head_expr
             }
             Term::Ann(_span, expr, _) => self.eval(expr), // TODO: Should the span be passed down?
-            Term::Let(_, _, def_expr, output_expr) => {
+            Term::Let(_span, _, _, def_expr, output_expr) => {
                 let def_expr = self.eval(def_expr);
                 self.rigid_exprs.push(def_expr);
                 let output_expr = self.eval(output_expr);
                 self.rigid_exprs.pop();
-                output_expr
+                output_expr // TODO: Wrap output in span
             }
 
             Term::Universe(_span) => Arc::new(Value::Universe), // TODO: pass span to value

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -322,10 +322,13 @@ impl<'arena, 'env> EvalContext<'arena, 'env> {
                     Closure::new(self.rigid_exprs.clone(), output_type),
                 ))
             }
-            Term::FunLit(input_name, output_expr) => Arc::new(Value::FunLit(
-                *input_name,
-                Closure::new(self.rigid_exprs.clone(), output_expr),
-            )),
+            Term::FunLit(_span, input_name, output_expr) => {
+                // TODO: pass span to value
+                Arc::new(Value::FunLit(
+                    *input_name,
+                    Closure::new(self.rigid_exprs.clone(), output_expr),
+                ))
+            }
             Term::FunApp(head_expr, input_expr) => {
                 let head_expr = self.eval(head_expr);
                 let input_expr = self.eval(input_expr);
@@ -957,7 +960,11 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
             Value::FunLit(input_name, output_expr) => {
                 let output_expr = self.quote_closure(output_expr);
 
-                Term::FunLit(*input_name, self.scope.to_scope(output_expr))
+                Term::FunLit(
+                    Span::from_value(&value),
+                    *input_name,
+                    self.scope.to_scope(output_expr),
+                )
             }
 
             Value::RecordType(labels, types) => {

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -1000,12 +1000,12 @@ impl<'in_arena, 'out_arena, 'env> QuoteContext<'in_arena, 'out_arena, 'env> {
         match value.as_ref() {
             Value::Stuck(span, head, spine) => {
                 let head_expr = match head {
-                    Head::Prim(prim) => Term::Prim(Span::Empty, *prim),
+                    Head::Prim(prim) => Term::Prim(*span, *prim),
                     Head::RigidVar(var) => {
                         // FIXME: Unwrap
-                        Term::RigidVar(Span::Empty, self.rigid_exprs.global_to_local(*var).unwrap())
+                        Term::RigidVar(*span, self.rigid_exprs.global_to_local(*var).unwrap())
                     }
-                    Head::FlexibleVar(var) => Term::FlexibleVar(Span::Empty, *var),
+                    Head::FlexibleVar(var) => Term::FlexibleVar(*span, *var),
                 };
 
                 spine.iter().fold(head_expr, |head_expr, elim| match elim {

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -7,8 +7,7 @@ use std::path::Path;
 
 use crate::core::binary;
 use crate::core::binary::{BufferError, ReadError};
-use crate::core::semantics::Spanned;
-use crate::source::{ByteRange, FileId, Span};
+use crate::source::{ByteRange, FileId, Span, Spanned};
 use crate::surface::{self, elaboration};
 use crate::{StringInterner, BUG_REPORT_URL};
 

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use crate::core::binary;
 use crate::core::binary::{BufferError, ReadError};
-use crate::core::semantics::SpanValue;
+use crate::core::semantics::Spanned;
 use crate::source::{ByteRange, FileId, Span};
 use crate::surface::{self, elaboration};
 use crate::{StringInterner, BUG_REPORT_URL};
@@ -301,7 +301,10 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         let surface_format = self.parse_term(format_file_id);
         let format_term = context.check(
             &surface_format,
-            &SpanValue(Span::Empty, Arc::new(Value::prim(Prim::FormatType, []))),
+            &Spanned {
+                span: Span::Empty,
+                inner: Arc::new(Value::prim(Prim::FormatType, [])),
+            },
         );
 
         // Emit errors we might have found during elaboration

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -301,7 +301,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         let surface_format = self.parse_term(format_file_id);
         let format_term = context.check(
             &surface_format,
-            &SpanValue::fixme(Arc::new(Value::prim(Prim::FormatType, []))),
+            &SpanValue(Span::Empty, Arc::new(Value::prim(Prim::FormatType, []))),
         );
 
         // Emit errors we might have found during elaboration

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -462,8 +462,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
             ReadError::UnwrappedNone(_) => Diagnostic::error()
                 .with_message(err.to_string())
                 .with_notes(vec![format!("option_unwrap was called on a none value.")]),
-            ReadError::BufferError(err) => self.buffer_error_to_diagnostic(err, Span::Empty),
-            ReadError::BufferErrorWithSpan(span, err) => self.buffer_error_to_diagnostic(err, span),
+            ReadError::BufferError(span, err) => self.buffer_error_to_diagnostic(err, span),
             ReadError::InvalidFormat(span) | ReadError::InvalidValue(span) => Diagnostic::bug()
                 .with_message(format!("unexpected error '{}'", err))
                 .with_labels(

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -300,10 +300,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         let surface_format = self.parse_term(format_file_id);
         let format_term = context.check(
             &surface_format,
-            &Spanned {
-                span: Span::Empty,
-                inner: Arc::new(Value::prim(Prim::FormatType, [])),
-            },
+            &Spanned::new(Span::Empty, Arc::new(Value::prim(Prim::FormatType, []))),
         );
 
         // Emit errors we might have found during elaboration

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -436,8 +436,14 @@ impl From<ReadError> for Diagnostic<usize> {
                 .with_notes(vec![format!(
                     "A fail format was encountered when reading this file."
                 )]),
-            ReadError::CondFailure => Diagnostic::error()
+            ReadError::CondFailure(span) => Diagnostic::error()
                 .with_message(err.to_string())
+                .with_labels(
+                    IntoIterator::into_iter([primary_label(&span)])
+                        .into_iter()
+                        .flatten()
+                        .collect(),
+                )
                 .with_notes(vec![format!(
                     "The predicate on a conditional format did not succeed."
                 )]),

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -9,9 +9,7 @@ use crate::core::binary;
 use crate::core::binary::ReadError;
 use crate::source::{ByteRange, FileId, Span};
 use crate::surface::{self, elaboration};
-use crate::StringInterner;
-
-const BUG_REPORT_URL: &str = concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new");
+use crate::{StringInterner, BUG_REPORT_URL};
 
 #[derive(Debug, Copy, Clone)]
 pub enum Status {

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -5,9 +5,9 @@ use std::cell::RefCell;
 use std::io::Read;
 use std::path::Path;
 
+use crate::core::binary;
 use crate::core::binary::ReadError;
-use crate::core::{binary, Span};
-use crate::source::{ByteRange, FileId};
+use crate::source::{ByteRange, FileId, Span};
 use crate::surface::{self, elaboration};
 use crate::StringInterner;
 

--- a/fathom/src/lib.rs
+++ b/fathom/src/lib.rs
@@ -12,6 +12,8 @@ pub mod surface;
 // Top level driver
 mod driver;
 
+pub const BUG_REPORT_URL: &str = concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new");
+
 // Public exports
 pub use driver::{Driver, Status};
 

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -36,6 +36,14 @@ impl<T> Spanned<T> {
     }
 }
 
+impl<T> Deref for Spanned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub enum Span {
     Range(ByteRange),

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -1,9 +1,41 @@
+use std::ops::Deref;
+
 ///! Types related to source files.
 
 /// File id.
 pub type FileId = usize; // TODO: use wrapper struct
 
-// TODO: Better name?
+#[derive(Debug, Clone)]
+pub struct Spanned<T> {
+    pub span: Span,
+    pub inner: T,
+}
+
+impl<T> Spanned<T> {
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn empty(inner: T) -> Self {
+        Spanned {
+            span: Span::Empty,
+            inner,
+        }
+    }
+
+    /// Merge the supplied span and the span of value and return value wrapped in that span.
+    pub fn merge(span: Span, other: Spanned<T>) -> Spanned<T> {
+        let Spanned {
+            span: other_span,
+            inner,
+        } = other;
+        Spanned {
+            span: span.merge(&other_span),
+            inner,
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub enum Span {
     Range(ByteRange),
@@ -13,6 +45,13 @@ pub enum Span {
 impl Span {
     pub const fn fixme() -> Span {
         Span::Empty
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        match (self, other) {
+            (Span::Range(a), Span::Range(b)) => a.merge(b).map(Span::Range).unwrap_or(Span::Empty),
+            (_, _) => Span::Empty,
+        }
     }
 }
 

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -53,6 +53,18 @@ impl ByteRange {
     pub const fn end(&self) -> BytePos {
         self.end
     }
+
+    pub fn merge(&self, other: &ByteRange) -> Option<ByteRange> {
+        if self.file_id == other.file_id {
+            Some(ByteRange::new(
+                self.file_id,
+                self.start.min(other.start),
+                self.end.max(other.end),
+            ))
+        } else {
+            None
+        }
+    }
 }
 
 impl Into<std::ops::Range<usize>> for ByteRange {

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -14,16 +14,6 @@ impl Span {
     pub const fn fixme() -> Span {
         Span::Empty
     }
-
-    pub fn range_todo(self) {
-        // placeholder function for when we should build a span from a ByteRange
-        // but the current location is expecting a range of (). Eventually this
-        // should be renamed range and return Option<ByteRange>?
-        // match self {
-        //     Span::Range(range) => Some(range),
-        //     Span::Empty => None
-        // }
-    }
 }
 
 impl From<&ByteRange> for Span {

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -3,6 +3,35 @@
 /// File id.
 pub type FileId = usize; // TODO: use wrapper struct
 
+// TODO: Better name?
+#[derive(Debug, Copy, Clone)]
+pub enum Span {
+    Range(ByteRange),
+    Empty,
+}
+
+impl Span {
+    pub const fn fixme() -> Span {
+        Span::Empty
+    }
+
+    pub fn range_todo(self) {
+        // placeholder function for when we should build a span from a ByteRange
+        // but the current location is expecting a range of (). Eventually this
+        // should be renamed range and return Option<ByteRange>?
+        // match self {
+        //     Span::Range(range) => Some(range),
+        //     Span::Empty => None
+        // }
+    }
+}
+
+impl From<&ByteRange> for Span {
+    fn from(range: &ByteRange) -> Self {
+        Span::Range(*range)
+    }
+}
+
 /// Byte offsets into source files.
 pub type BytePos = usize;
 

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 ///! Types related to source files.
 
@@ -7,13 +7,13 @@ pub type FileId = usize; // TODO: use wrapper struct
 
 #[derive(Debug, Clone)]
 pub struct Spanned<T> {
-    pub span: Span,
-    pub inner: T,
+    span: Span,
+    inner: T,
 }
 
 impl<T> Spanned<T> {
-    pub fn span(&self) -> Span {
-        self.span
+    pub fn new(span: Span, inner: T) -> Self {
+        Spanned { span, inner }
     }
 
     pub fn empty(inner: T) -> Self {
@@ -23,7 +23,11 @@ impl<T> Spanned<T> {
         }
     }
 
-    /// Merge the supplied span and the span of value and return value wrapped in that span.
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    /// Merge the supplied span with the span of `other` and return `other` wrapped in that span.
     pub fn merge(span: Span, other: Spanned<T>) -> Spanned<T> {
         let Spanned {
             span: other_span,
@@ -41,6 +45,12 @@ impl<T> Deref for Spanned<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl<T> DerefMut for Spanned<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
     }
 }
 

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -3,8 +3,9 @@
 use scoped_arena::Scope;
 use std::cell::RefCell;
 
-use crate::core::{Span, UIntStyle};
+use crate::core::UIntStyle;
 use crate::env::{self, EnvLen, GlobalVar, LocalVar, UniqueEnv};
+use crate::source::Span;
 use crate::surface::elaboration::FlexSource;
 use crate::surface::{BinOp, ExprField, FormatField, Item, Module, Pattern, Term, TypeField};
 use crate::{core, StringId, StringInterner};

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -241,7 +241,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::RecordLiteral((), scope.to_scope_from_iter(expr_fields))
             }
-            core::Term::ArrayLit(elem_exprs) => {
+            core::Term::ArrayLit(_span, elem_exprs) => {
                 let scope = self.scope;
                 let elem_exprs = elem_exprs.iter().map(|elem_exprs| self.check(elem_exprs));
 
@@ -461,7 +461,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::Proj((), self.scope.to_scope(head_expr), ((), *label))
             }
-            core::Term::ArrayLit(elem_exprs) => {
+            core::Term::ArrayLit(_span, elem_exprs) => {
                 let scope = self.scope;
                 let elem_exprs = elem_exprs.iter().map(|elem_exprs| self.check(elem_exprs));
 

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -365,7 +365,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_expr),
                 )
             }
-            core::Term::Universe => Term::Universe(()),
+            core::Term::Universe(_span) => Term::Universe(()),
             core::Term::FunType(_, input_type, output_type)
                 if !output_type.contains_free(LocalVar::last()) =>
             {

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -477,7 +477,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             core::Term::FormatRecord(_span, labels, formats) => {
                 Term::FormatRecord((), self.synth_format_fields(labels, formats))
             }
-            core::Term::FormatCond(label, format, cond) => {
+            core::Term::FormatCond(_span, label, format, cond) => {
                 let format = self.check(format);
                 self.push_rigid(Some(*label));
                 let cond = self.check(cond);
@@ -604,7 +604,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 }
                 // Use field refinements when `format` is a conditional format
                 // that binds the same name as the current field label.
-                core::Term::FormatCond(name, format, pred) if label == *name => {
+                core::Term::FormatCond(_span, name, format, pred) if label == *name => {
                     let format = self.check(format);
                     self.push_rigid(Some(label));
                     let pred = self.check(pred);

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -265,7 +265,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::Const::Pos(number) => self.check_number_literal(number),
                 core::Const::Ref(number) => self.check_number_literal(number),
             },
-            core::Term::ConstMatch(head_expr, branches, default_expr) => {
+            core::Term::ConstMatch(_span, head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
                 match default_expr {
                     Some(default_expr) => {
@@ -516,7 +516,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::Const::Pos(number) => self.synth_number_literal(number, core::Prim::PosType),
                 core::Const::Ref(number) => self.synth_number_literal(number, core::Prim::RefType),
             },
-            core::Term::ConstMatch(head_expr, branches, default_expr) => {
+            core::Term::ConstMatch(_span, head_expr, branches, default_expr) => {
                 let head_expr = self.synth(head_expr);
                 match default_expr {
                     Some(default_expr) => {

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -410,7 +410,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 )
             }
             core::Term::FunApp(_span, head_expr, input_expr) => match head_expr {
-                core::Term::FunApp(_span, core::Term::Prim(prim), lhs)
+                core::Term::FunApp(_span, core::Term::Prim(_span2, prim), lhs)
                     if prim_to_bin_op(prim).is_some() =>
                 {
                     // unwrap is safe due to is_some check above
@@ -492,7 +492,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             core::Term::FormatOverlap(_span, labels, formats) => {
                 Term::FormatOverlap((), self.synth_format_fields(labels, formats))
             }
-            core::Term::Prim(prim) => self.synth_prim(*prim),
+            core::Term::Prim(_span, prim) => self.synth_prim(*prim),
             core::Term::ConstLit(r#const) => match r#const {
                 core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
                 core::Const::U8(number, style) => {
@@ -589,7 +589,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 // Distill succeed formats back to computed formats
                 core::Term::FunApp(
                     _,
-                    core::Term::FunApp(_, core::Term::Prim(FormatSucceed), r#type),
+                    core::Term::FunApp(_span, core::Term::Prim(_prim_span, FormatSucceed), r#type),
                     expr,
                 ) => {
                     let r#type = self.check(r#type);

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -407,8 +407,8 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_expr),
                 )
             }
-            core::Term::FunApp(head_expr, input_expr) => match head_expr {
-                core::Term::FunApp(core::Term::Prim(prim), lhs)
+            core::Term::FunApp(_span, head_expr, input_expr) => match head_expr {
+                core::Term::FunApp(_span, core::Term::Prim(prim), lhs)
                     if prim_to_bin_op(prim).is_some() =>
                 {
                     // unwrap is safe due to is_some check above
@@ -586,7 +586,8 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             (self.scope).to_scope_from_iter(core_fields.map(|(label, format)| match format {
                 // Distill succeed formats back to computed formats
                 core::Term::FunApp(
-                    core::Term::FunApp(core::Term::Prim(FormatSucceed), r#type),
+                    _,
+                    core::Term::FunApp(_, core::Term::Prim(FormatSucceed), r#type),
                     expr,
                 ) => {
                     let r#type = self.check(r#type);

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -247,7 +247,9 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::ArrayLiteral((), scope.to_scope_from_iter(elem_exprs))
             }
-            core::Term::FormatRecord(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
+            core::Term::FormatRecord(_span, labels, _) if labels.is_empty() => {
+                Term::UnitLiteral(())
+            }
             core::Term::ConstLit(r#const) => match r#const {
                 core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
                 core::Const::U8(number, style) => self.check_number_literal_styled(number, *style),
@@ -468,11 +470,11 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 // FIXME: Type annotations
                 Term::ArrayLiteral((), scope.to_scope_from_iter(elem_exprs))
             }
-            core::Term::FormatRecord(labels, _) if labels.is_empty() => {
+            core::Term::FormatRecord(_span, labels, _) if labels.is_empty() => {
                 let format_type = self.synth_prim(core::Prim::FormatType);
                 Term::Ann((), &Term::UnitLiteral(()), self.scope.to_scope(format_type))
             }
-            core::Term::FormatRecord(labels, formats) => {
+            core::Term::FormatRecord(_span, labels, formats) => {
                 Term::FormatRecord((), self.synth_format_fields(labels, formats))
             }
             core::Term::FormatCond(label, format, cond) => {

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -489,7 +489,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(cond),
                 )
             }
-            core::Term::FormatOverlap(labels, formats) => {
+            core::Term::FormatOverlap(_span, labels, formats) => {
                 Term::FormatOverlap((), self.synth_format_fields(labels, formats))
             }
             core::Term::Prim(prim) => self.synth_prim(*prim),

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -201,7 +201,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 // Avoid adding extraneous type annotations!
                 self.check(expr)
             }
-            core::Term::Let(def_name, def_type, def_expr, output_expr) => {
+            core::Term::Let(_span, def_name, def_type, def_expr, output_expr) => {
                 let def_type = self.synth(def_type);
                 let def_expr = self.check(def_expr);
 
@@ -349,7 +349,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::Ann((), self.scope.to_scope(expr), self.scope.to_scope(r#type))
             }
-            core::Term::Let(def_name, def_type, def_expr, output_expr) => {
+            core::Term::Let(_span, def_name, def_type, def_expr, output_expr) => {
                 let def_type = self.synth(def_type);
                 let def_expr = self.check(def_expr);
 

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -217,7 +217,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_expr),
                 )
             }
-            core::Term::FunLit(input_name, output_expr) => {
+            core::Term::FunLit(_span, input_name, output_expr) => {
                 let input_name = self.push_rigid(*input_name);
                 let output_expr = self.check(output_expr);
                 self.pop_rigid();
@@ -395,7 +395,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_type),
                 )
             }
-            core::Term::FunLit(input_name, output_expr) => {
+            core::Term::FunLit(_span, input_name, output_expr) => {
                 let input_name = self.push_rigid(*input_name);
                 let output_expr = self.synth(output_expr);
                 self.pop_rigid();

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -366,7 +366,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 )
             }
             core::Term::Universe(_span) => Term::Universe(()),
-            core::Term::FunType(_, input_type, output_type)
+            core::Term::FunType(_span, _, input_type, output_type)
                 if !output_type.contains_free(LocalVar::last()) =>
             {
                 let input_type = self.check(input_type);
@@ -381,7 +381,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_type),
                 )
             }
-            core::Term::FunType(input_name, input_type, output_type) => {
+            core::Term::FunType(_span, input_name, input_type, output_type) => {
                 let input_type = self.check(input_type);
 
                 let input_name = self.push_rigid(*input_name);

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -456,7 +456,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 // TODO: type annotations?
                 Term::RecordLiteral((), scope.to_scope_from_iter(expr_fields))
             }
-            core::Term::RecordProj(head_expr, label) => {
+            core::Term::RecordProj(_span, head_expr, label) => {
                 let head_expr = self.synth(head_expr);
 
                 Term::Proj((), self.scope.to_scope(head_expr), ((), *label))

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -230,8 +230,8 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 )
             }
             core::Term::RecordType(_span, labels, _) if labels.is_empty() => Term::UnitLiteral(()),
-            core::Term::RecordLit(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
-            core::Term::RecordLit(labels, exprs) => {
+            core::Term::RecordLit(_span, labels, _) if labels.is_empty() => Term::UnitLiteral(()),
+            core::Term::RecordLit(_span, labels, exprs) => {
                 let scope = self.scope;
                 let expr_fields =
                     Iterator::zip(labels.iter(), exprs.iter()).map(|(label, expr)| ExprField {
@@ -444,8 +444,8 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 Term::RecordType((), type_fields)
             }
-            core::Term::RecordLit(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
-            core::Term::RecordLit(labels, exprs) => {
+            core::Term::RecordLit(_span, labels, _) if labels.is_empty() => Term::UnitLiteral(()),
+            core::Term::RecordLit(_span, labels, exprs) => {
                 let scope = self.scope;
                 let expr_fields =
                     Iterator::zip(labels.iter(), exprs.iter()).map(|(label, expr)| ExprField {

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -197,7 +197,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
     /// Distill a core term into a surface term, in a 'checkable' context.
     pub fn check(&mut self, core_term: &core::Term<'_>) -> Term<'arena, ()> {
         match core_term {
-            core::Term::Ann(expr, _) => {
+            core::Term::Ann(_span, expr, _) => {
                 // Avoid adding extraneous type annotations!
                 self.check(expr)
             }
@@ -343,7 +343,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 head_expr
             }
-            core::Term::Ann(expr, r#type) => {
+            core::Term::Ann(_span, expr, r#type) => {
                 let r#type = self.check(r#type);
                 let expr = self.check(expr);
 

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -250,7 +250,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
             core::Term::FormatRecord(_span, labels, _) if labels.is_empty() => {
                 Term::UnitLiteral(())
             }
-            core::Term::ConstLit(r#const) => match r#const {
+            core::Term::ConstLit(_span, r#const) => match r#const {
                 core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
                 core::Const::U8(number, style) => self.check_number_literal_styled(number, *style),
                 core::Const::U16(number, style) => self.check_number_literal_styled(number, *style),
@@ -493,7 +493,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 Term::FormatOverlap((), self.synth_format_fields(labels, formats))
             }
             core::Term::Prim(_span, prim) => self.synth_prim(*prim),
-            core::Term::ConstLit(r#const) => match r#const {
+            core::Term::ConstLit(_span, r#const) => match r#const {
                 core::Const::Bool(boolean) => Term::BooleanLiteral((), *boolean),
                 core::Const::U8(number, style) => {
                     self.synth_number_literal_styled(number, *style, core::Prim::U8Type)

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -229,7 +229,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.scope.to_scope(output_expr),
                 )
             }
-            core::Term::RecordType(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
+            core::Term::RecordType(_span, labels, _) if labels.is_empty() => Term::UnitLiteral(()),
             core::Term::RecordLit(labels, _) if labels.is_empty() => Term::UnitLiteral(()),
             core::Term::RecordLit(labels, exprs) => {
                 let scope = self.scope;
@@ -425,17 +425,17 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     )
                 }
             },
-            core::Term::RecordType(labels, _) if labels.is_empty() => {
+            core::Term::RecordType(_span, labels, _) if labels.is_empty() => {
                 Term::Ann((), &Term::UnitLiteral(()), &Term::Universe(()))
             }
-            core::Term::RecordType(labels, types) => {
+            core::Term::RecordType(_span, labels, types) => {
                 let initial_rigid_len = self.rigid_len();
                 let type_fields = (self.scope).to_scope_from_iter(
                     Iterator::zip(labels.iter(), types.iter()).map(|(label, r#type)| {
                         let r#type = self.check(r#type);
                         self.push_rigid(Some(*label));
                         TypeField {
-                            label: ((), *label),
+                            label: ((), *label), // TODO: range from span
                             type_: r#type,
                         }
                     }),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -2496,6 +2496,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                                     self.rigid_env.pop();
 
                                     return core::Term::ConstMatch(
+                                        (&range).into(),
                                         scrutinee_expr,
                                         self.scope.to_scope_from_iter(branches.into_iter()),
                                         Some(self.scope.to_scope(default_expr)),
@@ -2507,6 +2508,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                         if num_constructors == Some(branches.len()) {
                             // The absence of a default constructor is ok as the match was exhaustive.
                             return core::Term::ConstMatch(
+                                (&range).into(),
                                 scrutinee_expr,
                                 self.scope.to_scope_from_iter(branches.into_iter()),
                                 None,

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1520,7 +1520,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 };
 
                 match constant {
-                    Some(constant) => core::Term::ConstLit(constant),
+                    Some(constant) => core::Term::ConstLit(range.into(), constant),
                     None => core::Term::Prim(range.into(), Prim::ReportedError),
                 }
             }
@@ -1556,7 +1556,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 };
 
                 match constant {
-                    Some(constant) => core::Term::ConstLit(constant),
+                    Some(constant) => core::Term::ConstLit(range.into(), constant),
                     None => core::Term::Prim(range.into(), Prim::ReportedError),
                 }
             }
@@ -1891,9 +1891,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 self.push_message(Message::AmbiguousNumericLiteral { range: *range });
                 self.synth_reported_error(*range)
             }
-            Term::BooleanLiteral(_range, val) => {
+            Term::BooleanLiteral(range, val) => {
                 let bool_type = Arc::new(Value::prim(Prim::BoolType, []));
-                (core::Term::ConstLit(Const::Bool(*val)), bool_type)
+                (
+                    core::Term::ConstLit(range.into(), Const::Bool(*val)),
+                    bool_type,
+                )
             }
             Term::FormatRecord(range, format_fields) => {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1455,10 +1455,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 let len = match len_value.map(<_>::as_ref) {
                     None => Some(elem_exprs.len() as u64),
-                    Some(Value::ConstLit(Const::U8(len, _))) => Some(*len as u64),
-                    Some(Value::ConstLit(Const::U16(len, _))) => Some(*len as u64),
-                    Some(Value::ConstLit(Const::U32(len, _))) => Some(*len as u64),
-                    Some(Value::ConstLit(Const::U64(len, _))) => Some(*len as u64),
+                    Some(Value::ConstLit(_, Const::U8(len, _))) => Some(*len as u64),
+                    Some(Value::ConstLit(_, Const::U16(len, _))) => Some(*len as u64),
+                    Some(Value::ConstLit(_, Const::U32(len, _))) => Some(*len as u64),
+                    Some(Value::ConstLit(_, Const::U64(len, _))) => Some(*len as u64),
                     Some(Value::Stuck(span, Head::Prim(Prim::ReportedError), _)) => {
                         return core::Term::Prim(*span, Prim::ReportedError); // FIXME: should it use span here or range?
                     }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -118,12 +118,12 @@ impl<'arena> RigidEnv<'arena> {
         use crate::core::Prim::*;
         use crate::core::Term;
 
-        const VAR0: Term<'_> = Term::RigidVar(Span::fixme(), env::LocalVar::last());
-        const VAR1: Term<'_> = Term::RigidVar(Span::fixme(), env::LocalVar::last().prev());
-        const VAR2: Term<'_> = Term::RigidVar(Span::fixme(), env::LocalVar::last().prev().prev());
+        const VAR0: Term<'_> = Term::RigidVar(Span::Empty, env::LocalVar::last());
+        const VAR1: Term<'_> = Term::RigidVar(Span::Empty, env::LocalVar::last().prev());
+        const VAR2: Term<'_> = Term::RigidVar(Span::Empty, env::LocalVar::last().prev().prev());
         const VAR3: Term<'_> =
-            Term::RigidVar(Span::fixme(), env::LocalVar::last().prev().prev().prev());
-        const UNIVERSE: Term<'_> = Term::Universe(Span::fixme());
+            Term::RigidVar(Span::Empty, env::LocalVar::last().prev().prev().prev());
+        const UNIVERSE: Term<'_> = Term::Universe(Span::Empty);
         const FORMAT_TYPE: Term<'_> = Term::Prim(Span::Empty, FormatType);
         const BOOL_TYPE: Term<'_> = Term::Prim(Span::Empty, BoolType);
         const U8_TYPE: Term<'_> = Term::Prim(Span::Empty, U8Type);

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -26,10 +26,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::alloc::SliceVec;
-use crate::core::semantics::{self, ArcValue, Closure, Head, Spanned, Telescope, Value};
+use crate::core::semantics::{self, ArcValue, Closure, Head, Telescope, Value};
 use crate::core::{self, binary, Const, Prim, UIntStyle};
 use crate::env::{self, EnvLen, GlobalVar, SharedEnv, SliceEnv, UniqueEnv};
-use crate::source::{ByteRange, Span};
+use crate::source::{ByteRange, Span, Spanned};
 use crate::surface::elaboration::reporting::Message;
 use crate::surface::{distillation, pretty, BinOp, FormatField, Item, Module, Pattern, Term};
 use crate::{StringId, StringInterner};

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1375,7 +1375,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
     ) -> core::Term<'arena> {
         let expected_type = self.elim_context().force(expected_type);
 
-        match (surface_term, expected_type.inner.as_ref()) {
+        match (surface_term, expected_type.as_ref()) {
             (Term::Let(range, def_pattern, def_type, def_expr, output_expr), _) => {
                 let (def_pattern, def_type_value) = self.synth_ann_pattern(def_pattern, *def_type);
                 let def_type = self.quote_context(self.scope).quote(&def_type_value); // FIXME: avoid requote if possible?
@@ -1486,7 +1486,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     }
                 };
 
-                let len = match len_value.map(|val| (val.span(), val.inner.as_ref())) {
+                let len = match len_value.map(|val| (val.span(), val.as_ref())) {
                     None => Some(elem_exprs.len() as u64),
                     Some((_, Value::ConstLit(Const::U8(len, _)))) => Some(*len as u64),
                     Some((_, Value::ConstLit(Const::U16(len, _)))) => Some(*len as u64),
@@ -1766,7 +1766,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 // Ensure that the head type is a function type
                 let head_type = self.elim_context().force(&head_type);
-                let (head_expr, input_type, output_type) = match head_type.inner.as_ref() {
+                let (head_expr, input_type, output_type) = match head_type.as_ref() {
                     // The simple case - it's easy to see that it is a function type!
                     Value::FunType(_, input_type, output_type) => {
                         (head_expr, input_type.clone(), output_type.clone())
@@ -1879,7 +1879,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let head_expr_value = self.eval_context().eval(&head_expr);
 
                 let head_type = self.elim_context().force(&head_type);
-                match head_type.inner.as_ref() {
+                match head_type.as_ref() {
                     Value::RecordType(labels, types) => {
                         let mut labels = labels.iter();
                         let mut types = types.clone();

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1416,7 +1416,9 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 core::Term::RecordLit(labels, exprs.into())
             }
-            (Term::UnitLiteral(_), Value::Universe) => core::Term::RecordType(&[], &[]),
+            (Term::UnitLiteral(range), Value::Universe) => {
+                core::Term::RecordType(range.into(), &[], &[])
+            }
             (Term::UnitLiteral(_), _)
                 if matches!(
                     expected_type.match_prim_spine(),
@@ -1799,7 +1801,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 self.rigid_env.truncate(initial_rigid_len);
 
-                (core::Term::RecordType(labels, types.into()), universe)
+                (
+                    core::Term::RecordType(range.into(), labels, types.into()),
+                    universe,
+                )
             }
             Term::RecordLiteral(range, expr_fields) => {
                 let (labels, expr_fields) =

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -201,7 +201,7 @@ impl<'arena> RigidEnv<'arena> {
                 &Term::FunType(
                     Span::Empty,
                     None,
-                    &Term::FunApp(&Term::Prim(RefType), &VAR0),
+                    &Term::FunApp(Span::Empty, &Term::Prim(RefType), &VAR0),
                     &FORMAT_TYPE,
                 ),
             ),
@@ -228,7 +228,7 @@ impl<'arena> RigidEnv<'arena> {
                 &Term::FunType(
                     Span::Empty,
                     None,
-                    &Term::FunApp(&Term::Prim(OptionType), &VAR0),
+                    &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR0),
                     &FORMAT_TYPE,
                 ),
             ),
@@ -378,7 +378,7 @@ impl<'arena> RigidEnv<'arena> {
                     Span::Empty,
                     None,
                     &VAR0,
-                    &Term::FunApp(&Term::Prim(OptionType), &VAR1),
+                    &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR1),
                 ),
             ),
         );
@@ -390,7 +390,7 @@ impl<'arena> RigidEnv<'arena> {
                 Span::Empty,
                 env.name("A"),
                 &UNIVERSE,
-                &Term::FunApp(&Term::Prim(OptionType), &VAR0),
+                &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR0),
             ),
         );
         env.define_prim(
@@ -416,8 +416,8 @@ impl<'arena> RigidEnv<'arena> {
                             scope.to_scope(core::Term::FunType(
                                 Span::Empty,
                                 None,
-                                &Term::FunApp(&Term::Prim(OptionType), &VAR3), // Option A@3
-                                &VAR3,                                         // B@3
+                                &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR3), // Option A@3
+                                &VAR3,                                                      // B@3
                             )),
                         )),
                     )),
@@ -445,10 +445,11 @@ impl<'arena> RigidEnv<'arena> {
                             None,
                             // ArrayN len@2 A@1
                             scope.to_scope(Term::FunApp(
-                                scope.to_scope(Term::FunApp(array_type, &VAR2)),
+                                Span::Empty,
+                                scope.to_scope(Term::FunApp(Span::Empty, array_type, &VAR2)),
                                 &VAR1,
                             )),
-                            &Term::FunApp(&Term::Prim(OptionType), &VAR2), // Option A@2
+                            &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR2), // Option A@2
                         )),
                     )),
                 )),
@@ -1774,6 +1775,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 // Construct the final function application
                 let fun_app = core::Term::FunApp(
+                    range.into(),
                     self.scope.to_scope(head_expr),
                     self.scope.to_scope(input_expr),
                 );
@@ -2063,7 +2065,9 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
         };
 
         let fun_app = core::Term::FunApp(
+            (&range).into(),
             self.scope.to_scope(core::Term::FunApp(
+                (&range).into(), // FIXME: Should this be a sub-range of range (from one of the terms)?
                 self.scope.to_scope(fun),
                 self.scope.to_scope(lhs_expr),
             )),
@@ -2145,7 +2149,9 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     };
 
                     let format = core::Term::FunApp(
+                        (&range).into(),
                         self.scope.to_scope(core::Term::FunApp(
+                            (&range).into(), // FIXME: sub-range?
                             self.scope.to_scope(core::Term::Prim(Prim::FormatSucceed)),
                             self.scope.to_scope(r#type),
                         )),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -124,21 +124,21 @@ impl<'arena> RigidEnv<'arena> {
         const VAR3: Term<'_> =
             Term::RigidVar(Span::fixme(), env::LocalVar::last().prev().prev().prev());
         const UNIVERSE: Term<'_> = Term::Universe(Span::fixme());
-        const FORMAT_TYPE: Term<'_> = Term::Prim(FormatType);
-        const BOOL_TYPE: Term<'_> = Term::Prim(BoolType);
-        const U8_TYPE: Term<'_> = Term::Prim(U8Type);
-        const U16_TYPE: Term<'_> = Term::Prim(U16Type);
-        const U32_TYPE: Term<'_> = Term::Prim(U32Type);
-        const U64_TYPE: Term<'_> = Term::Prim(U64Type);
-        const S8_TYPE: Term<'_> = Term::Prim(S8Type);
-        const S16_TYPE: Term<'_> = Term::Prim(S16Type);
-        const S32_TYPE: Term<'_> = Term::Prim(S32Type);
-        const S64_TYPE: Term<'_> = Term::Prim(S64Type);
-        const ARRAY8_TYPE: Term<'_> = Term::Prim(Array8Type);
-        const ARRAY16_TYPE: Term<'_> = Term::Prim(Array16Type);
-        const ARRAY32_TYPE: Term<'_> = Term::Prim(Array32Type);
-        const ARRAY64_TYPE: Term<'_> = Term::Prim(Array64Type);
-        const POS_TYPE: Term<'_> = Term::Prim(PosType);
+        const FORMAT_TYPE: Term<'_> = Term::Prim(Span::Empty, FormatType);
+        const BOOL_TYPE: Term<'_> = Term::Prim(Span::Empty, BoolType);
+        const U8_TYPE: Term<'_> = Term::Prim(Span::Empty, U8Type);
+        const U16_TYPE: Term<'_> = Term::Prim(Span::Empty, U16Type);
+        const U32_TYPE: Term<'_> = Term::Prim(Span::Empty, U32Type);
+        const U64_TYPE: Term<'_> = Term::Prim(Span::Empty, U64Type);
+        const S8_TYPE: Term<'_> = Term::Prim(Span::Empty, S8Type);
+        const S16_TYPE: Term<'_> = Term::Prim(Span::Empty, S16Type);
+        const S32_TYPE: Term<'_> = Term::Prim(Span::Empty, S32Type);
+        const S64_TYPE: Term<'_> = Term::Prim(Span::Empty, S64Type);
+        const ARRAY8_TYPE: Term<'_> = Term::Prim(Span::Empty, Array8Type);
+        const ARRAY16_TYPE: Term<'_> = Term::Prim(Span::Empty, Array16Type);
+        const ARRAY32_TYPE: Term<'_> = Term::Prim(Span::Empty, Array32Type);
+        const ARRAY64_TYPE: Term<'_> = Term::Prim(Span::Empty, Array64Type);
+        const POS_TYPE: Term<'_> = Term::Prim(Span::Empty, PosType);
 
         let mut env = RigidEnvBuilder::new(interner, scope);
 
@@ -201,7 +201,7 @@ impl<'arena> RigidEnv<'arena> {
                 &Term::FunType(
                     Span::Empty,
                     None,
-                    &Term::FunApp(Span::Empty, &Term::Prim(RefType), &VAR0),
+                    &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, RefType), &VAR0),
                     &FORMAT_TYPE,
                 ),
             ),
@@ -228,7 +228,7 @@ impl<'arena> RigidEnv<'arena> {
                 &Term::FunType(
                     Span::Empty,
                     None,
-                    &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR0),
+                    &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR0),
                     &FORMAT_TYPE,
                 ),
             ),
@@ -378,7 +378,7 @@ impl<'arena> RigidEnv<'arena> {
                     Span::Empty,
                     None,
                     &VAR0,
-                    &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR1),
+                    &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR1),
                 ),
             ),
         );
@@ -390,7 +390,7 @@ impl<'arena> RigidEnv<'arena> {
                 Span::Empty,
                 env.name("A"),
                 &UNIVERSE,
-                &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR0),
+                &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR0),
             ),
         );
         env.define_prim(
@@ -416,8 +416,12 @@ impl<'arena> RigidEnv<'arena> {
                             scope.to_scope(core::Term::FunType(
                                 Span::Empty,
                                 None,
-                                &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR3), // Option A@3
-                                &VAR3,                                                      // B@3
+                                &Term::FunApp(
+                                    Span::Empty,
+                                    &Term::Prim(Span::Empty, OptionType),
+                                    &VAR3,
+                                ), // Option A@3
+                                &VAR3, // B@3
                             )),
                         )),
                     )),
@@ -449,7 +453,7 @@ impl<'arena> RigidEnv<'arena> {
                                 scope.to_scope(Term::FunApp(Span::Empty, array_type, &VAR2)),
                                 &VAR1,
                             )),
-                            &Term::FunApp(Span::Empty, &Term::Prim(OptionType), &VAR2), // Option A@2
+                            &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR2), // Option A@2
                         )),
                     )),
                 )),
@@ -986,7 +990,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
     //       coercions to the core language.
     fn convert(
         &mut self,
-        range: ByteRange, // NOTE: could be removed if source info is added to `core::Term`
+        range: ByteRange, // TODO: could be removed if source info is added to `core::Term`
         expr: core::Term<'arena>,
         type0: &ArcValue<'arena>,
         type1: &ArcValue<'arena>,
@@ -1002,7 +1006,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     rhs,
                     error,
                 });
-                core::Term::Prim(Prim::ReportedError)
+                core::Term::Prim((&range).into(), Prim::ReportedError)
             }
         }
     }
@@ -1398,7 +1402,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             .collect(),
                         type_labels: labels.iter().copied().collect(),
                     });
-                    return core::Term::Prim(Prim::ReportedError);
+                    return core::Term::Prim(range.into(), Prim::ReportedError);
                 }
 
                 let mut types = types.clone();
@@ -1436,14 +1440,16 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     Some((Prim::Array16Type, [App(len), App(elem_type)])) => (Some(len), elem_type),
                     Some((Prim::Array32Type, [App(len), App(elem_type)])) => (Some(len), elem_type),
                     Some((Prim::Array64Type, [App(len), App(elem_type)])) => (Some(len), elem_type),
-                    Some((Prim::ReportedError, _)) => return core::Term::Prim(Prim::ReportedError),
+                    Some((Prim::ReportedError, _)) => {
+                        return core::Term::Prim(range.into(), Prim::ReportedError)
+                    }
                     _ => {
                         let expected_type = self.pretty_print_value(&expected_type);
                         self.push_message(Message::ArrayLiteralNotSupported {
                             range: *range,
                             expected_type,
                         });
-                        return core::Term::Prim(Prim::ReportedError);
+                        return core::Term::Prim(range.into(), Prim::ReportedError);
                     }
                 };
 
@@ -1454,7 +1460,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     Some(Value::ConstLit(Const::U32(len, _))) => Some(*len as u64),
                     Some(Value::ConstLit(Const::U64(len, _))) => Some(*len as u64),
                     Some(Value::Stuck(Head::Prim(Prim::ReportedError), _)) => {
-                        return core::Term::Prim(Prim::ReportedError);
+                        return core::Term::Prim(range.into(), Prim::ReportedError);
                     }
                     _ => None,
                 };
@@ -1480,7 +1486,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             expected_len,
                         });
 
-                        core::Term::Prim(Prim::ReportedError)
+                        core::Term::Prim(range.into(), Prim::ReportedError)
                     }
                 }
             }
@@ -1515,7 +1521,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 match constant {
                     Some(constant) => core::Term::ConstLit(constant),
-                    None => core::Term::Prim(Prim::ReportedError),
+                    None => core::Term::Prim(range.into(), Prim::ReportedError),
                 }
             }
             (Term::NumberLiteral(range, number), _) => {
@@ -1545,16 +1551,16 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             range: *range,
                             expected_type,
                         });
-                        return core::Term::Prim(Prim::ReportedError);
+                        return core::Term::Prim(range.into(), Prim::ReportedError);
                     }
                 };
 
                 match constant {
                     Some(constant) => core::Term::ConstLit(constant),
-                    None => core::Term::Prim(Prim::ReportedError),
+                    None => core::Term::Prim(range.into(), Prim::ReportedError),
                 }
             }
-            (Term::ReportedError(_), _) => core::Term::Prim(Prim::ReportedError),
+            (Term::ReportedError(range), _) => core::Term::Prim(range.into(), Prim::ReportedError),
             (_, _) => {
                 let (core_term, synth_type) = self.synth(surface_term);
                 self.convert(surface_term.range(), core_term, &synth_type, &expected_type)
@@ -1950,118 +1956,284 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
         let operand_types = Option::zip(lhs_type.match_prim_spine(), rhs_type.match_prim_spine());
 
         let (fun, output_type) = match (op, operand_types) {
-            (Mul(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Mul), U8Type),
-            (Mul(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Mul), U16Type),
-            (Mul(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Mul), U32Type),
-            (Mul(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Mul), U64Type),
+            (Mul(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Mul), U8Type)
+            }
+            (Mul(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Mul), U16Type)
+            }
+            (Mul(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Mul), U32Type)
+            }
+            (Mul(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Mul), U64Type)
+            }
 
-            (Mul(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Mul), S8Type),
-            (Mul(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Mul), S16Type),
-            (Mul(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Mul), S32Type),
-            (Mul(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Mul), S64Type),
+            (Mul(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Mul), S8Type)
+            }
+            (Mul(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Mul), S16Type)
+            }
+            (Mul(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Mul), S32Type)
+            }
+            (Mul(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Mul), S64Type)
+            }
 
-            (Div(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Div), U8Type),
-            (Div(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Div), U16Type),
-            (Div(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Div), U32Type),
-            (Div(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Div), U64Type),
+            (Div(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Div), U8Type)
+            }
+            (Div(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Div), U16Type)
+            }
+            (Div(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Div), U32Type)
+            }
+            (Div(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Div), U64Type)
+            }
 
-            (Div(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Div), S8Type),
-            (Div(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Div), S16Type),
-            (Div(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Div), S32Type),
-            (Div(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Div), S64Type),
+            (Div(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Div), S8Type)
+            }
+            (Div(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Div), S16Type)
+            }
+            (Div(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Div), S32Type)
+            }
+            (Div(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Div), S64Type)
+            }
 
-            (Add(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Add), U8Type),
-            (Add(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Add), U16Type),
-            (Add(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Add), U32Type),
-            (Add(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Add), U64Type),
+            (Add(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Add), U8Type)
+            }
+            (Add(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Add), U16Type)
+            }
+            (Add(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Add), U32Type)
+            }
+            (Add(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Add), U64Type)
+            }
 
-            (Add(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Add), S8Type),
-            (Add(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Add), S16Type),
-            (Add(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Add), S32Type),
-            (Add(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Add), S64Type),
+            (Add(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Add), S8Type)
+            }
+            (Add(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Add), S16Type)
+            }
+            (Add(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Add), S32Type)
+            }
+            (Add(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Add), S64Type)
+            }
 
-            (Add(_), Some(((PosType, []), (U8Type, [])))) => (core::Term::Prim(PosAddU8), PosType),
+            (Add(_), Some(((PosType, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, PosAddU8), PosType)
+            }
             (Add(_), Some(((PosType, []), (U16Type, [])))) => {
-                (core::Term::Prim(PosAddU16), PosType)
+                (core::Term::Prim(Span::Empty, PosAddU16), PosType)
             }
             (Add(_), Some(((PosType, []), (U32Type, [])))) => {
-                (core::Term::Prim(PosAddU32), PosType)
+                (core::Term::Prim(Span::Empty, PosAddU32), PosType)
             }
             (Add(_), Some(((PosType, []), (U64Type, [])))) => {
-                (core::Term::Prim(PosAddU64), PosType)
+                (core::Term::Prim(Span::Empty, PosAddU64), PosType)
             }
 
-            (Sub(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Sub), U8Type),
-            (Sub(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Sub), U16Type),
-            (Sub(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Sub), U32Type),
-            (Sub(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Sub), U64Type),
+            (Sub(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Sub), U8Type)
+            }
+            (Sub(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Sub), U16Type)
+            }
+            (Sub(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Sub), U32Type)
+            }
+            (Sub(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Sub), U64Type)
+            }
 
-            (Sub(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Sub), S8Type),
-            (Sub(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Sub), S16Type),
-            (Sub(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Sub), S32Type),
-            (Sub(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Sub), S64Type),
+            (Sub(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Sub), S8Type)
+            }
+            (Sub(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Sub), S16Type)
+            }
+            (Sub(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Sub), S32Type)
+            }
+            (Sub(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Sub), S64Type)
+            }
 
-            (Eq(_), Some(((BoolType, []), (BoolType, [])))) => (core::Term::Prim(U8Eq), BoolType),
-            (Eq(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Eq), BoolType),
-            (Eq(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Eq), BoolType),
-            (Eq(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Eq), BoolType),
-            (Eq(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Eq), BoolType),
+            (Eq(_), Some(((BoolType, []), (BoolType, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Eq), BoolType)
+            }
+            (Eq(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Eq), BoolType)
+            }
+            (Eq(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Eq), BoolType)
+            }
+            (Eq(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Eq), BoolType)
+            }
+            (Eq(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Eq), BoolType)
+            }
 
-            (Eq(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Eq), BoolType),
-            (Eq(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Eq), BoolType),
-            (Eq(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Eq), BoolType),
-            (Eq(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Eq), BoolType),
+            (Eq(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Eq), BoolType)
+            }
+            (Eq(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Eq), BoolType)
+            }
+            (Eq(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Eq), BoolType)
+            }
+            (Eq(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Eq), BoolType)
+            }
 
-            (Neq(_), Some(((BoolType, []), (BoolType, [])))) => (core::Term::Prim(U8Neq), BoolType),
-            (Neq(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Neq), BoolType),
-            (Neq(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Neq), BoolType),
-            (Neq(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Neq), BoolType),
-            (Neq(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Neq), BoolType),
+            (Neq(_), Some(((BoolType, []), (BoolType, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Neq), BoolType)
+            }
+            (Neq(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Neq), BoolType)
+            }
+            (Neq(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Neq), BoolType)
+            }
+            (Neq(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Neq), BoolType)
+            }
+            (Neq(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Neq), BoolType)
+            }
 
-            (Neq(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Neq), BoolType),
-            (Neq(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Neq), BoolType),
-            (Neq(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Neq), BoolType),
-            (Neq(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Neq), BoolType),
+            (Neq(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Neq), BoolType)
+            }
+            (Neq(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Neq), BoolType)
+            }
+            (Neq(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Neq), BoolType)
+            }
+            (Neq(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Neq), BoolType)
+            }
 
-            (Lt(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Lt), BoolType),
-            (Lt(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Lt), BoolType),
-            (Lt(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Lt), BoolType),
-            (Lt(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Lt), BoolType),
+            (Lt(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Lt), BoolType)
+            }
+            (Lt(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Lt), BoolType)
+            }
+            (Lt(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Lt), BoolType)
+            }
+            (Lt(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Lt), BoolType)
+            }
 
-            (Lt(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Lt), BoolType),
-            (Lt(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Lt), BoolType),
-            (Lt(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Lt), BoolType),
-            (Lt(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Lt), BoolType),
+            (Lt(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Lt), BoolType)
+            }
+            (Lt(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Lt), BoolType)
+            }
+            (Lt(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Lt), BoolType)
+            }
+            (Lt(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Lt), BoolType)
+            }
 
-            (Lte(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Lte), BoolType),
-            (Lte(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Lte), BoolType),
-            (Lte(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Lte), BoolType),
-            (Lte(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Lte), BoolType),
+            (Lte(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Lte), BoolType)
+            }
+            (Lte(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Lte), BoolType)
+            }
+            (Lte(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Lte), BoolType)
+            }
+            (Lte(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Lte), BoolType)
+            }
 
-            (Lte(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Lte), BoolType),
-            (Lte(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Lte), BoolType),
-            (Lte(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Lte), BoolType),
-            (Lte(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Lte), BoolType),
+            (Lte(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Lte), BoolType)
+            }
+            (Lte(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Lte), BoolType)
+            }
+            (Lte(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Lte), BoolType)
+            }
+            (Lte(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Lte), BoolType)
+            }
 
-            (Gt(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Gt), BoolType),
-            (Gt(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Gt), BoolType),
-            (Gt(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Gt), BoolType),
-            (Gt(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Gt), BoolType),
+            (Gt(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Gt), BoolType)
+            }
+            (Gt(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Gt), BoolType)
+            }
+            (Gt(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Gt), BoolType)
+            }
+            (Gt(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Gt), BoolType)
+            }
 
-            (Gt(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Gt), BoolType),
-            (Gt(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Gt), BoolType),
-            (Gt(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Gt), BoolType),
-            (Gt(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Gt), BoolType),
+            (Gt(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Gt), BoolType)
+            }
+            (Gt(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Gt), BoolType)
+            }
+            (Gt(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Gt), BoolType)
+            }
+            (Gt(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Gt), BoolType)
+            }
 
-            (Gte(_), Some(((U8Type, []), (U8Type, [])))) => (core::Term::Prim(U8Gte), BoolType),
-            (Gte(_), Some(((U16Type, []), (U16Type, [])))) => (core::Term::Prim(U16Gte), BoolType),
-            (Gte(_), Some(((U32Type, []), (U32Type, [])))) => (core::Term::Prim(U32Gte), BoolType),
-            (Gte(_), Some(((U64Type, []), (U64Type, [])))) => (core::Term::Prim(U64Gte), BoolType),
+            (Gte(_), Some(((U8Type, []), (U8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U8Gte), BoolType)
+            }
+            (Gte(_), Some(((U16Type, []), (U16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U16Gte), BoolType)
+            }
+            (Gte(_), Some(((U32Type, []), (U32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U32Gte), BoolType)
+            }
+            (Gte(_), Some(((U64Type, []), (U64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, U64Gte), BoolType)
+            }
 
-            (Gte(_), Some(((S8Type, []), (S8Type, [])))) => (core::Term::Prim(S8Gte), BoolType),
-            (Gte(_), Some(((S16Type, []), (S16Type, [])))) => (core::Term::Prim(S16Gte), BoolType),
-            (Gte(_), Some(((S32Type, []), (S32Type, [])))) => (core::Term::Prim(S32Gte), BoolType),
-            (Gte(_), Some(((S64Type, []), (S64Type, [])))) => (core::Term::Prim(S64Gte), BoolType),
+            (Gte(_), Some(((S8Type, []), (S8Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S8Gte), BoolType)
+            }
+            (Gte(_), Some(((S16Type, []), (S16Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S16Gte), BoolType)
+            }
+            (Gte(_), Some(((S32Type, []), (S32Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S32Gte), BoolType)
+            }
+            (Gte(_), Some(((S64Type, []), (S64Type, [])))) => {
+                (core::Term::Prim(Span::Empty, S64Gte), BoolType)
+            }
             _ => {
                 let lhs_pretty = self.pretty_print_value(&lhs_type);
                 let rhs_pretty = self.pretty_print_value(&rhs_type);
@@ -2094,7 +2266,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
     fn synth_reported_error(&mut self, range: ByteRange) -> (core::Term<'arena>, ArcValue<'arena>) {
         let type_source = FlexSource::ReportedErrorType(range);
         let r#type = self.push_flexible_value(type_source, Arc::new(Value::Universe));
-        (core::Term::Prim(Prim::ReportedError), r#type)
+        (
+            core::Term::Prim((&range).into(), Prim::ReportedError),
+            r#type,
+        )
     }
 
     /// Check a series of format fields
@@ -2165,8 +2340,9 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     let format = core::Term::FunApp(
                         (&range).into(),
                         self.scope.to_scope(core::Term::FunApp(
-                            (&range).into(), // FIXME: sub-range?
-                            self.scope.to_scope(core::Term::Prim(Prim::FormatSucceed)),
+                            Span::Empty, // FIXME: sub-range?
+                            self.scope
+                                .to_scope(core::Term::Prim(Span::Empty, Prim::FormatSucceed)), // FIXME: sub-range?
                             self.scope.to_scope(r#type),
                         )),
                         self.scope.to_scope(expr),
@@ -2255,7 +2431,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                         output_expr
                     }
-                    CheckedPattern::Const(_, _) => {
+                    CheckedPattern::Const(range, _) => {
                         // Temporary vector for accumulating branches
                         let mut branches = Vec::new();
                         let num_constructors = match scrutinee_type.match_prim_spine() {
@@ -2341,9 +2517,9 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                                 scrutinee_expr_range: scrutinee_range,
                             });
                         }
-                        core::Term::Prim(Prim::ReportedError)
+                        core::Term::Prim((&range).into(), Prim::ReportedError)
                     }
-                    CheckedPattern::ReportedError(_) => {
+                    CheckedPattern::ReportedError(range) => {
                         // Check for any further errors in the first equation's output expression.
                         self.check(output_expr, expected_type);
                         self.check_match(
@@ -2356,7 +2532,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             expected_type,
                         );
 
-                        core::Term::Prim(Prim::ReportedError)
+                        core::Term::Prim((&range).into(), Prim::ReportedError)
                     }
                 }
             }
@@ -2368,7 +2544,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                         scrutinee_expr_range: scrutinee_range,
                     });
                 }
-                core::Term::Prim(Prim::ReportedError)
+                core::Term::Prim((&match_range).into(), Prim::ReportedError)
             }
         }
     }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1419,13 +1419,13 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
             (Term::UnitLiteral(range), Value::Universe) => {
                 core::Term::RecordType(range.into(), &[], &[])
             }
-            (Term::UnitLiteral(_), _)
+            (Term::UnitLiteral(range), _)
                 if matches!(
                     expected_type.match_prim_spine(),
                     Some((Prim::FormatType, [])),
                 ) =>
             {
-                core::Term::FormatRecord(&[], &[])
+                core::Term::FormatRecord(range.into(), &[], &[])
             }
             (Term::ArrayLiteral(range, elem_exprs), _) => {
                 use crate::core::semantics::Elim::FunApp as App;
@@ -1893,7 +1893,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));
                 let (labels, formats) = self.check_format_fields(*range, format_fields);
 
-                (core::Term::FormatRecord(labels, formats), format_type)
+                (
+                    core::Term::FormatRecord(range.into(), labels, formats),
+                    format_type,
+                )
             }
             Term::FormatCond(_range, (_, name), format, pred) => {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -498,7 +498,8 @@ impl<'arena> RigidEnv<'arena> {
     fn push_param(&mut self, name: Option<StringId>, r#type: ArcValue<'arena>) -> ArcValue<'arena> {
         // An expression that refers to itself once it is pushed onto the rigid
         // expression environment.
-        let expr = SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.exprs.len().next_global())));
+        let expr =
+            SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.exprs.len().next_global())));
 
         self.names.push(name);
         self.types.push(r#type);
@@ -1450,7 +1451,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 core::Term::RecordLit(range.into(), labels, exprs.into())
             }
-            (Term::UnitLiteral(range), Value::Universe(_)) => {
+            (Term::UnitLiteral(range), Value::Universe) => {
                 core::Term::RecordType(range.into(), &[], &[])
             }
             (Term::UnitLiteral(range), _)
@@ -1929,7 +1930,8 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 )
             }
             Term::FormatRecord(range, format_fields) => {
-                let format_type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
+                let format_type =
+                    SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
                 let (labels, formats) = self.check_format_fields(*range, format_fields);
 
                 (
@@ -1938,7 +1940,8 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 )
             }
             Term::FormatCond(range, (_, name), format, pred) => {
-                let format_type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
+                let format_type =
+                    SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
                 let format = self.check(format, &format_type);
                 let format_value = self.eval_context().eval(&format);
                 let repr_type = self.elim_context().format_repr(&format_value);
@@ -1958,7 +1961,8 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 )
             }
             Term::FormatOverlap(range, format_fields) => {
-                let format_type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
+                let format_type =
+                    SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
                 let (labels, formats) = self.check_format_fields(*range, format_fields);
 
                 (

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1377,7 +1377,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
             }
             (
                 Term::FunLiteral(range, input_pattern, input_type, output_expr),
-                Value::FunType(_, expected_input_type, output_type),
+                Value::FunType(_, _, expected_input_type, output_type),
             ) => {
                 let (input_name, input_type) =
                     self.check_ann_pattern(input_pattern, *input_type, expected_input_type);
@@ -1714,6 +1714,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 (
                     core::Term::FunLit(range.into(), input_name, self.scope.to_scope(output_expr)),
                     Arc::new(Value::FunType(
+                        Span::Empty,
                         input_name,
                         input_type,
                         Closure::new(
@@ -1731,7 +1732,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let head_type = self.elim_context().force(&head_type);
                 let (head_expr, input_type, output_type) = match head_type.as_ref() {
                     // The simple case - it's easy to see that it is a function type!
-                    Value::FunType(_, input_type, output_type) => {
+                    Value::FunType(_, _, input_type, output_type) => {
                         (head_expr, input_type.clone(), output_type.clone())
                     }
                     Value::Stuck(_, Head::Prim(Prim::ReportedError), _) => {
@@ -1760,6 +1761,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             self.scope.to_scope(output_type),
                         );
                         let fun_type = Arc::new(Value::FunType(
+                            Span::Empty,
                             None,
                             input_type.clone(),
                             output_type.clone(),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -498,8 +498,7 @@ impl<'arena> RigidEnv<'arena> {
     fn push_param(&mut self, name: Option<StringId>, r#type: ArcValue<'arena>) -> ArcValue<'arena> {
         // An expression that refers to itself once it is pushed onto the rigid
         // expression environment.
-        let expr =
-            SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.exprs.len().next_global())));
+        let expr = SpanValue::empty(Arc::new(Value::rigid_var(self.exprs.len().next_global())));
 
         self.names.push(name);
         self.types.push(r#type);
@@ -1253,7 +1252,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
             }
             Pattern::BooleanLiteral(range, val) => {
                 let r#const = Const::Bool(*val);
-                let r#type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::BoolType, [])));
+                let r#type = SpanValue::empty(Arc::new(Value::prim(Prim::BoolType, [])));
                 (CheckedPattern::Const(*range, r#const), r#type)
             }
         }
@@ -1861,12 +1860,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (
                     core::Term::RecordLit(range.into(), labels, exprs.into()),
-                    SpanValue::empty_fixme(Arc::new(Value::RecordType(labels, types))),
+                    SpanValue::empty(Arc::new(Value::RecordType(labels, types))),
                 )
             }
             Term::UnitLiteral(range) => (
                 core::Term::RecordLit(range.into(), &[], &[]),
-                SpanValue::empty_fixme(Arc::new(Value::RecordType(
+                SpanValue::empty(Arc::new(Value::RecordType(
                     &[],
                     Telescope::new(SharedEnv::new(), &[]),
                 ))),
@@ -1924,15 +1923,14 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 self.synth_reported_error(*range)
             }
             Term::BooleanLiteral(range, val) => {
-                let bool_type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::BoolType, [])));
+                let bool_type = SpanValue::empty(Arc::new(Value::prim(Prim::BoolType, [])));
                 (
                     core::Term::ConstLit(range.into(), Const::Bool(*val)),
                     bool_type,
                 )
             }
             Term::FormatRecord(range, format_fields) => {
-                let format_type =
-                    SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
+                let format_type = SpanValue::empty(Arc::new(Value::prim(Prim::FormatType, [])));
                 let (labels, formats) = self.check_format_fields(*range, format_fields);
 
                 (
@@ -1941,13 +1939,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 )
             }
             Term::FormatCond(range, (_, name), format, pred) => {
-                let format_type =
-                    SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
+                let format_type = SpanValue::empty(Arc::new(Value::prim(Prim::FormatType, [])));
                 let format = self.check(format, &format_type);
                 let format_value = self.eval_context().eval(&format);
                 let repr_type = self.elim_context().format_repr(&format_value);
                 self.rigid_env.push_param(Some(*name), repr_type);
-                let bool_type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::BoolType, [])));
+                let bool_type = SpanValue::empty(Arc::new(Value::prim(Prim::BoolType, [])));
                 let pred_expr = self.check(pred, &bool_type);
                 self.rigid_env.pop();
 
@@ -1962,8 +1959,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 )
             }
             Term::FormatOverlap(range, format_fields) => {
-                let format_type =
-                    SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
+                let format_type = SpanValue::empty(Arc::new(Value::prim(Prim::FormatType, [])));
                 let (labels, formats) = self.check_format_fields(*range, format_fields);
 
                 (
@@ -2300,7 +2296,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
         // TODO: Maybe it would be good to reuse lhs_type here if output_type is the same
         (
             fun_app,
-            SpanValue::empty_fixme(Arc::new(Value::prim(output_type, []))),
+            SpanValue::empty(Arc::new(Value::prim(output_type, []))),
         )
     }
 
@@ -2320,8 +2316,8 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
         format_fields: &[FormatField<'_, ByteRange>],
     ) -> (&'arena [StringId], &'arena [core::Term<'arena>]) {
         let universe_type = Value::arc_universe();
-        let format_type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::FormatType, [])));
-        let bool_type = SpanValue::empty_fixme(Arc::new(Value::prim(Prim::BoolType, [])));
+        let format_type = SpanValue::empty(Arc::new(Value::prim(Prim::FormatType, [])));
+        let bool_type = SpanValue::empty(Arc::new(Value::prim(Prim::BoolType, [])));
 
         let initial_rigid_len = self.rigid_env.len();
         let (labels, format_fields) =

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -123,7 +123,7 @@ impl<'arena> RigidEnv<'arena> {
         const VAR2: Term<'_> = Term::RigidVar(Span::fixme(), env::LocalVar::last().prev().prev());
         const VAR3: Term<'_> =
             Term::RigidVar(Span::fixme(), env::LocalVar::last().prev().prev().prev());
-        const UNIVERSE: Term<'_> = Term::Universe;
+        const UNIVERSE: Term<'_> = Term::Universe(Span::fixme());
         const FORMAT_TYPE: Term<'_> = Term::Prim(FormatType);
         const BOOL_TYPE: Term<'_> = Term::Prim(BoolType);
         const U8_TYPE: Term<'_> = Term::Prim(U8Type);
@@ -1631,7 +1631,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (match_expr, output_type)
             }
-            Term::Universe(_) => (core::Term::Universe, Arc::new(Value::Universe)),
+            Term::Universe(range) => (
+                core::Term::Universe(range.into()),
+                Arc::new(Value::Universe),
+            ),
             Term::Arrow(_, input_type, output_type) => {
                 let universe = Arc::new(Value::Universe); // FIXME: avoid temporary Arc
                 let input_type = self.check(input_type, &universe);

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1459,8 +1459,8 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     Some(Value::ConstLit(Const::U16(len, _))) => Some(*len as u64),
                     Some(Value::ConstLit(Const::U32(len, _))) => Some(*len as u64),
                     Some(Value::ConstLit(Const::U64(len, _))) => Some(*len as u64),
-                    Some(Value::Stuck(Head::Prim(Prim::ReportedError), _)) => {
-                        return core::Term::Prim(range.into(), Prim::ReportedError);
+                    Some(Value::Stuck(span, Head::Prim(Prim::ReportedError), _)) => {
+                        return core::Term::Prim(*span, Prim::ReportedError); // FIXME: should it use span here or range?
                     }
                     _ => None,
                 };
@@ -1737,7 +1737,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     Value::FunType(_, input_type, output_type) => {
                         (head_expr, input_type.clone(), output_type.clone())
                     }
-                    Value::Stuck(Head::Prim(Prim::ReportedError), _) => {
+                    Value::Stuck(_, Head::Prim(Prim::ReportedError), _) => {
                         return self.synth_reported_error(*range);
                     }
                     // It's not immediately obvious that the head type is a
@@ -1864,7 +1864,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             }
                         }
                     }
-                    Value::Stuck(Head::Prim(Prim::ReportedError), _) => {
+                    Value::Stuck(_, Head::Prim(Prim::ReportedError), _) => {
                         return self.synth_reported_error(*range);
                     }
                     _ => {}

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1460,11 +1460,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 };
 
                 match len {
-                    Some(len) if elem_exprs.len() as u64 == len => {
-                        core::Term::ArrayLit(self.scope.to_scope_from_iter(
+                    Some(len) if elem_exprs.len() as u64 == len => core::Term::ArrayLit(
+                        range.into(),
+                        self.scope.to_scope_from_iter(
                             (elem_exprs.iter()).map(|elem_expr| self.check(elem_expr, elem_type)),
-                        ))
-                    }
+                        ),
+                    ),
                     _ => {
                         // Check the array elements anyway in order to report
                         // any errors inside the literal as well.

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1576,13 +1576,16 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (expr, r#type)
             }
-            Term::Ann(_, expr, r#type) => {
+            Term::Ann(range, expr, r#type) => {
                 let r#type = self.check(r#type, &Arc::new(Value::Universe)); // FIXME: avoid temporary Arc
                 let type_value = self.eval_context().eval(&r#type);
                 let expr = self.check(expr, &type_value);
 
-                let ann_expr =
-                    core::Term::Ann(self.scope.to_scope(expr), self.scope.to_scope(r#type));
+                let ann_expr = core::Term::Ann(
+                    range.into(),
+                    self.scope.to_scope(expr),
+                    self.scope.to_scope(r#type),
+                );
 
                 (ann_expr, type_value)
             }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1922,7 +1922,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));
                 let (labels, formats) = self.check_format_fields(*range, format_fields);
 
-                (core::Term::FormatOverlap(labels, formats), format_type)
+                (
+                    core::Term::FormatOverlap(range.into(), labels, formats),
+                    format_type,
+                )
             }
             Term::BinOp(range, lhs, op, rhs) => self.synth_bin_op(*range, lhs, *op, rhs),
             Term::ReportedError(range) => self.synth_reported_error(*range),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1898,7 +1898,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     format_type,
                 )
             }
-            Term::FormatCond(_range, (_, name), format, pred) => {
+            Term::FormatCond(range, (_, name), format, pred) => {
                 let format_type = Arc::new(Value::prim(Prim::FormatType, []));
                 let format = self.check(format, &format_type);
                 let format_value = self.eval_context().eval(&format);
@@ -1910,6 +1910,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (
                     core::Term::FormatCond(
+                        range.into(),
                         *name,
                         self.scope.to_scope(format),
                         self.scope.to_scope(pred_expr),
@@ -2132,6 +2133,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             let cond_expr = self.check(pred, &bool_type);
 
                             formats.push(core::Term::FormatCond(
+                                (&range).into(), // FIXME: Is this range of all the fields? If so we need to merge ranges of the field only
                                 *label,
                                 self.scope.to_scope(format),
                                 self.scope.to_scope(cond_expr),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1486,10 +1486,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 let len = match len_value.map(|val| (val.0, val.1.as_ref())) {
                     None => Some(elem_exprs.len() as u64),
-                    Some((_, Value::ConstLit(_, Const::U8(len, _)))) => Some(*len as u64),
-                    Some((_, Value::ConstLit(_, Const::U16(len, _)))) => Some(*len as u64),
-                    Some((_, Value::ConstLit(_, Const::U32(len, _)))) => Some(*len as u64),
-                    Some((_, Value::ConstLit(_, Const::U64(len, _)))) => Some(*len as u64),
+                    Some((_, Value::ConstLit(Const::U8(len, _)))) => Some(*len as u64),
+                    Some((_, Value::ConstLit(Const::U16(len, _)))) => Some(*len as u64),
+                    Some((_, Value::ConstLit(Const::U32(len, _)))) => Some(*len as u64),
+                    Some((_, Value::ConstLit(Const::U64(len, _)))) => Some(*len as u64),
                     Some((span, Value::Stuck(Head::Prim(Prim::ReportedError), _))) => {
                         return core::Term::Prim(span, Prim::ReportedError); // FIXME: should it use span here or range?
                     }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1848,7 +1848,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                         {
                             if label == type_label {
                                 let head_expr = self.scope.to_scope(head_expr);
-                                let expr = core::Term::RecordProj(head_expr, *label);
+                                let expr = core::Term::RecordProj(range.into(), head_expr, *label);
                                 return (expr, r#type);
                             } else {
                                 let head_expr = head_expr_value.clone();

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1420,7 +1420,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 core::Term::FunLit(range.into(), input_name, self.scope.to_scope(output_expr))
             }
-            (Term::RecordLiteral(range, expr_fields), Value::RecordType(_, labels, types)) => {
+            (Term::RecordLiteral(range, expr_fields), Value::RecordType(labels, types)) => {
                 // TODO: improve handling of duplicate labels
                 if expr_fields.len() != labels.len()
                     || Iterator::zip(expr_fields.iter(), labels.iter())
@@ -1861,13 +1861,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (
                     core::Term::RecordLit(range.into(), labels, exprs.into()),
-                    SpanValue::fixme(Arc::new(Value::RecordType(Span::Empty, labels, types))),
+                    SpanValue::empty_fixme(Arc::new(Value::RecordType(labels, types))),
                 )
             }
             Term::UnitLiteral(range) => (
                 core::Term::RecordLit(range.into(), &[], &[]),
-                SpanValue::fixme(Arc::new(Value::RecordType(
-                    Span::Empty,
+                SpanValue::empty_fixme(Arc::new(Value::RecordType(
                     &[],
                     Telescope::new(SharedEnv::new(), &[]),
                 ))),
@@ -1879,7 +1878,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 let head_type = self.elim_context().force(&head_type);
                 match head_type.1.as_ref() {
-                    Value::RecordType(_, labels, types) => {
+                    Value::RecordType(labels, types) => {
                         let mut labels = labels.iter();
                         let mut types = types.clone();
 

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1371,7 +1371,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 )
             }
             (
-                Term::FunLiteral(_, input_pattern, input_type, output_expr),
+                Term::FunLiteral(range, input_pattern, input_type, output_expr),
                 Value::FunType(_, expected_input_type, output_type),
             ) => {
                 let (input_name, input_type) =
@@ -1382,7 +1382,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 self.rigid_env.pop();
 
-                core::Term::FunLit(input_name, self.scope.to_scope(output_expr))
+                core::Term::FunLit(range.into(), input_name, self.scope.to_scope(output_expr))
             }
             (Term::RecordLiteral(range, expr_fields), Value::RecordType(labels, types)) => {
                 // TODO: improve handling of duplicate labels
@@ -1695,7 +1695,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (fun_type, universe)
             }
-            Term::FunLiteral(_, input_pattern, input_type, output_expr) => {
+            Term::FunLiteral(range, input_pattern, input_type, output_expr) => {
                 let (input_pattern, input_type) =
                     self.synth_ann_pattern(input_pattern, *input_type);
 
@@ -1705,7 +1705,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 self.rigid_env.pop();
 
                 (
-                    core::Term::FunLit(input_name, self.scope.to_scope(output_expr)),
+                    core::Term::FunLit(range.into(), input_name, self.scope.to_scope(output_expr)),
                     Arc::new(Value::FunType(
                         input_name,
                         input_type,

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1414,7 +1414,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     exprs.push(expr);
                 }
 
-                core::Term::RecordLit(labels, exprs.into())
+                core::Term::RecordLit(range.into(), labels, exprs.into())
             }
             (Term::UnitLiteral(range), Value::Universe) => {
                 core::Term::RecordType(range.into(), &[], &[])
@@ -1821,12 +1821,12 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 let types = Telescope::new(self.rigid_env.exprs.clone(), types.into());
 
                 (
-                    core::Term::RecordLit(labels, exprs.into()),
+                    core::Term::RecordLit(range.into(), labels, exprs.into()),
                     Arc::new(Value::RecordType(labels, types)),
                 )
             }
-            Term::UnitLiteral(_) => (
-                core::Term::RecordLit(&[], &[]),
+            Term::UnitLiteral(range) => (
+                core::Term::RecordLit(range.into(), &[], &[]),
                 Arc::new(Value::RecordType(
                     &[],
                     Telescope::new(SharedEnv::new(), &[]),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -27,9 +27,9 @@ use std::sync::Arc;
 
 use crate::alloc::SliceVec;
 use crate::core::semantics::{self, ArcValue, Closure, Head, Telescope, Value};
-use crate::core::{self, binary, Const, Prim, Span, UIntStyle};
+use crate::core::{self, binary, Const, Prim, UIntStyle};
 use crate::env::{self, EnvLen, GlobalVar, SharedEnv, SliceEnv, UniqueEnv};
-use crate::source::ByteRange;
+use crate::source::{ByteRange, Span};
 use crate::surface::elaboration::reporting::Message;
 use crate::surface::{distillation, pretty, BinOp, FormatField, Item, Module, Pattern, Term};
 use crate::{StringId, StringInterner};

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1317,7 +1317,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
         let expected_type = self.elim_context().force(expected_type);
 
         match (surface_term, expected_type.as_ref()) {
-            (Term::Let(_, def_pattern, def_type, def_expr, output_expr), _) => {
+            (Term::Let(range, def_pattern, def_type, def_expr, output_expr), _) => {
                 let (def_pattern, def_type_value) = self.synth_ann_pattern(def_pattern, *def_type);
                 let def_type = self.quote_context(self.scope).quote(&def_type_value); // FIXME: avoid requote if possible?
                 let def_expr = self.check(def_expr, &def_type_value);
@@ -1328,6 +1328,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 self.rigid_env.pop();
 
                 core::Term::Let(
+                    range.into(),
                     def_name,
                     self.scope.to_scope(def_type),
                     self.scope.to_scope(def_expr),
@@ -1589,7 +1590,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (ann_expr, type_value)
             }
-            Term::Let(_, def_pattern, def_type, def_expr, output_expr) => {
+            Term::Let(range, def_pattern, def_type, def_expr, output_expr) => {
                 let (def_pattern, def_type_value) = self.synth_ann_pattern(def_pattern, *def_type);
                 let def_type = self.quote_context(self.scope).quote(&def_type_value); // FIXME: avoid requote if possible?
                 let def_expr = self.check(def_expr, &def_type_value);
@@ -1600,6 +1601,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 self.rigid_env.pop();
 
                 let let_expr = core::Term::Let(
+                    range.into(),
                     def_name,
                     self.scope.to_scope(def_type),
                     self.scope.to_scope(def_expr),
@@ -2168,7 +2170,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 }
 
                 match def_pattern {
-                    CheckedPattern::Name(_, name) => {
+                    CheckedPattern::Name(range, name) => {
                         let def_name = Some(name);
                         let def_expr = self.eval_context().eval(&scrutinee_expr);
                         self.rigid_env.push_def(def_name, def_expr, def_type_value);
@@ -2187,6 +2189,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                         );
 
                         core::Term::Let(
+                            (&range).into(), // FIXME: is this the right range to use here?
                             def_name,
                             self.scope.to_scope(def_type),
                             scrutinee_expr,

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -557,10 +557,7 @@ impl<'i, 'arena> RigidEnvBuilder<'i, 'arena> {
                 .eval(r#type);
         self.env.push_def(
             name,
-            Spanned {
-                span: Span::Empty,
-                inner: Arc::new(Value::prim(prim, [])),
-            },
+            Spanned::new(Span::Empty, Arc::new(Value::prim(prim, []))),
             r#type,
         );
     }
@@ -1747,9 +1744,9 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                 (
                     core::Term::FunLit(range.into(), input_name, self.scope.to_scope(output_expr)),
                     // FIXME: Should this use range too?
-                    Spanned {
-                        span: Span::Empty,
-                        inner: Arc::new(Value::FunType(
+                    Spanned::new(
+                        Span::Empty,
+                        Arc::new(Value::FunType(
                             input_name,
                             input_type,
                             Closure::new(
@@ -1757,7 +1754,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                                 self.scope.to_scope(output_type),
                             ),
                         )),
-                    },
+                    ),
                 )
             }
             Term::App(range, head_expr, input_expr) => {

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1389,7 +1389,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 core::Term::FunLit(range.into(), input_name, self.scope.to_scope(output_expr))
             }
-            (Term::RecordLiteral(range, expr_fields), Value::RecordType(labels, types)) => {
+            (Term::RecordLiteral(range, expr_fields), Value::RecordType(_, labels, types)) => {
                 // TODO: improve handling of duplicate labels
                 if expr_fields.len() != labels.len()
                     || Iterator::zip(expr_fields.iter(), labels.iter())
@@ -1828,12 +1828,13 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 (
                     core::Term::RecordLit(range.into(), labels, exprs.into()),
-                    Arc::new(Value::RecordType(labels, types)),
+                    Arc::new(Value::RecordType(Span::Empty, labels, types)),
                 )
             }
             Term::UnitLiteral(range) => (
                 core::Term::RecordLit(range.into(), &[], &[]),
                 Arc::new(Value::RecordType(
+                    Span::Empty,
                     &[],
                     Telescope::new(SharedEnv::new(), &[]),
                 )),
@@ -1845,7 +1846,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
 
                 let head_type = self.elim_context().force(&head_type);
                 match head_type.as_ref() {
-                    Value::RecordType(labels, types) => {
+                    Value::RecordType(_, labels, types) => {
                         let mut labels = labels.iter();
                         let mut types = types.clone();
 

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use crate::source::{ByteRange, FileId};
 use crate::surface::elaboration::{unification, FlexSource};
 use crate::surface::BinOp;
-use crate::{StringId, StringInterner};
+use crate::{StringId, StringInterner, BUG_REPORT_URL};
 
 /// Elaboration diagnostic messages.
 #[derive(Debug, Clone)]
@@ -115,6 +115,10 @@ pub enum Message {
     /// A cycle between module items was detected.
     CycleDetected {
         names: Vec<StringId>,
+    },
+    /// Core term lacked span information
+    MissingSpan {
+        range: ByteRange,
     },
 }
 
@@ -437,6 +441,13 @@ impl Message {
                     .with_message("cycle detected")
                     .with_notes(vec![cycle])
             }
+            Message::MissingSpan { range } => Diagnostic::bug()
+                .with_message("produced core term without span")
+                .with_labels(vec![primary_label(range)])
+                .with_notes(vec![format!(
+                    "please file a bug report at: {}",
+                    BUG_REPORT_URL
+                )]),
         }
     }
 }

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -610,7 +610,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     new_elem_exprs.push(self.rename(flexible_var, elem_expr)?);
                 }
 
-                Ok(Term::ArrayLit(new_elem_exprs.into()))
+                Ok(Term::ArrayLit(
+                    Span::from_value(value), // FIXME: As above
+                    new_elem_exprs.into(),
+                ))
             }
 
             Value::FormatRecord(labels, formats) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -580,7 +580,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let types = self.rename_telescope(flexible_var, types)?;
 
-                Ok(Term::RecordType(labels, types))
+                Ok(Term::RecordType(
+                    Span::from_value(value), // FIXME: As above
+                    labels,
+                    types,
+                ))
             }
             Value::RecordLit(labels, exprs) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -552,7 +552,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 })
             }
 
-            Value::Universe => Ok(Term::Universe),
+            Value::Universe => Ok(Term::Universe(Span::from_value(value))), // FIXME: As above
 
             Value::FunType(input_name, input_type, output_type) => {
                 let input_type = self.rename(flexible_var, input_type)?;

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -548,6 +548,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                             };
 
                             Term::ConstMatch(
+                                Span::from_value(value), // FIXME: As above
                                 self.scope.to_scope(head_expr?),
                                 pattern_branches.into(),
                                 default_expr.map(|expr| self.scope.to_scope(expr) as &_),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -630,6 +630,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 let format = self.rename(flexible_var, format)?;
                 let cond = self.rename_closure(flexible_var, cond)?;
                 Ok(Term::FormatCond(
+                    Span::from_value(value), // FIXME: As above
                     *label,
                     self.scope.to_scope(format),
                     self.scope.to_scope(cond),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -625,11 +625,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     self.scope.to_scope(cond),
                 ))
             }
-            Value::FormatOverlap(span, labels, formats) => {
+            Value::FormatOverlap(labels, formats) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let formats = self.rename_telescope(flexible_var, formats)?;
 
-                Ok(Term::FormatOverlap(*span, labels, formats))
+                Ok(Term::FormatOverlap(span, labels, formats))
             }
 
             Value::ConstLit(span, constant) => Ok(Term::ConstLit(*span, *constant)),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -20,10 +20,11 @@ use std::sync::Arc;
 
 use crate::alloc::SliceVec;
 use crate::core::semantics::{
-    self, ArcValue, Closure, Elim, Head, Spanned, SplitBranches, Telescope, Value,
+    self, ArcValue, Closure, Elim, Head, SplitBranches, Telescope, Value,
 };
 use crate::core::{Prim, Term};
 use crate::env::{EnvLen, GlobalVar, LocalVar, SharedEnv, SliceEnv, UniqueEnv};
+use crate::source::Spanned;
 use crate::StringId;
 
 /// Errors encountered during unification.

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -24,7 +24,6 @@ use crate::core::semantics::{
 };
 use crate::core::{Prim, Term};
 use crate::env::{EnvLen, GlobalVar, LocalVar, SharedEnv, SliceEnv, UniqueEnv};
-use crate::source::Span;
 use crate::StringId;
 
 /// Errors encountered during unification.
@@ -481,7 +480,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
     /// correspond to the given `spine`.
     fn fun_intros(&self, spine: &[Elim<'arena>], term: Term<'arena>) -> Term<'arena> {
         spine.iter().fold(term, |term, elim| match elim {
-            Elim::FunApp(_) => Term::FunLit(Span::fixme(), None, self.scope.to_scope(term)),
+            Elim::FunApp(_) => Term::FunLit(term.span(), None, self.scope.to_scope(term)),
             Elim::RecordProj(_) | Elim::ConstMatch(_) => {
                 unreachable!("should have been caught by `init_renaming`")
             }

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -246,7 +246,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 }
                 self.unify_telescopes(types0, types1)
             }
-            (Value::RecordLit(labels0, exprs0), Value::RecordLit(labels1, exprs1)) => {
+            (Value::RecordLit(_, labels0, exprs0), Value::RecordLit(_, labels1, exprs1)) => {
                 if labels0 != labels1 {
                     return Err(Error::Mismatch);
                 }
@@ -255,8 +255,12 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 }
                 Ok(())
             }
-            (Value::RecordLit(labels, exprs), _) => self.unify_record_lit(labels, exprs, &value1),
-            (_, Value::RecordLit(labels, exprs)) => self.unify_record_lit(labels, exprs, &value0),
+            (Value::RecordLit(_, labels, exprs), _) => {
+                self.unify_record_lit(labels, exprs, &value1)
+            }
+            (_, Value::RecordLit(_, labels, exprs)) => {
+                self.unify_record_lit(labels, exprs, &value0)
+            }
 
             (Value::ArrayLit(elem_exprs0), Value::ArrayLit(elem_exprs1)) => {
                 for (elem_expr0, elem_expr1) in
@@ -582,14 +586,14 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
                 Ok(Term::RecordType(*span, labels, types))
             }
-            Value::RecordLit(labels, exprs) => {
+            Value::RecordLit(span, labels, exprs) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let mut new_exprs = SliceVec::new(self.scope, exprs.len());
                 for expr in exprs {
                     new_exprs.push(self.rename(flexible_var, expr)?);
                 }
 
-                Ok(Term::RecordLit(Span::fixme(), labels, new_exprs.into()))
+                Ok(Term::RecordLit(*span, labels, new_exprs.into()))
             }
 
             Value::ArrayLit(elem_exprs) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -332,8 +332,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         closure0: &Closure<'arena>,
         closure1: &Closure<'arena>,
     ) -> Result<(), Error> {
-        let var =
-            SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+        let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
         let value0 = self.elim_context().apply_closure(closure0, var.clone());
         let value1 = self.elim_context().apply_closure(closure1, var);
 
@@ -367,8 +366,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 return Err(error);
             }
 
-            let var =
-                SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+            let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
             telescope0 = next_telescope0(var.clone());
             telescope1 = next_telescope1(var);
             self.rigid_exprs.push();
@@ -388,8 +386,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         output_expr: &Closure<'arena>,
         value: &ArcValue<'arena>,
     ) -> Result<(), Error> {
-        let var =
-            SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+        let var = SpanValue::empty(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
         let value = self.elim_context().fun_app(value.clone(), var.clone());
         let output_expr = self.elim_context().apply_closure(output_expr, var);
 
@@ -666,7 +663,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
             match self.rename(flexible_var, &value) {
                 Ok(term) => {
                     terms.push(term);
-                    let var = SpanValue::empty_fixme(Arc::new(Value::rigid_var(
+                    let var = SpanValue::empty(Arc::new(Value::rigid_var(
                         self.rigid_exprs.next_global(),
                     )));
                     telescope = next_telescope(var);
@@ -711,7 +708,7 @@ impl PartialRenaming {
     }
 
     fn next_rigid_var<'arena>(&self) -> ArcValue<'arena> {
-        SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.source.len().next_global())))
+        SpanValue::empty(Arc::new(Value::rigid_var(self.source.len().next_global())))
     }
 
     /// Set a rigid source variable to rigid target variable mapping, ensuring

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -226,7 +226,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Value::Stuck(Head::FlexibleVar(var1), spine1),
             ) if var0 == var1 => self.unify_spines(spine0, spine1),
 
-            (Value::Universe(_), Value::Universe(_)) => Ok(()),
+            (Value::Universe, Value::Universe) => Ok(()),
 
             (
                 Value::FunType(_, _, input_type0, output_type0),
@@ -339,7 +339,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
         closure0: &Closure<'arena>,
         closure1: &Closure<'arena>,
     ) -> Result<(), Error> {
-        let var = SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+        let var =
+            SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
         let value0 = self.elim_context().apply_closure(closure0, var.clone());
         let value1 = self.elim_context().apply_closure(closure1, var);
 
@@ -373,7 +374,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 return Err(error);
             }
 
-            let var = SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+            let var =
+                SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
             telescope0 = next_telescope0(var.clone());
             telescope1 = next_telescope1(var);
             self.rigid_exprs.push();
@@ -393,7 +395,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
         output_expr: &Closure<'arena>,
         value: &ArcValue<'arena>,
     ) -> Result<(), Error> {
-        let var = SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
+        let var =
+            SpanValue::empty_fixme(Arc::new(Value::rigid_var(self.rigid_exprs.next_global())));
         let value = self.elim_context().fun_app(value.clone(), var.clone());
         let output_expr = self.elim_context().apply_closure(output_expr, var);
 
@@ -565,7 +568,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 })
             }
 
-            Value::Universe(span) => Ok(Term::Universe(*span)),
+            Value::Universe => Ok(Term::Universe(span)),
 
             Value::FunType(span, input_name, input_type, output_type) => {
                 let input_type = self.rename(flexible_var, input_type)?;

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -268,10 +268,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(())
             }
 
-            (
-                Value::FormatRecord(_, labels0, formats0),
-                Value::FormatRecord(_, labels1, formats1),
-            ) => {
+            (Value::FormatRecord(labels0, formats0), Value::FormatRecord(labels1, formats1)) => {
                 if labels0 != labels1 {
                     return Err(Error::Mismatch);
                 }
@@ -612,11 +609,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(Term::ArrayLit(span, new_elem_exprs.into()))
             }
 
-            Value::FormatRecord(span, labels, formats) => {
+            Value::FormatRecord(labels, formats) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let formats = self.rename_telescope(flexible_var, formats)?;
 
-                Ok(Term::FormatRecord(*span, labels, formats))
+                Ok(Term::FormatRecord(span, labels, formats))
             }
             Value::FormatCond(span, label, format, cond) => {
                 let format = self.rename(flexible_var, format)?;

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -262,7 +262,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 self.unify_record_lit(labels, exprs, &value0)
             }
 
-            (Value::ArrayLit(elem_exprs0), Value::ArrayLit(elem_exprs1)) => {
+            (Value::ArrayLit(_, elem_exprs0), Value::ArrayLit(_, elem_exprs1)) => {
                 for (elem_expr0, elem_expr1) in
                     Iterator::zip(elem_exprs0.iter(), elem_exprs1.iter())
                 {
@@ -596,13 +596,13 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(Term::RecordLit(*span, labels, new_exprs.into()))
             }
 
-            Value::ArrayLit(elem_exprs) => {
+            Value::ArrayLit(span, elem_exprs) => {
                 let mut new_elem_exprs = SliceVec::new(self.scope, elem_exprs.len());
                 for elem_expr in elem_exprs {
                     new_elem_exprs.push(self.rename(flexible_var, elem_expr)?);
                 }
 
-                Ok(Term::ArrayLit(Span::fixme(), new_elem_exprs.into()))
+                Ok(Term::ArrayLit(*span, new_elem_exprs.into()))
             }
 
             Value::FormatRecord(labels, formats) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -511,6 +511,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 spine.iter().fold(Ok(head_expr), |head_expr, elim| {
                     Ok(match elim {
                         Elim::FunApp(input_expr) => Term::FunApp(
+                            Span::from_value(value), // FIXME: As above
                             self.scope.to_scope(head_expr?),
                             self.scope.to_scope(self.rename(flexible_var, input_expr)?),
                         ),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -640,7 +640,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let formats = self.rename_telescope(flexible_var, formats)?;
 
-                Ok(Term::FormatOverlap(labels, formats))
+                Ok(Term::FormatOverlap(
+                    Span::from_value(value), // FIXME: As above
+                    labels,
+                    formats,
+                ))
             }
 
             Value::ConstLit(constant) => Ok(Term::ConstLit(*constant)),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -559,6 +559,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 let output_type = self.rename_closure(flexible_var, output_type)?;
 
                 Ok(Term::FunType(
+                    Span::from_value(value), // FIXME: As above
                     *input_name,
                     self.scope.to_scope(input_type),
                     self.scope.to_scope(output_type),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -624,11 +624,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     self.scope.to_scope(cond),
                 ))
             }
-            Value::FormatOverlap(labels, formats) => {
+            Value::FormatOverlap(span, labels, formats) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let formats = self.rename_telescope(flexible_var, formats)?;
 
-                Ok(Term::FormatOverlap(Span::fixme(), labels, formats))
+                Ok(Term::FormatOverlap(*span, labels, formats))
             }
 
             Value::ConstLit(constant) => Ok(Term::ConstLit(Span::fixme(), *constant)),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -247,7 +247,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 }
                 self.unify_telescopes(types0, types1)
             }
-            (Value::RecordLit(_, labels0, exprs0), Value::RecordLit(_, labels1, exprs1)) => {
+            (Value::RecordLit(labels0, exprs0), Value::RecordLit(labels1, exprs1)) => {
                 if labels0 != labels1 {
                     return Err(Error::Mismatch);
                 }
@@ -256,12 +256,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 }
                 Ok(())
             }
-            (Value::RecordLit(_, labels, exprs), _) => {
-                self.unify_record_lit(labels, exprs, &value1)
-            }
-            (_, Value::RecordLit(_, labels, exprs)) => {
-                self.unify_record_lit(labels, exprs, &value0)
-            }
+            (Value::RecordLit(labels, exprs), _) => self.unify_record_lit(labels, exprs, &value1),
+            (_, Value::RecordLit(labels, exprs)) => self.unify_record_lit(labels, exprs, &value0),
 
             (Value::ArrayLit(_, elem_exprs0), Value::ArrayLit(_, elem_exprs1)) => {
                 for (elem_expr0, elem_expr1) in
@@ -597,14 +593,14 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
                 Ok(Term::RecordType(span, labels, types))
             }
-            Value::RecordLit(span, labels, exprs) => {
+            Value::RecordLit(labels, exprs) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let mut new_exprs = SliceVec::new(self.scope, exprs.len());
                 for expr in exprs {
                     new_exprs.push(self.rename(flexible_var, expr)?);
                 }
 
-                Ok(Term::RecordLit(*span, labels, new_exprs.into()))
+                Ok(Term::RecordLit(span, labels, new_exprs.into()))
             }
 
             Value::ArrayLit(span, elem_exprs) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -620,7 +620,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let formats = self.rename_telescope(flexible_var, formats)?;
 
-                Ok(Term::FormatRecord(labels, formats))
+                Ok(Term::FormatRecord(
+                    Span::from_value(value), // FIXME: As above
+                    labels,
+                    formats,
+                ))
             }
             Value::FormatCond(label, format, cond) => {
                 let format = self.rename(flexible_var, format)?;

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -228,8 +228,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
             (Value::Universe(_), Value::Universe(_)) => Ok(()),
 
             (
-                Value::FunType(_, input_type0, output_type0),
-                Value::FunType(_, input_type1, output_type1),
+                Value::FunType(_, _, input_type0, output_type0),
+                Value::FunType(_, _, input_type1, output_type1),
             ) => {
                 self.unify(input_type0, input_type1)?;
                 self.unify_closures(output_type0, output_type1)
@@ -555,12 +555,12 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
             Value::Universe(span) => Ok(Term::Universe(*span)),
 
-            Value::FunType(input_name, input_type, output_type) => {
+            Value::FunType(span, input_name, input_type, output_type) => {
                 let input_type = self.rename(flexible_var, input_type)?;
                 let output_type = self.rename_closure(flexible_var, output_type)?;
 
                 Ok(Term::FunType(
-                    Span::fixme(),
+                    *span,
                     *input_name,
                     self.scope.to_scope(input_type),
                     self.scope.to_scope(output_type),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -271,7 +271,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(())
             }
 
-            (Value::FormatRecord(labels0, formats0), Value::FormatRecord(labels1, formats1)) => {
+            (
+                Value::FormatRecord(_, labels0, formats0),
+                Value::FormatRecord(_, labels1, formats1),
+            ) => {
                 if labels0 != labels1 {
                     return Err(Error::Mismatch);
                 }
@@ -605,11 +608,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(Term::ArrayLit(*span, new_elem_exprs.into()))
             }
 
-            Value::FormatRecord(labels, formats) => {
+            Value::FormatRecord(span, labels, formats) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let formats = self.rename_telescope(flexible_var, formats)?;
 
-                Ok(Term::FormatRecord(Span::fixme(), labels, formats))
+                Ok(Term::FormatRecord(*span, labels, formats))
             }
             Value::FormatCond(label, format, cond) => {
                 let format = self.rename(flexible_var, format)?;

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -259,7 +259,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
             (Value::RecordLit(labels, exprs), _) => self.unify_record_lit(labels, exprs, &value1),
             (_, Value::RecordLit(labels, exprs)) => self.unify_record_lit(labels, exprs, &value0),
 
-            (Value::ArrayLit(_, elem_exprs0), Value::ArrayLit(_, elem_exprs1)) => {
+            (Value::ArrayLit(elem_exprs0), Value::ArrayLit(elem_exprs1)) => {
                 for (elem_expr0, elem_expr1) in
                     Iterator::zip(elem_exprs0.iter(), elem_exprs1.iter())
                 {
@@ -603,13 +603,13 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(Term::RecordLit(span, labels, new_exprs.into()))
             }
 
-            Value::ArrayLit(span, elem_exprs) => {
+            Value::ArrayLit(elem_exprs) => {
                 let mut new_elem_exprs = SliceVec::new(self.scope, elem_exprs.len());
                 for elem_expr in elem_exprs {
                     new_elem_exprs.push(self.rename(flexible_var, elem_expr)?);
                 }
 
-                Ok(Term::ArrayLit(*span, new_elem_exprs.into()))
+                Ok(Term::ArrayLit(span, new_elem_exprs.into()))
             }
 
             Value::FormatRecord(span, labels, formats) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -196,7 +196,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         value1: &ArcValue<'arena>,
     ) -> Result<(), Error> {
         // Check for pointer equality before trying to force the values
-        if Arc::ptr_eq(&value0.inner, &value1.inner) {
+        if Arc::ptr_eq(&value0, &value1) {
             return Ok(());
         }
 

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -474,7 +474,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
     /// correspond to the given `spine`.
     fn fun_intros(&self, spine: &[Elim<'arena>], term: Term<'arena>) -> Term<'arena> {
         spine.iter().fold(term, |term, elim| match elim {
-            Elim::FunApp(_) => Term::FunLit(None, self.scope.to_scope(term)),
+            Elim::FunApp(_) => Term::FunLit(Span::fixme(), None, self.scope.to_scope(term)),
             Elim::RecordProj(_) | Elim::ConstMatch(_) => {
                 unreachable!("should have been caught by `init_renaming`")
             }
@@ -568,7 +568,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
             Value::FunLit(input_name, output_expr) => {
                 let output_expr = self.rename_closure(flexible_var, output_expr)?;
 
-                Ok(Term::FunLit(*input_name, self.scope.to_scope(output_expr)))
+                Ok(Term::FunLit(
+                    Span::from_value(value), // FIXME: As above
+                    *input_name,
+                    self.scope.to_scope(output_expr),
+                ))
             }
 
             Value::RecordType(labels, types) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -240,7 +240,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
             (Value::FunLit(_, _, output_expr), _) => self.unify_fun_lit(output_expr, &value1),
             (_, Value::FunLit(_, _, output_expr)) => self.unify_fun_lit(output_expr, &value0),
 
-            (Value::RecordType(labels0, types0), Value::RecordType(labels1, types1)) => {
+            (Value::RecordType(_, labels0, types0), Value::RecordType(_, labels1, types1)) => {
                 if labels0 != labels1 {
                     return Err(Error::Mismatch);
                 }
@@ -576,11 +576,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 ))
             }
 
-            Value::RecordType(labels, types) => {
+            Value::RecordType(span, labels, types) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let types = self.rename_telescope(flexible_var, types)?;
 
-                Ok(Term::RecordType(Span::fixme(), labels, types))
+                Ok(Term::RecordType(*span, labels, types))
             }
             Value::RecordLit(labels, exprs) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -497,7 +497,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         match self.elim_context().force(value).as_ref() {
             Value::Stuck(head, spine) => {
                 let head_expr = match head {
-                    Head::Prim(prim) => Term::Prim(*prim),
+                    Head::Prim(prim) => Term::Prim(Span::fixme(), *prim),
                     Head::RigidVar(source_var) => match self.renaming.get_as_local(*source_var) {
                         None => return Err(RenameError::EscapingRigidVar(*source_var)),
                         Some(target_var) => Term::RigidVar(Span::from_value(value), target_var), // FIXME: Should this be the value we're matching on and not the value passed into the function?

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -516,7 +516,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                             self.scope.to_scope(self.rename(flexible_var, input_expr)?),
                         ),
                         Elim::RecordProj(label) => {
-                            Term::RecordProj(self.scope.to_scope(head_expr?), *label)
+                            Term::RecordProj(
+                                Span::from_value(value), // FIXME: As above
+                                self.scope.to_scope(head_expr?),
+                                *label,
+                            )
                         }
                         Elim::ConstMatch(branches) => {
                             let mut branches = branches.clone();

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -225,7 +225,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Value::Stuck(_, Head::FlexibleVar(var1), spine1),
             ) if var0 == var1 => self.unify_spines(spine0, spine1),
 
-            (Value::Universe, Value::Universe) => Ok(()),
+            (Value::Universe(_), Value::Universe(_)) => Ok(()),
 
             (
                 Value::FunType(_, input_type0, output_type0),
@@ -553,7 +553,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 })
             }
 
-            Value::Universe => Ok(Term::Universe(Span::fixme())),
+            Value::Universe(span) => Ok(Term::Universe(*span)),
 
             Value::FunType(input_name, input_type, output_type) => {
                 let input_type = self.rename(flexible_var, input_type)?;

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -282,8 +282,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
             }
 
             (
-                Value::FormatCond(label0, format0, cond0),
-                Value::FormatCond(label1, format1, cond1),
+                Value::FormatCond(_, label0, format0, cond0),
+                Value::FormatCond(_, label1, format1, cond1),
             ) => {
                 if label0 != label1 {
                     return Err(Error::Mismatch);
@@ -614,11 +614,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
                 Ok(Term::FormatRecord(*span, labels, formats))
             }
-            Value::FormatCond(label, format, cond) => {
+            Value::FormatCond(span, label, format, cond) => {
                 let format = self.rename(flexible_var, format)?;
                 let cond = self.rename_closure(flexible_var, cond)?;
                 Ok(Term::FormatCond(
-                    Span::fixme(),
+                    *span,
                     *label,
                     self.scope.to_scope(format),
                     self.scope.to_scope(cond),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -647,7 +647,10 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 ))
             }
 
-            Value::ConstLit(constant) => Ok(Term::ConstLit(*constant)),
+            Value::ConstLit(constant) => Ok(Term::ConstLit(
+                Span::from_value(value), // FIXME: As above
+                *constant,
+            )),
         }
     }
 

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -292,7 +292,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 self.unify_closures(cond0, cond1)
             }
 
-            (Value::ConstLit(const0), Value::ConstLit(const1)) if const0 == const1 => Ok(()),
+            (Value::ConstLit(_, const0), Value::ConstLit(_, const1)) if const0 == const1 => Ok(()),
 
             // Flexible-rigid cases
             //
@@ -631,7 +631,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(Term::FormatOverlap(*span, labels, formats))
             }
 
-            Value::ConstLit(constant) => Ok(Term::ConstLit(Span::fixme(), *constant)),
+            Value::ConstLit(span, constant) => Ok(Term::ConstLit(*span, *constant)),
         }
     }
 

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -241,7 +241,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
             (Value::FunLit(_, output_expr), _) => self.unify_fun_lit(output_expr, &value1),
             (_, Value::FunLit(_, output_expr)) => self.unify_fun_lit(output_expr, &value0),
 
-            (Value::RecordType(_, labels0, types0), Value::RecordType(_, labels1, types1)) => {
+            (Value::RecordType(labels0, types0), Value::RecordType(labels1, types1)) => {
                 if labels0 != labels1 {
                     return Err(Error::Mismatch);
                 }
@@ -591,11 +591,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 ))
             }
 
-            Value::RecordType(span, labels, types) => {
+            Value::RecordType(labels, types) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?
                 let types = self.rename_telescope(flexible_var, types)?;
 
-                Ok(Term::RecordType(*span, labels, types))
+                Ok(Term::RecordType(span, labels, types))
             }
             Value::RecordLit(span, labels, exprs) => {
                 let labels = self.scope.to_scope(labels); // FIXME: avoid copy if this is the same arena?

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -22,8 +22,9 @@ use crate::alloc::SliceVec;
 use crate::core::semantics::{
     self, ArcValue, Closure, Elim, Head, SplitBranches, Telescope, Value,
 };
-use crate::core::{Prim, Span, Term};
+use crate::core::{Prim, Term};
 use crate::env::{EnvLen, GlobalVar, LocalVar, SharedEnv, SliceEnv, UniqueEnv};
+use crate::source::Span;
 use crate::StringId;
 
 /// Errors encountered during unification.

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -235,11 +235,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 self.unify(input_type0, input_type1)?;
                 self.unify_closures(output_type0, output_type1)
             }
-            (Value::FunLit(_, _, output_expr0), Value::FunLit(_, _, output_expr1)) => {
+            (Value::FunLit(_, output_expr0), Value::FunLit(_, output_expr1)) => {
                 self.unify_closures(output_expr0, output_expr1)
             }
-            (Value::FunLit(_, _, output_expr), _) => self.unify_fun_lit(output_expr, &value1),
-            (_, Value::FunLit(_, _, output_expr)) => self.unify_fun_lit(output_expr, &value0),
+            (Value::FunLit(_, output_expr), _) => self.unify_fun_lit(output_expr, &value1),
+            (_, Value::FunLit(_, output_expr)) => self.unify_fun_lit(output_expr, &value0),
 
             (Value::RecordType(_, labels0, types0), Value::RecordType(_, labels1, types1)) => {
                 if labels0 != labels1 {
@@ -581,11 +581,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     self.scope.to_scope(output_type),
                 ))
             }
-            Value::FunLit(span, input_name, output_expr) => {
+            Value::FunLit(input_name, output_expr) => {
                 let output_expr = self.rename_closure(flexible_var, output_expr)?;
 
                 Ok(Term::FunLit(
-                    *span,
+                    span,
                     *input_name,
                     self.scope.to_scope(output_expr),
                 ))

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -286,7 +286,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 self.unify_closures(cond0, cond1)
             }
 
-            (Value::ConstLit(_, const0), Value::ConstLit(_, const1)) if const0 == const1 => Ok(()),
+            (Value::ConstLit(const0), Value::ConstLit(const1)) if const0 == const1 => Ok(()),
 
             // Flexible-rigid cases
             //
@@ -632,7 +632,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(Term::FormatOverlap(span, labels, formats))
             }
 
-            Value::ConstLit(span, constant) => Ok(Term::ConstLit(*span, *constant)),
+            Value::ConstLit(constant) => Ok(Term::ConstLit(span, *constant)),
         }
     }
 

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -234,11 +234,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 self.unify(input_type0, input_type1)?;
                 self.unify_closures(output_type0, output_type1)
             }
-            (Value::FunLit(_, output_expr0), Value::FunLit(_, output_expr1)) => {
+            (Value::FunLit(_, _, output_expr0), Value::FunLit(_, _, output_expr1)) => {
                 self.unify_closures(output_expr0, output_expr1)
             }
-            (Value::FunLit(_, output_expr), _) => self.unify_fun_lit(output_expr, &value1),
-            (_, Value::FunLit(_, output_expr)) => self.unify_fun_lit(output_expr, &value0),
+            (Value::FunLit(_, _, output_expr), _) => self.unify_fun_lit(output_expr, &value1),
+            (_, Value::FunLit(_, _, output_expr)) => self.unify_fun_lit(output_expr, &value0),
 
             (Value::RecordType(labels0, types0), Value::RecordType(labels1, types1)) => {
                 if labels0 != labels1 {
@@ -566,11 +566,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     self.scope.to_scope(output_type),
                 ))
             }
-            Value::FunLit(input_name, output_expr) => {
+            Value::FunLit(span, input_name, output_expr) => {
                 let output_expr = self.rename_closure(flexible_var, output_expr)?;
 
                 Ok(Term::FunLit(
-                    Span::fixme(),
+                    *span,
                     *input_name,
                     self.scope.to_scope(output_expr),
                 ))

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -276,8 +276,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
             }
 
             (
-                Value::FormatCond(_, label0, format0, cond0),
-                Value::FormatCond(_, label1, format1, cond1),
+                Value::FormatCond(label0, format0, cond0),
+                Value::FormatCond(label1, format1, cond1),
             ) => {
                 if label0 != label1 {
                     return Err(Error::Mismatch);
@@ -615,11 +615,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
                 Ok(Term::FormatRecord(span, labels, formats))
             }
-            Value::FormatCond(span, label, format, cond) => {
+            Value::FormatCond(label, format, cond) => {
                 let format = self.rename(flexible_var, format)?;
                 let cond = self.rename_closure(flexible_var, cond)?;
                 Ok(Term::FormatCond(
-                    *span,
+                    span,
                     *label,
                     self.scope.to_scope(format),
                     self.scope.to_scope(cond),

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -593,7 +593,11 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     new_exprs.push(self.rename(flexible_var, expr)?);
                 }
 
-                Ok(Term::RecordLit(labels, new_exprs.into()))
+                Ok(Term::RecordLit(
+                    Span::from_value(value), // FIXME: As above
+                    labels,
+                    new_exprs.into(),
+                ))
             }
 
             Value::ArrayLit(elem_exprs) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -229,8 +229,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
             (Value::Universe, Value::Universe) => Ok(()),
 
             (
-                Value::FunType(_, _, input_type0, output_type0),
-                Value::FunType(_, _, input_type1, output_type1),
+                Value::FunType(_, input_type0, output_type0),
+                Value::FunType(_, input_type1, output_type1),
             ) => {
                 self.unify(input_type0, input_type1)?;
                 self.unify_closures(output_type0, output_type1)
@@ -570,12 +570,12 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
             Value::Universe => Ok(Term::Universe(span)),
 
-            Value::FunType(span, input_name, input_type, output_type) => {
+            Value::FunType(input_name, input_type, output_type) => {
                 let input_type = self.rename(flexible_var, input_type)?;
                 let output_type = self.rename_closure(flexible_var, output_type)?;
 
                 Ok(Term::FunType(
-                    *span,
+                    span,
                     *input_name,
                     self.scope.to_scope(input_type),
                     self.scope.to_scope(output_type),

--- a/formats/data/edid/invalid/wrong-magic.snap
+++ b/formats/data/edid/invalid/wrong-magic.snap
@@ -1,6 +1,11 @@
 stdout = ''
 stderr = '''
 error: conditional format failed
- = The predicate on a conditional format did not succeed.
+   ┌─ formats/edid.fathom:18:26
+   │
+18 │     magic <- u64le where u64_eq magic 0x00ffffffffffff00,
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = The predicate on a conditional format did not succeed.
 
 '''

--- a/formats/data/edid/invalid/wrong-magic.snap
+++ b/formats/data/edid/invalid/wrong-magic.snap
@@ -7,5 +7,6 @@ error: conditional format failed
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = The predicate on a conditional format did not succeed.
+   = failed value: 18374686479671623935
 
 '''

--- a/formats/unwrap-none.fathom
+++ b/formats/unwrap-none.fathom
@@ -1,0 +1,4 @@
+def main = {
+    let ary : Array16 3 U16 = [1, 2, 3],
+    x <- unwrap U16 (array16_find _ U16 (fun el => el == (4 : U16)) ary),
+};

--- a/formats/unwrap-none.snap
+++ b/formats/unwrap-none.snap
@@ -1,0 +1,7 @@
+stdout = '''
+def main : Format = {
+    let ary : Array16 3 U16 = [ 1, 2, 3 ],
+    x <- unwrap U16 (array16_find (_ ary) U16 (fun el => el == (4 : U16)) ary),
+};
+'''
+stderr = ''

--- a/tests/cmd/fathom-data.md
+++ b/tests/cmd/fathom-data.md
@@ -244,7 +244,12 @@ Unexpected data in the binary file will result in an error
 $ fathom data --module formats/edid.fathom formats/data/edid/invalid/wrong-magic.edid
 ? failed
 error: conditional format failed
- = The predicate on a conditional format did not succeed.
+   ┌─ formats/edid.fathom:18:26
+   │
+18 │     magic <- u64le where u64_eq magic 0x00ffffffffffff00,
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = The predicate on a conditional format did not succeed.
 
 
 ```

--- a/tests/cmd/fathom-data.md
+++ b/tests/cmd/fathom-data.md
@@ -291,3 +291,18 @@ error: mismatched types
 
 
 ```
+
+### Unwrap none
+
+Unwrapping a none value will result in an error
+
+```console
+$ fathom data --module formats/unwrap-none.fathom
+>             formats/data/opentype/aots/cmap0_font1.otf
+? failed
+error: unwrapped none
+ = option_unwrap was called on a none value.
+
+
+```
+

--- a/tests/cmd/fathom-data.md
+++ b/tests/cmd/fathom-data.md
@@ -250,6 +250,7 @@ error: conditional format failed
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = The predicate on a conditional format did not succeed.
+   = failed value: 18374686479671623935
 
 
 ```


### PR DESCRIPTION
This PR adds source location information to `core::Term` and `Value` so that this information can flow from the surface language through the core language and back out. This allows some errors to be much more helpful.

This is a large change but I tried to keep the commits focussed on a single `Term` or `Value` variant so the history should be quite readable. There are a number of `FIXME`, `TODO` comments and a few references to a `Span::fixme` method left. Most of them are questions that I want to discuss to determine the right approach to resolve them.

I initially added spans to `Value` directly but this made it difficult when reusing a shared value instance (since they are ref-counted). For example, when encountering a `fail` format the value is the shared fail instance in the environment but the span is wherever this particular use of fail occurred. As a result of wanting to be able to provide a decent error in situations like this I refactored the handling of `Values` to instead have a wrapper type (`SpanValue`) that contains a `Span` and a `Value`. This way the span is independent of the `Value`. This worked out well for the `fail` case, allowing the location in the format to be included in the error.

There's a similar case that I would like to work but have not worked out how to do it—I did add a test though. When you unwrap none the error is:

```
error: unwrapped none
 = option_unwrap was called on a none value.
```

I'd like that to be able to point at where the unwrap occurred but got a bit lost in `step` macro.

Another thing I'm unsure about is things like this (from `synth`):

```rust
            Term::RecordLiteral(range, expr_fields) => {
                ⋮
                let types = Telescope::new(self.rigid_env.exprs.clone(), types.into());

                (
                    core::Term::RecordLit(range.into(), labels, exprs.into()),
                    SpanValue::empty(Arc::new(Value::RecordType(labels, types))),
                )
            }
```

where we return a term an its type. Should the type use the same range as the term? This question accounts for a bunch of the TODOs/FIXMEs I have in different places.