### PR TITLE
Some tweaks to tuple distillation

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -1,8 +1,7 @@
 //! Core language.
 
 use crate::env::{Index, Level};
-use crate::source::Span;
-use crate::StringId;
+use crate::source::{Span, StringId};
 
 pub mod binary;
 pub mod prim;

--- a/fathom/src/core/prim.rs
+++ b/fathom/src/core/prim.rs
@@ -6,9 +6,7 @@ use std::sync::Arc;
 use crate::core::semantics::{ArcValue, Elim, ElimEnv, Value};
 use crate::core::{self, Const, Prim, UIntStyle};
 use crate::env::{self, SharedEnv, UniqueEnv};
-use crate::source::Span;
-use crate::source::Spanned;
-use crate::{StringId, StringInterner};
+use crate::source::{Span, Spanned, StringId, StringInterner};
 
 /// Environment of primitives
 pub struct Env<'arena> {

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 use crate::alloc::SliceVec;
 use crate::core::{prim, Const, LocalInfo, Prim, Term};
 use crate::env::{EnvLen, Index, Level, SharedEnv, SliceEnv};
-use crate::source::{Span, Spanned};
-use crate::StringId;
+use crate::source::{Span, Spanned, StringId};
 
 /// Atomically reference counted values. We use reference counting to increase
 /// the amount of sharing we can achieve during evaluation.

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -7,9 +7,9 @@ use std::path::Path;
 
 use crate::core::binary;
 use crate::core::binary::{BufferError, ReadError};
-use crate::source::{ByteRange, FileId, Span};
+use crate::source::{ByteRange, FileId, Span, StringInterner};
 use crate::surface::{self, elaboration};
-use crate::{StringInterner, BUG_REPORT_URL};
+use crate::BUG_REPORT_URL;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Status {

--- a/fathom/src/lib.rs
+++ b/fathom/src/lib.rs
@@ -19,12 +19,3 @@ pub const BUG_REPORT_URL: &str = concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/
 
 // Public exports
 pub use driver::{Driver, Status};
-
-/// Interned strings.
-pub type StringId = string_interner::symbol::SymbolU16;
-
-/// String interner.
-pub type StringInterner = string_interner::StringInterner<
-    string_interner::backend::BucketBackend<StringId>,
-    std::hash::BuildHasherDefault<fxhash::FxHasher32>,
->;

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -1,6 +1,15 @@
+//! Types related to source files.
+
 use std::ops::{Deref, DerefMut};
 
-///! Types related to source files.
+// Interned strings.
+pub type StringId = string_interner::symbol::SymbolU16;
+
+/// String interner.
+pub type StringInterner = string_interner::StringInterner<
+    string_interner::backend::BucketBackend<StringId>,
+    std::hash::BuildHasherDefault<fxhash::FxHasher32>,
+>;
 
 /// File id.
 pub type FileId = usize; // TODO: use wrapper struct

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -7,8 +7,7 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use lalrpop_util::lalrpop_mod;
 use scoped_arena::Scope;
 
-use crate::source::{ByteRange, FileId};
-use crate::{StringId, StringInterner};
+use crate::source::{ByteRange, FileId, StringId, StringInterner};
 
 lalrpop_mod!(
     #[allow(clippy::all)]

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -4,14 +4,14 @@ use scoped_arena::Scope;
 use std::cell::RefCell;
 
 use crate::alloc::SliceVec;
+use crate::core;
 use crate::core::{Const, UIntStyle};
 use crate::env::{self, EnvLen, Index, Level, UniqueEnv};
-use crate::source::Span;
+use crate::source::{Span, StringId, StringInterner};
 use crate::surface::elaboration::MetaSource;
 use crate::surface::{
     BinOp, ExprField, FormatField, Item, ItemDef, Module, Pattern, Term, TypeField,
 };
-use crate::{core, StringId, StringInterner};
 
 /// Distillation context.
 pub struct Context<'interner, 'arena, 'env> {

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -29,10 +29,9 @@ use crate::alloc::SliceVec;
 use crate::core::semantics::{self, ArcValue, Head, Telescope, Value};
 use crate::core::{self, prim, Const, Prim, UIntStyle};
 use crate::env::{self, EnvLen, Level, SharedEnv, UniqueEnv};
-use crate::source::{ByteRange, Span, Spanned};
+use crate::source::{ByteRange, Span, Spanned, StringId, StringInterner};
 use crate::surface::elaboration::reporting::Message;
 use crate::surface::{distillation, pretty, BinOp, FormatField, Item, Module, Pattern, Term};
-use crate::{StringId, StringInterner};
 
 mod order;
 mod reporting;

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -981,11 +981,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 core::Term::RecordLit(range.into(), labels, exprs.into())
             }
             (Term::Tuple(range, elem_exprs), Value::Universe) => {
-                let labels = (0..elem_exprs.len()).map(|idx| {
-                    self.interner
-                        .borrow_mut()
-                        .get_or_intern(format!("_{}", idx))
-                });
+                let labels = (0..elem_exprs.len())
+                    .map(|index| self.interner.borrow_mut().get_tuple_label(index));
                 let labels = self.scope.to_scope_from_iter(labels);
 
                 let initial_local_len = self.local_env.len();
@@ -1018,12 +1015,10 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                     }
 
                     // use numeric labels for excess elems
-                    for (idx, elem_expr) in elem_exprs {
+                    for (index, elem_expr) in elem_exprs {
                         expr_labels.push((
                             elem_expr.range(),
-                            self.interner
-                                .borrow_mut()
-                                .get_or_intern(format!("_{}", idx)),
+                            self.interner.borrow_mut().get_tuple_label(index),
                         ));
                     }
 
@@ -1055,11 +1050,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 let initial_local_len = self.local_env.len();
                 let format_type = self.format_type.clone();
 
-                let labels = (0..elem_exprs.len()).map(|idx| {
-                    self.interner
-                        .borrow_mut()
-                        .get_or_intern(format!("_{}", idx))
-                });
+                let labels = (0..elem_exprs.len())
+                    .map(|index| self.interner.borrow_mut().get_tuple_label(index));
                 let labels = self.scope.to_scope_from_iter(labels);
 
                 let mut formats = SliceVec::new(self.scope, elem_exprs.len());
@@ -1431,11 +1423,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 )
             }
             Term::Tuple(range, elem_exprs) => {
-                let labels = (0..elem_exprs.len()).map(|idx| {
-                    self.interner
-                        .borrow_mut()
-                        .get_or_intern(format!("_{}", idx))
-                });
+                let labels = (0..elem_exprs.len())
+                    .map(|index| self.interner.borrow_mut().get_tuple_label(index));
                 let labels = self.scope.to_scope_from_iter(labels);
 
                 let mut exprs = SliceVec::new(self.scope, labels.len());

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -20,10 +20,9 @@
 
 use fxhash::{FxHashMap, FxHashSet};
 
-use crate::source::ByteRange;
+use crate::source::{ByteRange, StringId};
 use crate::surface::elaboration::reporting::Message;
 use crate::surface::{elaboration, FormatField, Item, Module, Pattern, Term};
-use crate::StringId;
 
 enum Error {
     CycleDetected,

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -2,10 +2,10 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use itertools::Itertools;
 use std::cell::RefCell;
 
-use crate::source::{ByteRange, FileId};
+use crate::source::{ByteRange, FileId, StringId, StringInterner};
 use crate::surface::elaboration::{unification, MetaSource};
 use crate::surface::BinOp;
-use crate::{StringId, StringInterner, BUG_REPORT_URL};
+use crate::BUG_REPORT_URL;
 
 /// Elaboration diagnostic messages.
 #[derive(Debug, Clone)]

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -24,8 +24,7 @@ use crate::core::semantics::{
 };
 use crate::core::{Prim, Term};
 use crate::env::{EnvLen, Index, Level, SharedEnv, SliceEnv, UniqueEnv};
-use crate::source::Spanned;
-use crate::StringId;
+use crate::source::{Spanned, StringId};
 
 /// Errors encountered during unification.
 ///

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -1,8 +1,7 @@
 use scoped_arena::Scope;
 use std::cell::RefCell;
 
-use crate::{StringId, StringInterner};
-use crate::source::{ByteRange, FileId};
+use crate::source::{ByteRange, FileId, StringId, StringInterner};
 use crate::surface::{ExprField, FormatField, Item, ItemDef, Module, ParseMessage, Pattern, Term, TypeField, BinOp};
 use crate::surface::lexer::{Error as LexerError, Token};
 

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -2,8 +2,8 @@ use pretty::{Doc, DocAllocator, DocBuilder, DocPtr, RefDoc};
 use scoped_arena::Scope;
 use std::cell::RefCell;
 
+use crate::source::{StringId, StringInterner};
 use crate::surface::{BinOp, FormatField, Item, Module, Pattern, Term};
-use crate::{StringId, StringInterner};
 
 /// Term precedences
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Some tweaks to the distillation of tuples:

- parses the field labels as opposed to pretty printing then checking for equality
- only checks for type dependencies if the fields of a record look like a tuple