### PR TITLE
Span related cleanups

### DIFF
--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -15,12 +15,6 @@ use crate::StringId;
 /// the amount of sharing we can achieve during evaluation.
 pub type ArcValue<'arena> = Spanned<Arc<Value<'arena>>>;
 
-impl<'arena> ArcValue<'arena> {
-    pub fn match_prim_spine(&self) -> Option<(Prim, &[Elim<'arena>])> {
-        self.as_ref().match_prim_spine()
-    }
-}
-
 /// Values in weak-head-normal form, with bindings converted to closures.
 #[derive(Debug, Clone)]
 pub enum Value<'arena> {
@@ -77,12 +71,6 @@ impl<'arena> Value<'arena> {
             Value::Stuck(Head::Prim(prim), spine) => Some((*prim, spine)),
             _ => None,
         }
-    }
-
-    /// Create a new `Arc<Value::Universe>` with no associated span.
-    pub fn arc_universe() -> ArcValue<'arena> {
-        // TODO: Can we share a single instance of this?
-        Spanned::empty(Arc::new(Value::Universe))
     }
 }
 

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -61,10 +61,6 @@ pub enum Span {
 }
 
 impl Span {
-    pub const fn fixme() -> Span {
-        Span::Empty
-    }
-
     pub fn merge(&self, other: &Span) -> Span {
         match (self, other) {
             (Span::Range(a), Span::Range(b)) => a.merge(b).map(Span::Range).unwrap_or(Span::Empty),

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -73,6 +73,12 @@ impl Span {
     }
 }
 
+impl From<ByteRange> for Span {
+    fn from(range: ByteRange) -> Self {
+        Span::Range(range)
+    }
+}
+
 impl From<&ByteRange> for Span {
     fn from(range: &ByteRange) -> Self {
         Span::Range(*range)

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -334,7 +334,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                         core::EntryInfo::Definition => {}
                         core::EntryInfo::Parameter => {
                             let var = self.rigid_len().global_to_local(var).unwrap();
-                            let input_expr = self.check(&core::Term::RigidVar(Span::fixme(), var)); // FIXME: What span should be used here?
+                            let input_expr = self.check(&core::Term::RigidVar(Span::Empty, var));
                             head_expr = Term::App(
                                 (),
                                 self.scope.to_scope(head_expr),

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -824,7 +824,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
     ) -> core::Term<'arena> {
         let rigid_infos = (self.scope).to_scope_from_iter(self.rigid_env.infos.iter().copied());
         core::Term::FlexibleInsertion(
-            (&source.range()).into(),
+            source.range().into(),
             self.flexible_env.push(source, r#type),
             rigid_infos,
         )
@@ -2150,9 +2150,9 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
         };
 
         let fun_app = core::Term::FunApp(
-            (&range).into(),
+            range.into(),
             self.scope.to_scope(core::Term::FunApp(
-                (&range).into(), // FIXME: Should this be a sub-range of range (from one of the terms)?
+                range.into(), // FIXME: Should this be a sub-range of range (from one of the terms)?
                 self.scope.to_scope(core::Term::Prim(Span::Empty, fun)),
                 self.scope.to_scope(lhs_expr),
             )),
@@ -2167,12 +2167,10 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
     }
 
     fn synth_reported_error(&mut self, range: ByteRange) -> (core::Term<'arena>, ArcValue<'arena>) {
+        let expr = core::Term::Prim(range.into(), Prim::ReportedError);
         let type_source = FlexSource::ReportedErrorType(range);
         let r#type = self.push_flexible_value(type_source, Value::arc_universe());
-        (
-            core::Term::Prim((&range).into(), Prim::ReportedError),
-            r#type,
-        )
+        (expr, r#type)
     }
 
     /// Check a series of format fields
@@ -2214,7 +2212,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             let cond_expr = self.check(pred, &bool_type);
 
                             formats.push(core::Term::FormatCond(
-                                (&range).into(), // FIXME: Is this range of all the fields? If so we need to merge ranges of the field only
+                                range.into(), // FIXME: Is this range of all the fields? If so we need to merge ranges of the field only
                                 *label,
                                 self.scope.to_scope(format),
                                 self.scope.to_scope(cond_expr),
@@ -2241,7 +2239,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     };
 
                     let format = core::Term::FunApp(
-                        (&range).into(),
+                        range.into(),
                         self.scope.to_scope(core::Term::FunApp(
                             Span::Empty, // FIXME: sub-range?
                             self.scope
@@ -2313,7 +2311,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                         );
 
                         core::Term::Let(
-                            (&range).into(), // FIXME: is this the right range to use here?
+                            range.into(), // FIXME: is this the right range to use here?
                             def_name,
                             self.scope.to_scope(def_type),
                             scrutinee_expr,
@@ -2398,7 +2396,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                                     self.rigid_env.pop();
 
                                     return core::Term::ConstMatch(
-                                        (&range).into(),
+                                        range.into(),
                                         scrutinee_expr,
                                         self.scope.to_scope_from_iter(branches.into_iter()),
                                         Some(self.scope.to_scope(default_expr)),
@@ -2410,7 +2408,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                         if num_constructors == Some(branches.len()) {
                             // The absence of a default constructor is ok as the match was exhaustive.
                             return core::Term::ConstMatch(
-                                (&range).into(),
+                                range.into(),
                                 scrutinee_expr,
                                 self.scope.to_scope_from_iter(branches.into_iter()),
                                 None,
@@ -2424,7 +2422,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                                 scrutinee_expr_range: scrutinee_range,
                             });
                         }
-                        core::Term::Prim((&range).into(), Prim::ReportedError)
+                        core::Term::Prim(range.into(), Prim::ReportedError)
                     }
                     CheckedPattern::ReportedError(range) => {
                         // Check for any further errors in the first equation's output expression.
@@ -2439,7 +2437,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             expected_type,
                         );
 
-                        core::Term::Prim((&range).into(), Prim::ReportedError)
+                        core::Term::Prim(range.into(), Prim::ReportedError)
                     }
                 }
             }
@@ -2451,7 +2449,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                         scrutinee_expr_range: scrutinee_range,
                     });
                 }
-                core::Term::Prim((&match_range).into(), Prim::ReportedError)
+                core::Term::Prim(match_range.into(), Prim::ReportedError)
             }
         }
     }


### PR DESCRIPTION
Addressed some stuff I came across after the addition of spans. I’ve computed spans in some places in the elaborated terms. I also added a by-value conversion on byte ranges to make things a little cleaner in places, and cached some commonly used values to increase sharing (see the commit comment for more details).