### PR TITLE
Add some assertions that all `Term`s produced by elaboration and quotatation are well-scoped

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -261,7 +261,10 @@ impl<'arena> Term<'arena> {
     pub fn is_closed(&self, mut local_env: EnvLen, meta_env: EnvLen) -> bool {
         match self {
             Term::LocalVar(_, var) => var.0 < local_env.0,
-            Term::MetaVar(_, var) | Term::InsertedMeta(_, var, _) => var.0 < meta_env.0,
+            Term::MetaVar(_, var) => var.0 < meta_env.0,
+            Term::InsertedMeta(_, var, infos) => {
+                var.0 < meta_env.0 && infos.len() <= local_env.0.into()
+            }
             Term::ItemVar(_, _) | Term::Universe(_) | Term::Prim(_, _) | Term::ConstLit(_, _) => {
                 true
             }

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -257,7 +257,8 @@ impl<'arena> Term<'arena> {
         }
     }
 
-    /// Returns `true` if the term is "closed" (does not contain free local or meta variables) with respect to `local_env` and `meta_env`.
+    /// Returns `true` if the term is "closed" (does not contain free local
+    /// or meta variables) with respect to `local_env` and `meta_env`.
     pub fn is_closed(&self, mut local_env: EnvLen, meta_env: EnvLen) -> bool {
         match self {
             Term::LocalVar(_, var) => var.0 < local_env.0,

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -82,7 +82,7 @@ impl<'arena> Value<'arena> {
                 let head_is_closed = match head {
                     Head::Prim(_) => true,
                     Head::LocalVar(var) => var.0 < local_env.0,
-                    Head::MetaVar(var) => var.0 < local_env.0,
+                    Head::MetaVar(var) => var.0 < meta_env.0,
                 };
                 head_is_closed
                     && spine.iter().all(|elim| match elim {
@@ -167,7 +167,7 @@ impl<'arena> Closure<'arena> {
     }
 
     pub fn is_closed(&self, meta_env: EnvLen) -> bool {
-        self.term.is_closed(self.local_exprs.len(), meta_env)
+        self.term.is_closed(self.local_exprs.len().next(), meta_env)
     }
 }
 

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -73,7 +73,8 @@ impl<'arena> Value<'arena> {
         }
     }
 
-    /// Returns `true` if the term is "closed" (does not contain free local or meta variables) with respect to `local_env` and `meta_env`.
+    /// Returns `true` if the term is "closed" (does not contain free local
+    /// or meta variables) with respect to `local_env` and `meta_env`.
     pub fn is_closed(&self, local_env: EnvLen, meta_env: EnvLen) -> bool {
         match self {
             Value::ConstLit(_) | Value::Universe => true,

--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -42,7 +42,7 @@ type RawVar = u16;
 /// [de Bruijn index]: https://en.wikipedia.org/wiki/De_Bruijn_index
 /// [alpha-equivalence]: https://ncatlab.org/nlab/show/alpha-equivalence
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Index(RawVar);
+pub struct Index(pub RawVar);
 
 impl Index {
     /// The last variable to be bound in the environment.
@@ -83,7 +83,7 @@ pub fn indices() -> impl Iterator<Item = Index> {
 /// Because of this, we're able to sidestep the need for expensive variable
 /// shifting during [normalisation][crate::core::semantics::EvalEnv::normalise].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Level(RawVar);
+pub struct Level(pub RawVar);
 
 impl Level {
     /// The first variable to be bound in the environment.
@@ -112,7 +112,7 @@ pub fn levels() -> impl Iterator<Item = Level> {
 
 /// The length of an environment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct EnvLen(RawVar);
+pub struct EnvLen(pub RawVar);
 
 impl EnvLen {
     /// Construct a new, empty environment.
@@ -153,6 +153,10 @@ impl EnvLen {
     /// Truncate the environment to the given length.
     pub fn truncate(&mut self, len: EnvLen) {
         *self = len;
+    }
+
+    pub const fn next(self) -> Self {
+        Self(self.0 + 1) // FIXME: check overflow?
     }
 }
 


### PR DESCRIPTION
Could also be done with [`contracts`](https://docs.rs/contracts/latest/contracts/) if we don't mind adding an extra dependency.