### PR TITLE
Rename environment structs in semantics

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -116,8 +116,8 @@ pub enum Term<'arena> {
     /// [entry information]: EntryInfo
     /// [function literals]: Term::FunLit
     /// [function applications]: Term::FunApp
-    /// [evaluation]: semantics::EvalContext::eval
-    /// [quoting]: semantics::QuoteContext::quote
+    /// [evaluation]: semantics::EvalEnv::eval
+    /// [quoting]: semantics::QuoteEnv::quote
     //
     // TODO: Bit-vectors might make this a bit more compact and cheaper to
     //       construct. For example:

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -221,7 +221,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         // Parse and elaborate the term
         let surface_term = self.parse_term(file_id);
         let (term, r#type) = context.synth(&surface_term);
-        let r#type = context.quote_context(&self.core_scope).quote(&r#type);
+        let r#type = context.quote_env(&self.core_scope).quote(&r#type);
 
         // Emit errors we might have found during elaboration
         let elab_messages = context.drain_messages();
@@ -259,8 +259,8 @@ impl<'surface, 'core> Driver<'surface, 'core> {
             return Status::Error;
         }
 
-        let term = context.eval_context().normalise(&self.core_scope, &term);
-        let r#type = context.quote_context(&self.core_scope).quote(&r#type);
+        let term = context.eval_env().normalise(&self.core_scope, &term);
+        let r#type = context.quote_env(&self.core_scope).quote(&r#type);
 
         self.surface_scope.reset(); // Reuse the surface scope for distillation
         let mut context = context.distillation_context(&self.surface_scope);
@@ -312,7 +312,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
             return Status::Error;
         }
 
-        let format = context.eval_context().eval(&format_term);
+        let format = context.eval_env().eval(&format_term);
         let buffer = binary::Buffer::from(buffer_data);
         let refs = match context.binary_context(buffer).read_entrypoint(format) {
             Ok(refs) => refs,
@@ -329,7 +329,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
             let exprs = parsed_refs.iter().map(|parsed_ref| {
                 let core_scope = &self.core_scope;
                 let surface_scope = &self.surface_scope;
-                let expr = context.quote_context(core_scope).quote(&parsed_ref.expr);
+                let expr = context.quote_env(core_scope).quote(&parsed_ref.expr);
                 context.distillation_context(surface_scope).check(&expr)
             });
 
@@ -440,7 +440,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
             ReadError::CondFailure(span, ref value) => {
                 let core_scope = &self.core_scope;
                 let surface_scope = &self.surface_scope;
-                let expr = context.quote_context(core_scope).quote(value);
+                let expr = context.quote_env(core_scope).quote(value);
                 let surface_term = context.distillation_context(surface_scope).check(&expr);
                 let pretty_context = surface::pretty::Context::new(&self.interner, surface_scope);
                 let doc = pretty_context.term(&surface_term).into_doc();

--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -81,7 +81,7 @@ pub fn local_vars() -> impl Iterator<Item = LocalVar> {
 /// Levels are used in [values][crate::core::semantics::Value] because they
 /// are not tied to a specific binding depth, unlike [indices][LocalVar].
 /// Because of this, we're able to sidestep the need for expensive variable
-/// shifting during [normalisation][crate::core::semantics::EvalContext::normalise].
+/// shifting during [normalisation][crate::core::semantics::EvalEnv::normalise].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GlobalVar(RawVar);
 


### PR DESCRIPTION
This has been bugging me for a while, not sure what you think.

It’s probably a little less confusing to call these ‘environments’ as they are more related to evaluation, although to be honest the difference between ‘contexts’ and ‘environments’ is sometimes a tad… context dependent!

The rename reduces verbosity slightly in some cases which is a nice win for readability as well, I think.