### PR TITLE
CI improvements and cleanups to flake.nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,94 +10,63 @@ on:
       - main
 
 jobs:
-  spec:
-    runs-on: ubuntu-20.04
-    name: Check Makam Specification
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install specification dependencies
-        run: yarn install
-        working-directory: ./experiments/makam-spec
-      - name: Check specification
-        run: yarn test
-        working-directory: ./experiments/makam-spec
-
-  check:
-    runs-on: ubuntu-20.04
+  cargo-test:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.56.0", "stable", "beta", "nightly"]
-    name: Check (${{ matrix.rust }})
+        rust-toolchain: ["stable", "minimum"]
+    name: Rust Tests (${{ matrix.rust-toolchain }})
     steps:
-      - uses: actions/checkout@v2
-      - name: Install minimal ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
 
-  test:
-    runs-on: ubuntu-20.04
+      - name: cargo check
+        run: nix develop .#${{ matrix.rust-toolchain }} --command cargo check
+      - name: cargo build
+        run: nix develop .#${{ matrix.rust-toolchain }} --command cargo build
+      - name: cargo test
+        run: nix develop .#${{ matrix.rust-toolchain }} --command cargo test
+
+  cargo-fmt:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.56.0", "stable", "beta", "nightly"]
-    name: Test Suite (${{ matrix.rust }})
+        rust-toolchain: ["stable"]
+    name: Rust Formatting (${{ matrix.rust-toolchain }})
     steps:
-      - uses: actions/checkout@v2
-      - name: Install minimal ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
 
-  fmt:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        rust: ["stable"]
-    name: Rustfmt (${{ matrix.rust }})
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install minimal ${{ matrix.rust }} with rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: nix develop .#${{ matrix.rust-toolchain }} --command cargo fmt
 
-#   clippy:
-#     runs-on: ubuntu-20.04
-#     strategy:
-#       matrix:
-#         rust: ["1.56.0", "stable", "beta", "nightly"]
-#     name: Clippy (${{ matrix.rust }})
-#     steps:
-#       - uses: actions/checkout@v2
-#       - name: Install minimal ${{ matrix.rust }} with clippy
-#         uses: actions-rs/toolchain@v1
-#         with:
-#           profile: minimal
-#           toolchain: ${{ matrix.rust }}
-#           override: true
-#           components: clippy
-#       - name: Run cargo clippy
-#         uses: actions-rs/cargo@v1
-#         with:
-#           command: clippy
-#           args: -- -D warnings
+  # cargo-clippy:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       rust-toolchain: ["stable", "minimum"]
+  #   name: Clippy (${{ matrix.rust }})
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
+  #     - name: Install Nix
+  #       uses: cachix/install-nix-action@v17
+  #
+  #     - name: Run cargo clippy
+  #       run: nix develop .#${{ matrix.rust }} --command cargo clippy --deny warnings
+
+  nixpkgs-fmt:
+    runs-on: ubuntu-latest
+    name: Nix Formatting
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+
+      - name: Run nixpkgs-fmt
+        run: nix develop --command nixpkgs-fmt --check .

--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["YesLogic Pty. Ltd. <info@yeslogic.com>"]
 repository = "https://github.com/yeslogic/fathom"
 edition = "2018"
+rust-version = "1.56.0"
 publish = false
 
 description = "A language for declaratively specifying binary data formats"

--- a/flake.lock
+++ b/flake.lock
@@ -15,41 +15,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1659610603,
-        "narHash": "sha256-LYgASYSPYo7O71WfeUOaEUzYfzuXm8c8eavJcel+pfI=",
-        "owner": "nmattia",
-        "repo": "naersk",
-        "rev": "c6a45e4277fa58abd524681466d3450f896dc094",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nmattia",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1645371475,
-        "narHash": "sha256-z2n0y5ME7yQTqzzGWnQTVd1MG5Bp1E+of7ZgA861/9E=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "38bc843f1ce76958a9f6f0a1e4e3455221c8ecf6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1660639432,
@@ -69,8 +34,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
-        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "lastModified": 1659610603,
+        "narHash": "sha256-LYgASYSPYo7O71WfeUOaEUzYfzuXm8c8eavJcel+pfI=",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "rev": "c6a45e4277fa58abd524681466d3450f896dc094",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646470760,
-        "narHash": "sha256-dQISyucVCCPaFioUhy5ZgfBz8rOMKGI8k13aPDFTqEs=",
+        "lastModified": 1660639432,
+        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1fc7212a2c3992eedc6eedf498955c321ad81cc2",
+        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646619817,
-        "narHash": "sha256-7CP5de05lc0r6JSMtrDYRxbDYJnBUTKDuYKy0shs7iU=",
+        "lastModified": 1660791450,
+        "narHash": "sha256-I3q06x8HkjavfzvQm2nlGjYwclKfYRYjo3x9jqKBSgA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6ee6a13b64ac9b577070ba235e3b1e35303ce7b1",
+        "rev": "98db932adeee26ea311ba4bbbdf4e0e5c3569fc4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,9 @@
         # Library functions from nixpkgs
         lib = pkgs.lib;
 
+        # Load the minimum supported Rust version (MSRV) from the manifest
+        fathomManifest = lib.importTOML ./fathom/Cargo.toml;
+        minimumRustVersion = fathomManifest.package.rust-version;
 
         # Setup Rust toolchains to build and test against
         #
@@ -53,7 +56,7 @@
         rustToolchains = {
           nightly = pkgs.rust-bin.nightly.latest.minimal;
           stable = pkgs.rust-bin.stable.latest.minimal;
-          minimum = pkgs.rust-bin.stable."1.56.0".minimal;
+          minimum = pkgs.rust-bin.stable.${minimumRustVersion}.minimal;
         };
       in
       {

--- a/flake.nix
+++ b/flake.nix
@@ -1,23 +1,25 @@
+# A Nix flake that initialises a development environment for Fathom
+#
+# NOTE: A Nix environment is not required to work on Fathom, but this Flake is
+# provided for your convinience if you already are.
+
 {
   # Flake dependency specification
   #
-  # To update individual inputs use:
+  # To update all flake inputs:
   #
-  # ```
-  # nix flake lock --update-input <input>
-  # ```
+  #     $ nix flake update --commit-lockfile
+  #
+  # To update individual flake inputs:
+  #
+  #     $ nix flake lock --update-input <input> ... --commit-lockfile
+  #
   inputs = {
     # Nix package repository
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     # Convenience functions for writing flakes
     flake-utils.url = "github:numtide/flake-utils";
-    # Precisely filter files copied to the nix store
-    nix-filter.url = "github:numtide/nix-filter";
-
-    # Build rust crates from `Cargo.lock` dependencies
-    naersk.url = "github:nmattia/naersk";
-    naersk.inputs.nixpkgs.follows = "nixpkgs";
 
     # Rust toolchain
     rust-overlay.url = "github:oxalica/rust-overlay";
@@ -25,153 +27,108 @@
     rust-overlay.inputs.flake-utils.follows = "flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-filter, naersk, rust-overlay }:
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
     # Build the output set for each default system and map system sets into
     # attributes, resulting in paths such as:
     #
-    #     nix build .#packages.<system>.<name>
+    #     $ nix build .#packages.<system>.<name>
+    #
     flake-utils.lib.eachDefaultSystem (system:
       let
         # Package set with the rust overlay included added
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ (import rust-overlay) ];
+          overlays = [ (import inputs.rust-overlay) ];
         };
 
-        # Crate containing the `fathom` binary
-        crateName = "fathom";
-        minimumRustVersion = "1.56.0";
+        # Library functions from nixpkgs
+        lib = pkgs.lib;
 
-        # TODO: detect the above variables dynamically using the `Cargo.toml` file.
-        # NOTE: using a workspace complicates this
-
-        # manifest = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-        #
-        # crateName = manifest.package.name;
-        # minimumRustVersion = manifest.package.rust-version;
 
         # Setup Rust toolchains to build and test against
-        rust = {
+        #
+        # The names of the toolchains will be used as the names of the
+        # development shells loaded by the `nix develop .#<name>` command (see
+        # the `devShells` flake output defined below).
+        rustToolchains = {
           nightly = pkgs.rust-bin.nightly.latest.minimal;
           stable = pkgs.rust-bin.stable.latest.minimal;
-          minimum = pkgs.rust-bin.stable.${minimumRustVersion}.minimal;
-        };
-
-        # Override Naersk for each Rust toolchain
-        naersk-lib = {
-          # nightly = naersk.lib."${system}".override { cargo = rust.nightly; rustc = rust.nightly; };
-          # stable = naersk.lib."${system}".override { cargo = rust.stable; rustc = rust.stable; };
-          minimum = naersk.lib."${system}".override { cargo = rust.minimum; rustc = rust.minimum; };
-        };
-
-        # Restrict sources copied to the nix store
-        crate-sources = nix-filter.lib.filter {
-          name = "fathom";
-          root = ./.;
-          include = [
-            ./Cargo.toml
-            ./Cargo.lock
-            (nix-filter.lib.inDirectory "fathom")
-          ];
-          exclude = [
-            (nix-filter.lib.inDirectory "examples")
-            (nix-filter.lib.inDirectory "test")
-          ];
-        };
-        crate-check-sources = nix-filter.lib.filter {
-          name = "fathom";
-          root = ./.;
-          include = [
-            ./Cargo.toml
-            ./Cargo.lock
-            (nix-filter.lib.inDirectory "fathom")
-          ];
-        };
-        nix-sources = nix-filter.lib.filter {
-          name = "fathom";
-          root = ./.;
-          include = [
-            (nix-filter.lib.matchExt "nix")
-          ];
+          minimum = pkgs.rust-bin.stable."1.56.0".minimal;
         };
       in
       {
-        # Executed by `nix flake check`
-        checks = {
-          # Check Rust crate tests
-          # TODO: test using `rust.nightly`, `rust.stable`, and `rust.minimum`
-          ${crateName} = naersk-lib.minimum.buildPackage {
-            pname = crateName;
-            root = crate-check-sources;
-            doCheck = true;
-          };
+        # Development shells
+        #
+        #    $ nix develop .#<name>
+        #    $ nix develop .#<name> --command cargo check
+        #
+        # [Direnv](https://direnv.net/) is recommended for automatically loading the
+        # development environemnts provided in your current shell. For example:
+        #
+        #    $ echo "use flake" > .envrc && direnv allow
+        #    $ cargo check
+        #
+        # If you want to live on the bleeding edge, you could also try using the
+        # nightly shell with the following `.envrc` file:
+        #
+        #    use flake .#nightly
+        #
+        # If you choose to use Direnv, note that `.envrc` should be added to
+        # your local git excludes, or added to to your global gitignore.
+        devShells = {
+          # Use the stable toolchain by default for development, to get the
+          # latest diagnostics and compiler improvements.
+          #
+          #    $ nix develop
+          #    $ nix develop --command cargo check
+          #
+          default = self.devShells.${system}.stable;
+        } // (
+          # Map over the `rustToolchains` defined above, creating a shell
+          # environment for each. This is useful for testing regressions against
+          # the minimum supported Rust version. For example:
+          #
+          #     $ nix develop .#minimum --command cargo check
+          #
+          pkgs.lib.mapAttrs
+            (name: rustToolchain:
+              let
+                rustWithExtensions = rustToolchain.override {
+                  extensions = [ "rust-src" "rustfmt" "clippy" ];
+                };
+              in
+              pkgs.mkShell {
+                name = "${name}-shell";
 
-          # Check Rust formatting
-          rustfmt = pkgs.runCommand "check-rustfmt"
-            {
-              buildInputs = [
-                (rust.stable.override { extensions = [ "rustfmt" ]; })
-              ];
-            }
-            ''
-              mkdir $out
-              cargo fmt --manifest-path ${crate-check-sources}/Cargo.toml -- --check
-            '';
+                packages = [
+                  rustWithExtensions
+                  pkgs.nixpkgs-fmt
+                ];
 
-          # Check Nix formatting
-          nixpkgs-fmt = pkgs.runCommand "check-nixpkgs-fmt"
-            {
-              buildInputs = [ pkgs.nixpkgs-fmt ];
-            }
-            ''
-              mkdir $out
-              nixpkgs-fmt --check ${nix-sources}
-            '';
-        };
+                # Print backtraces on panics
+                RUST_BACKTRACE = 1;
 
-        # Executed by `nix build .#<name>`
-        packages.${crateName} = naersk-lib.minimum.buildPackage {
-          pname = crateName;
-          root = crate-sources;
-        };
-
-        # Executed by `nix build`
-        defaultPackage = self.packages.${system}.${crateName};
-
-
-        # Executed by `nix run .#<name>`
-        apps.${crateName} = flake-utils.lib.mkApp {
-          drv = self.packages.${system}.${crateName};
-        };
-
-        # Executed by `nix run . -- <args?>`
-        defaultApp = self.apps.${system}.${crateName};
-
-
-        # Used by `nix develop .#<name>`
-        devShells = (
-          let
-            # Creates a development shell using a specific Rust toolchain
-            createShell = { rust }: pkgs.mkShell {
-              packages = [
-                (rust.override { extensions = [ "rust-src" "rustfmt" ]; })
-                pkgs.nixpkgs-fmt
-              ];
-              # Print backtraces on panics
-              RUST_BACKTRACE = 1;
-              # Certain tools like `rust-analyzer` won't work without this
-              RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
-            };
-          in
-          {
-            nightly = createShell { rust = rust.nightly; };
-            stable = createShell { rust = rust.stable; };
-            minimum = createShell { rust = rust.minimum; };
-          }
+                # Certain tools like `rust-analyzer` won't work without this
+                RUST_SRC_PATH = "${rustWithExtensions}/lib/rustlib/src/rust/library";
+              })
+            rustToolchains
         );
 
-        # Used by `nix develop`
-        devShell = self.devShells.${system}.stable;
+
+        # Flake checks
+        #
+        #     $ nix flake check
+        #
+        checks = {
+          # Check Nix formatting
+          nixpkgs-fmt = pkgs.runCommand "check-nixpkgs-fmt"
+            { buildInputs = [ pkgs.nixpkgs-fmt ]; }
+            ''
+              echo "checking nix formatting"
+              nixpkgs-fmt --check ${./flake.nix}
+              touch $out
+            '';
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -88,10 +88,15 @@
           default = self.devShells.${system}.stable;
         } // (
           # Map over the `rustToolchains` defined above, creating a shell
-          # environment for each. This is useful for testing regressions against
-          # the minimum supported Rust version. For example:
+          # environment for each.
           #
-          #     $ nix develop .#minimum --command cargo check
+          # This is useful for testing regressions against the minimum
+          # supported Rust version, and to select the apropriate Rust toolchain
+          # on CI.
+          #
+          # For example, to run the tests using the `minimum` Rust toolchain:
+          #
+          #     $ nix develop .#minimum --command cargo test
           #
           pkgs.lib.mapAttrs
             (name: rustToolchain:


### PR DESCRIPTION
The PR reduces the number of Rust toolchains we test against on CI. This was a holdover from my habits during pre-1.0 Rust where we were encouraged to test _all the versions_. Hopefully Github’s error de-duplication will improve in the future (see https://github.com/actions/runner/issues/504).

I also took the time to clean up the `flake.nix` file. It skips the packaging for now and just loads a Rust development environment. This is used on CI to load Rust instead of [actions-rs](https://github.com/actions-rs/) which appears to be dormant. This might be controversial, but it seemed decently clean and decreases the amount of setup stuck in CI land. We can always switch to another approach in the future though, as Fathom’s use case is pretty simple.

I also added the minimum supported rust version to `fathom/Cargo.toml`. This is used to drive the MSRV used on CI.