### PR TITLE
Cleanups to pattern matching elaboration

### DIFF
--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -145,7 +145,7 @@ impl<Range> fmt::Display for BinOp<Range> {
 }
 
 impl<Range: Clone> Pattern<Range> {
-    fn range(&self) -> Range {
+    pub fn range(&self) -> Range {
         match self {
             Pattern::Name(range, _)
             | Pattern::Placeholder(range)

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -2376,14 +2376,7 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                             );
                         }
 
-                        if is_reachable {
-                            // TODO: this should be admitted if the scrutinee type is uninhabited
-                            self.push_message(Message::NonExhaustiveMatchExpr {
-                                match_expr_range: match_range,
-                                scrutinee_expr_range: scrutinee.range,
-                            });
-                        }
-                        core::Term::Prim(range.into(), Prim::ReportedError)
+                        self.check_match_absurd(is_reachable, match_range, scrutinee)
                     }
                     CheckedPattern::ReportedError(range) => {
                         // Check for any further errors in the first equation's output expression.
@@ -2400,17 +2393,24 @@ impl<'interner, 'arena, 'error> Context<'interner, 'arena, 'error> {
                     }
                 }
             }
-            None => {
-                if is_reachable {
-                    // TODO: this should be admitted if the scrutinee type is uninhabited
-                    self.push_message(Message::NonExhaustiveMatchExpr {
-                        match_expr_range: match_range,
-                        scrutinee_expr_range: scrutinee.range,
-                    });
-                }
-                core::Term::Prim(match_range.into(), Prim::ReportedError)
-            }
+            None => self.check_match_absurd(is_reachable, match_range, scrutinee),
         }
+    }
+
+    fn check_match_absurd(
+        &mut self,
+        is_reachable: bool,
+        match_range: ByteRange,
+        scrutinee: &Scrutinee<'arena>,
+    ) -> core::Term<'arena> {
+        if is_reachable {
+            // TODO: this should be admitted if the scrutinee type is uninhabited
+            self.push_message(Message::NonExhaustiveMatchExpr {
+                match_expr_range: match_range,
+                scrutinee_expr_range: scrutinee.range,
+            });
+        }
+        core::Term::Prim(match_range.into(), Prim::ReportedError)
     }
 }
 

--- a/tests/succeed/match/check-const-1.snap
+++ b/tests/succeed/match/check-const-1.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => 0, _ => let x : U8 = _; x } : U8
+let x : U8 = 3; match x { 1 => 0, _ => _ } : U8
 '''
 stderr = ''

--- a/tests/succeed/match/check-const-2.snap
+++ b/tests/succeed/match/check-const-2.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => 0, 3 => 7, _ => let x : U8 = _; x } : U8
+let x : U8 = 3; match x { 1 => 0, 3 => 7, _ => _ } : U8
 '''
 stderr = ''

--- a/tests/succeed/match/check-const-bool.snap
+++ b/tests/succeed/match/check-const-bool.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : Bool = false; match x { false => 0, _ => let x : Bool = _; 1 } : U8
+let x : Bool = false; match x { false => 0, _ => 1 } : U8
 '''
 stderr = ''

--- a/tests/succeed/match/check-const-redundant.snap
+++ b/tests/succeed/match/check-const-redundant.snap
@@ -1,5 +1,5 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => 0, 3 => 7, _ => let x : U8 = _; x } : U8
+let x : U8 = 3; match x { 1 => 0, 3 => 7, _ => _ } : U8
 '''
 stderr = '''
 warning: unreachable pattern

--- a/tests/succeed/match/synth-const-1.snap
+++ b/tests/succeed/match/synth-const-1.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => x, _ => let x : U8 = _; x } : U8
+let x : U8 = 3; match x { 1 => x, _ => _ } : U8
 '''
 stderr = ''

--- a/tests/succeed/match/synth-const-2.snap
+++ b/tests/succeed/match/synth-const-2.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => x, 3 => x, _ => let x : U8 = _; x } : U8
+let x : U8 = 3; match x { 1 => x, 3 => x, _ => _ } : U8
 '''
 stderr = ''


### PR DESCRIPTION
Apologies for the large diff! This builds upon #396, doing a bunch of cleanups related to the checking of patterns and elaboration of pattern matching. While our approach to pattern matching is still pretty naive (and that’s ok!), it was hard for me to understand and was somewhat embarrassing to look at, so I’ve tried to untangle it, reducing the number of parameters passed (keeping clippy happy) and splitting it into methods with more comments.