### PR TITLE
Fix issue #421

### DIFF
--- a/tests/succeed/tuple/generic-pair.fathom
+++ b/tests/succeed/tuple/generic-pair.fathom
@@ -1,0 +1,3 @@
+let fst = fun (A: Type) (B: Type) (p: {_0: A, _1: B}) => p._0;
+let snd = fun (A: Type) (B: Type) (p: (A, B)) => p._1;
+{}

--- a/tests/succeed/tuple/generic-pair.snap
+++ b/tests/succeed/tuple/generic-pair.snap
@@ -1,0 +1,6 @@
+stdout = '''
+let fst : fun (A : Type) (B : Type) -> (A, B) -> A = fun A B p => p._0;
+let snd : fun (A : Type) (B : Type) -> (A, B) -> B = fun A B p => p._1;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/tuple/generic-triple.fathom
+++ b/tests/succeed/tuple/generic-triple.fathom
@@ -1,0 +1,4 @@
+let get1 = fun (A: Type) (B: Type) (C: Type) (p: {_0: A, _1: B, _2: C}) => p._0;
+let get2 = fun (A: Type) (B: Type) (C: Type) (p: (A, B, C)) => p._1;
+let get3 = fun (A: Type) (B: Type) (C: Type) (p: (A, B, C)) => p._2;
+{}

--- a/tests/succeed/tuple/generic-triple.snap
+++ b/tests/succeed/tuple/generic-triple.snap
@@ -1,0 +1,10 @@
+stdout = '''
+let get1 : fun (A : Type) (B : Type) (C : Type) -> (A, B, C) -> A =
+fun A B C p => p._0;
+let get2 : fun (A : Type) (B : Type) (C : Type) -> (A, B, C) -> B =
+fun A B C p => p._1;
+let get3 : fun (A : Type) (B : Type) (C : Type) -> (A, B, C) -> C =
+fun A B C p => p._2;
+() : ()
+'''
+stderr = ''


### PR DESCRIPTION
- The issue was in distillation: we didn't push labels while distilling dependent tuples.

- Fixed a bug in the caching of tuple labels: `get_tuple_label` would not grow the `tuple_labels` vector, so `tuple_labels` would always be empty! This didn't affect correctness, but it did mean there was no performance improvement. 

- Added `get_tuple_labels` for getting a whole slice of tuple labels at once, and used it to optimize the implementation of `is_tuple_labels` 

Fixes #421 