### PR TITLE
Fix issue #408

### DIFF
--- a/tests/succeed/record-type/generic-pair.fathom
+++ b/tests/succeed/record-type/generic-pair.fathom
@@ -1,0 +1,3 @@
+let fst = fun (A: Type) (B: Type) (p: {x: A, y: B}) => p.x;
+let snd = fun (A: Type) (B: Type) (p: {x: A, y: B}) => p.y;
+{}

--- a/tests/succeed/record-type/generic-pair.snap
+++ b/tests/succeed/record-type/generic-pair.snap
@@ -1,0 +1,6 @@
+stdout = '''
+let fst : fun (A : Type) (B : Type) -> { x : A, y : B } -> A = fun A B p => p.x;
+let snd : fun (A : Type) (B : Type) -> { x : A, y : B } -> B = fun A B p => p.y;
+{} : {}
+'''
+stderr = ''

--- a/tests/succeed/record-type/generic-tiple.fathom
+++ b/tests/succeed/record-type/generic-tiple.fathom
@@ -1,0 +1,4 @@
+let get1 = fun (A: Type) (B: Type) (C: Type) (p: {x: A, y: B, z: C}) => p.x;
+let get2 = fun (A: Type) (B: Type) (C: Type) (p: {x: A, y: B, z: C}) => p.y;
+let get3 = fun (A: Type) (B: Type) (C: Type) (p: {x: A, y: B, z: C}) => p.z;
+{}

--- a/tests/succeed/record-type/generic-tiple.snap
+++ b/tests/succeed/record-type/generic-tiple.snap
@@ -1,0 +1,10 @@
+stdout = '''
+let get1 : fun (A : Type) (B : Type) (C : Type) -> { x : A, y : B, z : C } ->
+A = fun A B C p => p.x;
+let get2 : fun (A : Type) (B : Type) (C : Type) -> { x : A, y : B, z : C } ->
+B = fun A B C p => p.y;
+let get3 : fun (A : Type) (B : Type) (C : Type) -> { x : A, y : B, z : C } ->
+C = fun A B C p => p.z;
+{} : {}
+'''
+stderr = ''


### PR DESCRIPTION
The cause of the bug was in the implementation of renaming record telescopes: we were pushing variables onto the local environment while traversing the telescope, rather than onto the partial renaming (cf `rename_closure`)

Fixes #408 