### PR TITLE
Preserve name of default branch in `core::Term::ConstMatch`

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -181,7 +181,7 @@ pub enum Term<'arena> {
         Span,
         &'arena Term<'arena>,
         &'arena [(Const, Term<'arena>)],
-        Option<&'arena Term<'arena>>,
+        Option<(Option<StringId>, &'arena Term<'arena>)>,
     ),
 }
 
@@ -252,7 +252,7 @@ impl<'arena> Term<'arena> {
             Term::ConstMatch(_, scrut, branches, default_expr) => {
                 scrut.binds_local(var)
                     || branches.iter().any(|(_, term)| term.binds_local(var))
-                    || default_expr.map_or(false, |term| term.binds_local(var.prev()))
+                    || default_expr.map_or(false, |(_, term)| term.binds_local(var.prev()))
             }
         }
     }

--- a/tests/succeed/equality.snap
+++ b/tests/succeed/equality.snap
@@ -41,12 +41,12 @@ let four_chars : fun (P : U32 -> Type) -> P "beng" -> P 1650814567 =
 refl U32 "beng";
 let three_chars : fun (P : U32 -> Type) -> P "BEN " -> P 1111838240 =
 refl U32 "BEN ";
-let foo : U32 -> U32 = fun x => match x { 1 => 0, _ => _ };
+let foo : U32 -> U32 = fun x => match x { 1 => 0, x => x };
 let eq_foo : fun (P : (U32 -> U32) -> Type) -> P (fun x => match x {
     1 => 0,
-    _ => _,
-}) -> P (fun x => match x { 1 => 0, _ => _ }) = refl (U32 ->
-U32) (fun _ => match _ { 1 => 0, _ => _ });
+    x => x,
+}) -> P (fun x => match x { 1 => 0, x => x }) = refl (U32 ->
+U32) (fun _ => match _ { 1 => 0, x => x });
 Type : Type
 '''
 stderr = ''

--- a/tests/succeed/match/check-const-1.snap
+++ b/tests/succeed/match/check-const-1.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => 0, _ => _ } : U8
+let x : U8 = 3; match x { 1 => 0, x => x } : U8
 '''
 stderr = ''

--- a/tests/succeed/match/check-const-2.snap
+++ b/tests/succeed/match/check-const-2.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => 0, 3 => 7, _ => _ } : U8
+let x : U8 = 3; match x { 1 => 0, 3 => 7, x => x } : U8
 '''
 stderr = ''

--- a/tests/succeed/match/check-const-redundant.snap
+++ b/tests/succeed/match/check-const-redundant.snap
@@ -1,5 +1,5 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => 0, 3 => 7, _ => _ } : U8
+let x : U8 = 3; match x { 1 => 0, 3 => 7, x => x } : U8
 '''
 stderr = '''
 warning: unreachable pattern

--- a/tests/succeed/match/synth-const-1.snap
+++ b/tests/succeed/match/synth-const-1.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => x, _ => _ } : U8
+let x : U8 = 3; match x { 1 => x, x => x } : U8
 '''
 stderr = ''

--- a/tests/succeed/match/synth-const-2.snap
+++ b/tests/succeed/match/synth-const-2.snap
@@ -1,4 +1,4 @@
 stdout = '''
-let x : U8 = 3; match x { 1 => x, 3 => x, _ => _ } : U8
+let x : U8 = 3; match x { 1 => x, 3 => x, x => x } : U8
 '''
 stderr = ''


### PR DESCRIPTION
At the moment, we throw away the name of the binder when elaborating pattern matches to `ConstMatch` with a default branch

eg
```fathom
match x {
    0 => 1,
    y => y,
}
```
elaborates to 
```fathom
match x {
    0 => 1,
    _ => _,
}
```
This patch preserves the name of the binding, making the elaborated core more readable