### PR TITLE
Record and tuple patterns

### DIFF
--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -42,7 +42,7 @@ type RawVar = u16;
 /// [de Bruijn index]: https://en.wikipedia.org/wiki/De_Bruijn_index
 /// [alpha-equivalence]: https://ncatlab.org/nlab/show/alpha-equivalence
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Index(RawVar);
+pub struct Index(pub RawVar);
 
 impl Index {
     /// The last variable to be bound in the environment.
@@ -83,7 +83,7 @@ pub fn indices() -> impl Iterator<Item = Index> {
 /// Because of this, we're able to sidestep the need for expensive variable
 /// shifting during [normalisation][crate::core::semantics::EvalEnv::normalise].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Level(RawVar);
+pub struct Level(pub RawVar);
 
 impl Level {
     /// The first variable to be bound in the environment.
@@ -112,7 +112,7 @@ pub fn levels() -> impl Iterator<Item = Level> {
 
 /// The length of an environment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct EnvLen(RawVar);
+pub struct EnvLen(pub RawVar);
 
 impl EnvLen {
     /// Construct a new, empty environment.
@@ -153,6 +153,10 @@ impl EnvLen {
     /// Truncate the environment to the given length.
     pub fn truncate(&mut self, len: EnvLen) {
         *self = len;
+    }
+
+    pub fn next(self) -> EnvLen {
+        Self(self.0 + 1)
     }
 }
 
@@ -197,6 +201,14 @@ impl<Entry> UniqueEnv<Entry> {
     /// Truncate the environment to the given length.
     pub fn truncate(&mut self, len: EnvLen) {
         self.entries.truncate(len.0 as usize);
+    }
+}
+
+impl<Entry> IntoIterator for UniqueEnv<Entry> {
+    type Item = Entry;
+    type IntoIter = <Vec<Entry> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
     }
 }
 

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 
 use crate::{StringId, StringInterner};
 use crate::source::{ByteRange, FileId};
-use crate::surface::{ExprField, FormatField, Item, ItemDef, Module, ParseMessage, Pattern, Term, TypeField, BinOp};
+use crate::surface::{PatternField, ExprField, FormatField, Item, ItemDef, Module, ParseMessage, Pattern, Term, TypeField, BinOp};
 use crate::surface::lexer::{Error as LexerError, Token};
 
 grammar<'arena, 'source>(
@@ -89,16 +89,18 @@ Item: Item<'arena, ByteRange> = {
     },
 };
 
-Pattern: Pattern<ByteRange> = {
+Pattern: Pattern<'arena, ByteRange> = {
     <start: @L> <name: Name> <end: @R> => Pattern::Name(ByteRange::new(file_id, start, end), name),
     <start: @L> "_" <end: @R> => Pattern::Placeholder(ByteRange::new(file_id, start, end)),
     <start: @L> <string: StringLiteral> <end: @R> => Pattern::StringLiteral(ByteRange::new(file_id, start, end), string),
     <start: @L> <number: NumberLiteral> <end: @R> => Pattern::NumberLiteral(ByteRange::new(file_id, start, end), number),
     <start: @L> "true" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(file_id, start, end), true),
     <start: @L> "false" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(file_id, start, end), false),
+    <start: @L> "{" <fields: Seq<PatternField, ",">> "}" <end: @R> => Pattern::RecordLiteral(ByteRange::new(file_id, start, end), fields),
+    <start: @L> <patterns: Tuple<Pattern>> <end: @R> => Pattern::Tuple(ByteRange::new(file_id, start, end), patterns),
 };
 
-AnnPattern: (Pattern<ByteRange>, Option<&'arena Term<'arena, ByteRange>>) = {
+AnnPattern: (Pattern<'arena, ByteRange>, Option<&'arena Term<'arena, ByteRange>>) = {
     <pattern: Pattern> => (pattern, None),
     "(" <pattern: Pattern> ":" <type_: LetTerm> ")" => (pattern, Some(scope.to_scope(type_))),
 };
@@ -258,7 +260,11 @@ TypeField: TypeField<'arena, ByteRange> = {
 };
 
 ExprField: ExprField<'arena, ByteRange> = {
-    <label: RangedName> "=" <expr: Term> => ExprField { label, expr },
+    <label: RangedName> <expr: ("=" <Term>)?> => ExprField { label, expr },
+};
+
+PatternField: PatternField<'arena, ByteRange> = {
+    <label: RangedName> <pattern : ("=" <Pattern>)?> => PatternField { label, pattern },
 };
 
 BinExpr<Lhs, Op, Rhs>: Term<'arena, ByteRange> = {
@@ -291,8 +297,8 @@ BinOpGte: BinOp<ByteRange> = <start: @L> ">=" <end: @R> => BinOp::Gte(ByteRange:
 
 Tuple<Elem>: &'arena [Elem] = {
     "(" ")" => &[],
-    "(" <term: Term> "," ")" => scope.to_scope_from_iter([term]),
-    "(" <terms: Seq2<Term, ",">> ")" => terms,
+    "(" <elem: Elem> "," ")" => scope.to_scope_from_iter([elem]),
+    "(" <elems: Seq2<Elem, ",">> ")" => elems,
 };
 
 #[inline]

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -103,7 +103,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                         self.space(),
                         self.text("="),
                         self.space(),
-                        self.pattern(&pattern),
+                        self.pattern(pattern),
                     ]),
                     None => self.string_id(field.label.1),
                 }),

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -94,6 +94,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 true => self.text("true"),
                 false => self.text("false"),
             },
+            Pattern::RecordLiteral(_, _) => todo!(),
+            Pattern::Tuple(_, _) => todo!(),
         }
     }
 
@@ -278,14 +280,15 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
             Term::RecordLiteral(_, expr_fields) => self.sequence(
                 true,
                 self.text("{"),
-                expr_fields.iter().map(|field| {
-                    self.concat([
+                expr_fields.iter().map(|field| match &field.expr {
+                    Some(expr) => self.concat([
                         self.string_id(field.label.1),
                         self.space(),
                         self.text("="),
                         self.space(),
-                        self.term_prec(Prec::Top, &field.expr),
-                    ])
+                        self.term_prec(Prec::Top, expr),
+                    ]),
+                    None => self.string_id(field.label.1),
                 }),
                 self.text(","),
                 self.text("}"),

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -94,8 +94,35 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 true => self.text("true"),
                 false => self.text("false"),
             },
-            Pattern::RecordLiteral(_, _) => todo!(),
-            Pattern::Tuple(_, _) => todo!(),
+            Pattern::RecordLiteral(_, pattern_fields) => self.sequence(
+                false,
+                self.text("{"),
+                pattern_fields.iter().map(|field| match &field.pattern {
+                    Some(pattern) => self.concat([
+                        self.string_id(field.label.1),
+                        self.space(),
+                        self.text("="),
+                        self.space(),
+                        self.pattern(&pattern),
+                    ]),
+                    None => self.string_id(field.label.1),
+                }),
+                self.text(","),
+                self.text("}"),
+            ),
+            Pattern::Tuple(_, patterns) if patterns.len() == 1 => self.concat([
+                self.text("("),
+                self.pattern(&patterns[0]),
+                self.text(","),
+                self.text(")"),
+            ]),
+            Pattern::Tuple(_, patterns) => self.sequence(
+                false,
+                self.text("("),
+                patterns.iter().map(|pattern| self.pattern(pattern)),
+                self.text(","),
+                self.text(")"),
+            ),
         }
     }
 

--- a/tests/fail/elaboration/duplicate-field-labels/record-pattern.fathom
+++ b/tests/fail/elaboration/duplicate-field-labels/record-pattern.fathom
@@ -1,0 +1,4 @@
+//~ exit-code = 1
+
+let {x, y, x} = {x = false, y = true};
+{}

--- a/tests/fail/elaboration/duplicate-field-labels/record-pattern.snap
+++ b/tests/fail/elaboration/duplicate-field-labels/record-pattern.snap
@@ -1,0 +1,14 @@
+stdout = ''
+stderr = '''
+error: duplicate labels found in record
+  ┌─ tests/fail/elaboration/duplicate-field-labels/record-pattern.fathom:3:12
+  │
+3 │ let {x, y, x} = {x = false, y = true};
+  │     -------^-
+  │     │      │
+  │     │      duplicate field
+  │     the record literal
+  │
+  = duplicate fields `x`
+
+'''

--- a/tests/succeed/record-literal/shorthand-check.fathom
+++ b/tests/succeed/record-literal/shorthand-check.fathom
@@ -1,0 +1,9 @@
+let id = fun _ a => a;
+let always = fun _ _ a _ => a;
+{
+    id,
+    always,
+} : {
+    id      : fun (A: Type) -> A -> A,
+    always  : fun (A: Type) (B: Type) -> A -> B -> A,
+}

--- a/tests/succeed/record-literal/shorthand-check.snap
+++ b/tests/succeed/record-literal/shorthand-check.snap
@@ -1,0 +1,9 @@
+stdout = '''
+let id : fun (_ : Type) -> _ -> _ = fun _ a => a;
+let always : fun (_ : Type) (_ : Type) -> _ -> _ -> _ = fun _ _ a _ => a;
+{ id, always } : {
+    id : fun (A : Type) -> A -> A,
+    always : fun (A : Type) (B : Type) -> A -> B -> A,
+}
+'''
+stderr = ''

--- a/tests/succeed/record-literal/shorthand-synth.fathom
+++ b/tests/succeed/record-literal/shorthand-synth.fathom
@@ -1,0 +1,4 @@
+let x = false;
+let y = true;
+let z = false;
+{x, y, z}

--- a/tests/succeed/record-literal/shorthand-synth.snap
+++ b/tests/succeed/record-literal/shorthand-synth.snap
@@ -1,0 +1,8 @@
+stdout = '''
+let x : Bool = false; let y : Bool = true; let z : Bool = false; { x, y, z } : {
+    x : Bool,
+    y : Bool,
+    z : Bool,
+}
+'''
+stderr = ''

--- a/tests/succeed/record-pattern/fun-lit-check.fathom
+++ b/tests/succeed/record-pattern/fun-lit-check.fathom
@@ -1,0 +1,4 @@
+let f   = (fun ({}: {}) => {}) : _;
+let get = (fun ({x = a} : {x: Bool}) => a) : _;
+let fst = (fun ({x = a, y = b} : {x: Bool, y: U16}) => a) : _;
+{}

--- a/tests/succeed/record-pattern/fun-lit-check.snap
+++ b/tests/succeed/record-pattern/fun-lit-check.snap
@@ -1,0 +1,9 @@
+stdout = '''
+let f : () -> () = fun _ => ();
+let get : { x : Bool } -> Bool = fun _ => let a : Bool = _.x; a;
+let fst : { x : Bool, y : U16 } -> Bool = fun _ => let a : Bool = _.x;
+let b : U16 = _.y;
+a;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/record-pattern/fun-lit-generic-check.fathom
+++ b/tests/succeed/record-pattern/fun-lit-generic-check.fathom
@@ -1,0 +1,3 @@
+let fst = (fun (A: Type) (B: Type) ({x, y}: {x: A, y: B}) => x) : _;
+let snd = (fun (A: Type) (B: Type) ({x, y}: {x: A, y: B}) => y) : _;
+{}

--- a/tests/succeed/record-pattern/fun-lit-generic-check.snap
+++ b/tests/succeed/record-pattern/fun-lit-generic-check.snap
@@ -1,0 +1,12 @@
+stdout = '''
+let fst : fun (A : Type) (B : Type) -> { x : A, y : B } -> A =
+fun A B _ => let x : A = _.x;
+let y : B = _.y;
+x;
+let snd : fun (A : Type) (B : Type) -> { x : A, y : B } -> B =
+fun A B _ => let x : A = _.x;
+let y : B = _.y;
+y;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/record-pattern/fun-lit-generic-synth.fathom
+++ b/tests/succeed/record-pattern/fun-lit-generic-synth.fathom
@@ -1,0 +1,3 @@
+let fst = fun (A: Type) (B: Type) ({x, y}: {x: A, y: B}) => x;
+let snd = fun (A: Type) (B: Type) ({x, y}: {x: A, y: B}) => y;
+{}

--- a/tests/succeed/record-pattern/fun-lit-generic-synth.snap
+++ b/tests/succeed/record-pattern/fun-lit-generic-synth.snap
@@ -1,0 +1,12 @@
+stdout = '''
+let fst : fun (A : Type) (B : Type) -> { x : A, y : B } -> A =
+fun A B _ => let x : A = _.x;
+let y : B = _.y;
+x;
+let snd : fun (A : Type) (B : Type) -> { x : A, y : B } -> B =
+fun A B _ => let x : A = _.x;
+let y : B = _.y;
+y;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/record-pattern/fun-lit-synth.fathom
+++ b/tests/succeed/record-pattern/fun-lit-synth.fathom
@@ -1,0 +1,4 @@
+let f   = fun ({}: {}) => {};
+let get = fun ({x = a} : {x: Bool}) => a;
+let fst = fun ({x = a, y = b} : {x: Bool, y: U16}) => a;
+{}

--- a/tests/succeed/record-pattern/fun-lit-synth.snap
+++ b/tests/succeed/record-pattern/fun-lit-synth.snap
@@ -1,0 +1,9 @@
+stdout = '''
+let f : () -> () = fun _ => ();
+let get : { x : Bool } -> Bool = fun _ => let a : Bool = _.x; a;
+let fst : { x : Bool, y : U16 } -> Bool = fun _ => let a : Bool = _.x;
+let b : U16 = _.y;
+a;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/record-pattern/fun-type-synth.fathom
+++ b/tests/succeed/record-pattern/fun-type-synth.fathom
@@ -1,0 +1,4 @@
+let f   = fun ({}: {}) -> Bool;
+let get = fun ({x = a} : {x: Type}) -> a;
+let fst = fun ({x = a, y = b} : {x: Type, y: U16}) -> a;
+{}

--- a/tests/succeed/record-pattern/fun-type-synth.snap
+++ b/tests/succeed/record-pattern/fun-type-synth.snap
@@ -1,0 +1,9 @@
+stdout = '''
+let f : Type = () -> Bool;
+let get : Type = fun (_ : { x : Type }) -> (let a : Type = _.x; a);
+let fst : Type = fun (_ : { x : Type, y : U16 }) -> (let a : Type = _.x;
+let b : U16 = _.y;
+a);
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/record-pattern/let-synth.fathom
+++ b/tests/succeed/record-pattern/let-synth.fathom
@@ -1,4 +1,6 @@
 let r = {x1 = false, x2 = false, x3 = {y1 = true, y2 = true}};
 let {x1 = a1, x2 = a2, x3 = {y1 = b1, y2 = b2}} = r;
 let {a, b} = {a = false, b = true};
+let (x, _) = (false, true);
+let (_, _) = (false, true);
 {}

--- a/tests/succeed/record-pattern/let-synth.fathom
+++ b/tests/succeed/record-pattern/let-synth.fathom
@@ -1,0 +1,4 @@
+let r = {x1 = false, x2 = false, x3 = {y1 = true, y2 = true}};
+let {x1 = a1, x2 = a2, x3 = {y1 = b1, y2 = b2}} = r;
+let {a, b} = {a = false, b = true};
+{}

--- a/tests/succeed/record-pattern/let-synth.snap
+++ b/tests/succeed/record-pattern/let-synth.snap
@@ -1,0 +1,16 @@
+stdout = '''
+let r : { x1 : Bool, x2 : Bool, x3 : { y1 : Bool, y2 : Bool } } = {
+    x1 = false,
+    x2 = false,
+    x3 = { y1 = true, y2 = true },
+};
+let a1 : Bool = r.x1;
+let a2 : Bool = r.x2;
+let b1 : Bool = r.x3.y1;
+let b2 : Bool = r.x3.y2;
+let _ : { a : Bool, b : Bool } = { a = false, b = true };
+let a : Bool = _.a;
+let b : Bool = _.b;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/record-pattern/let-synth.snap
+++ b/tests/succeed/record-pattern/let-synth.snap
@@ -11,6 +11,9 @@ let b2 : Bool = r.x3.y2;
 let _ : { a : Bool, b : Bool } = { a = false, b = true };
 let a : Bool = _.a;
 let b : Bool = _.b;
+let _ : (Bool, Bool) = (false, true);
+let x : Bool = _._0;
+let _ : (Bool, Bool) = (false, true);
 () : ()
 '''
 stderr = ''

--- a/tests/succeed/record-pattern/shorthand.fathom
+++ b/tests/succeed/record-pattern/shorthand.fathom
@@ -1,0 +1,3 @@
+let r = {x1 = false, x2 = false, x3 = {y1 = true, y2 = true}};
+let {x1, x2, x3 = {y1, y2}} = r;
+{}

--- a/tests/succeed/record-pattern/shorthand.snap
+++ b/tests/succeed/record-pattern/shorthand.snap
@@ -1,0 +1,13 @@
+stdout = '''
+let r : { x1 : Bool, x2 : Bool, x3 : { y1 : Bool, y2 : Bool } } = {
+    x1 = false,
+    x2 = false,
+    x3 = { y1 = true, y2 = true },
+};
+let x1 : Bool = r.x1;
+let x2 : Bool = r.x2;
+let y1 : Bool = r.x3.y1;
+let y2 : Bool = r.x3.y2;
+() : ()
+'''
+stderr = ''


### PR DESCRIPTION
Adds record and tuple patterns. When used in "irrefutable" positions (ie `let` expressions, fun literals and fun types) they elaborate to chains of simpler `let` expressions.

```fathom
let {x = a, y = b} = r;
z
```
elaborates to
```fathom
let a = r.x;
let b = r.y;
z
```

Using record/tuple patterns in `match` expressions is much more complex, so I will leave that for a follow-up PR