### PR TITLE
Allow `TestMode` to be set per-file by config comments

### DIFF
--- a/tests/fail/elaboration/item-cycle.fathom
+++ b/tests/fail/elaboration/item-cycle.fathom
@@ -1,4 +1,5 @@
-//~ ignore = true
+//~ exit-code = 1
+//~ mode = "module"
 
 def first = second;
 def second = third;

--- a/tests/fail/elaboration/item-cycle.snap
+++ b/tests/fail/elaboration/item-cycle.snap
@@ -1,0 +1,9 @@
+stdout = ''
+stderr = '''
+error: cycle detected
+ = first → second → third → first
+
+error: cycle detected
+ = a → b → c → d → b
+
+'''


### PR DESCRIPTION
Allows the `TestMode` for test files to be overridden by `//~ mode = "module"` or `//~ mode = "term"` comments