### PR TITLE
Recommend the `EditorConfig` extension for VSCode users

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "EditorConfig.EditorConfig"
+    ]
+}


### PR DESCRIPTION
VSCode allows you to list recommended project-specific extensions in `.vscode/extensions.json`. This will prompt VSCode users to install the listed extensions the first time they load the project. This should make it slightly easier for new contributors who use VSCode to stick to the project's editing style.