### PR TITLE
Use raw identifiers in LALRPOP grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
  "globwalk",
  "itertools",
  "lalrpop",
- "lalrpop-util",
+ "lalrpop-util 0.19.7",
  "libtest-mimic",
  "logos",
  "pretty",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -567,9 +567,8 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852b75a095da6b69da8c5557731c3afd06525d4f655a4fc1c799e2ec8bc4dce4"
+version = "0.19.8"
+source = "git+https://github.com/kmeakin/lalrpop?branch=raw-identifiers#a945c2a68032f833142bdf6874cf280270c0ec8a"
 dependencies = [
  "ascii-canvas",
  "atty",
@@ -577,7 +576,7 @@ dependencies = [
  "diff",
  "ena",
  "itertools",
- "lalrpop-util",
+ "lalrpop-util 0.19.8",
  "petgraph",
  "pico-args",
  "regex",
@@ -593,6 +592,11 @@ name = "lalrpop-util"
 version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6d265705249fe209280676d8f68887859fa42e1d34f342fc05bd47726a5e188"
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.8"
+source = "git+https://github.com/kmeakin/lalrpop?branch=raw-identifiers#a945c2a68032f833142bdf6874cf280270c0ec8a"
 dependencies = [
  "regex",
 ]
@@ -761,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",

--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -32,7 +32,7 @@ string-interner = "0.14.0"
 termsize = "0.1.6"
 
 [build-dependencies]
-lalrpop = "0.19.5"
+lalrpop = { git = "https://github.com/kmeakin/lalrpop", branch = "raw-identifiers" }
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -68,8 +68,7 @@ pub struct ItemDef<'arena, Range> {
     /// Parameter patterns
     patterns: &'arena [(Pattern<Range>, Option<&'arena Term<'arena, Range>>)],
     /// An optional type annotation for the defined expression
-    // FIXME: raw identifiers in LALRPOP grammars https://github.com/lalrpop/lalrpop/issues/613
-    type_: Option<&'arena Term<'arena, Range>>,
+    r#type: Option<&'arena Term<'arena, Range>>,
     /// The defined expression
     expr: &'arena Term<'arena, Range>,
 }
@@ -347,8 +346,7 @@ pub enum FormatField<'arena, Range> {
         /// Label identifying the field
         label: (Range, StringId),
         /// Optional type annotation
-        // FIXME: raw identifiers in LALRPOP grammars https://github.com/lalrpop/lalrpop/issues/613
-        type_: Option<Term<'arena, Range>>,
+        r#type: Option<Term<'arena, Range>>,
         /// The expression that this field compute
         expr: Term<'arena, Range>,
     },
@@ -360,8 +358,7 @@ pub struct TypeField<'arena, Range> {
     /// Label identifying the field
     label: (Range, StringId),
     /// The type that is expected for this field
-    // FIXME: raw identifiers in LALRPOP grammars https://github.com/lalrpop/lalrpop/issues/613
-    type_: Term<'arena, Range>,
+    r#type: Term<'arena, Range>,
 }
 
 /// A field definition in a record literal

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -113,7 +113,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     range: (),
                     label: ((), *label),
                     patterns: &[],
-                    type_: Some(r#type),
+                    r#type: Some(r#type),
                     expr,
                 })
             }
@@ -551,7 +551,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                         self.push_local(Some(*label));
                         TypeField {
                             label: ((), *label), // TODO: range from span
-                            type_: r#type,
+                            r#type,
                         }
                     }),
                 );
@@ -737,7 +737,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                     FormatField::Computed {
                         label: ((), label),
-                        type_: Some(r#type),
+                        r#type: Some(r#type),
                         expr,
                     }
                 }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -456,8 +456,9 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
             });
         }
 
-        let filtered_fields = (fields.iter().enumerate())
-            .filter_map(move |(index, field)| (!duplicate_indices.contains(&index)).then_some(field));
+        let filtered_fields = (fields.iter().enumerate()).filter_map(move |(index, field)| {
+            (!duplicate_indices.contains(&index)).then_some(field)
+        });
 
         (labels.into(), filtered_fields)
     }
@@ -614,7 +615,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
             match item {
                 Item::Def(item) => {
                     let (expr, type_value) =
-                        self.synth_fun_lit(item.range, item.patterns, item.expr, item.type_);
+                        self.synth_fun_lit(item.range, item.patterns, item.expr, item.r#type);
                     let expr_value = self.eval_env().eval(&expr);
                     let r#type = self.quote_env().quote(self.scope, &type_value);
 
@@ -1408,7 +1409,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 let mut types = SliceVec::new(self.scope, labels.len());
 
                 for type_field in type_fields {
-                    let r#type = self.check(&type_field.type_, &universe);
+                    let r#type = self.check(&type_field.r#type, &universe);
                     let type_value = self.eval_env().eval(&r#type);
                     self.local_env
                         .push_param(Some(type_field.label.1), type_value);
@@ -1889,7 +1890,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 }
                 FormatField::Computed {
                     label: (label_range, label),
-                    type_: r#type,
+                    r#type,
                     expr,
                 } => {
                     let (expr, r#type, type_value) = match r#type {

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -149,7 +149,7 @@ fn item_dependencies(
         Item::Def(item) => {
             let initial_locals_names_len = local_names.len();
             push_pattern_deps(item.patterns, item_names, local_names, &mut deps);
-            if let Some(r#type) = item.type_ {
+            if let Some(r#type) = item.r#type {
                 term_deps(r#type, item_names, local_names, &mut deps);
             }
             term_deps(item.expr, item_names, local_names, &mut deps);
@@ -228,7 +228,7 @@ fn term_deps(
         Term::RecordType(_, type_fields) => {
             let initial_locals_names_len = local_names.len();
             for type_field in *type_fields {
-                term_deps(&type_field.type_, item_names, local_names, deps);
+                term_deps(&type_field.r#type, item_names, local_names, deps);
                 local_names.push(type_field.label.1);
             }
             local_names.truncate(initial_locals_names_len);
@@ -311,10 +311,10 @@ fn field_deps(
             }
             FormatField::Computed {
                 label: (_, label),
-                type_,
+                r#type,
                 expr,
             } => {
-                if let Some(r#type) = type_ {
+                if let Some(r#type) = r#type {
                     term_deps(r#type, item_names, local_names, deps);
                 }
                 term_deps(expr, item_names, local_names, deps);

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -73,12 +73,12 @@ pub Module: Module<'arena, ByteRange> = {
 };
 
 Item: Item<'arena, ByteRange> = {
-    <start: @L> "def" <label: RangedName> <patterns: AnnPattern*> <type_: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
+    <start: @L> "def" <label: RangedName> <patterns: AnnPattern*> <r#type: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
         Item::Def(ItemDef {
             range: ByteRange::new(file_id, start, end),
             label,
             patterns: scope.to_scope_from_iter(patterns),
-            type_: type_.map(|type_| scope.to_scope(type_) as &_),
+            r#type: r#type.map(|r#type| scope.to_scope(r#type) as &_),
             expr: scope.to_scope(expr),
         })
     },
@@ -99,17 +99,16 @@ Pattern: Pattern<ByteRange> = {
 
 AnnPattern: (Pattern<ByteRange>, Option<&'arena Term<'arena, ByteRange>>) = {
     <pattern: Pattern> => (pattern, None),
-    "(" <pattern: Pattern> ":" <type_: LetTerm> ")" => (pattern, Some(scope.to_scope(type_))),
+    "(" <pattern: Pattern> ":" <r#type: LetTerm> ")" => (pattern, Some(scope.to_scope(r#type))),
 };
 
 pub Term: Term<'arena, ByteRange> = {
     LetTerm,
-    // FIXME: LALRPOP does not accept raw identifiers (see: https://github.com/lalrpop/lalrpop/issues/613)
-    <start: @L> <expr: LetTerm> ":" <type_: LetTerm> <end: @R> => {
+    <start: @L> <expr: LetTerm> ":" <r#type: LetTerm> <end: @R> => {
         Term::Ann(
             ByteRange::new(file_id, start, end),
             scope.to_scope(expr),
-            scope.to_scope(type_),
+            scope.to_scope(r#type),
         )
     },
 };
@@ -247,13 +246,13 @@ FormatField: FormatField<'arena, ByteRange> = {
     <label: RangedName> "<-" <format: Term> <pred: ("where" <Term>)?> => {
         FormatField::Format { label, format, pred }
     },
-    "let" <label: RangedName> <type_: (":" <Term>)?> "=" <expr: Term> => {
-        FormatField::Computed { label, type_, expr }
+    "let" <label: RangedName> <r#type: (":" <Term>)?> "=" <expr: Term> => {
+        FormatField::Computed { label, r#type, expr }
     },
 };
 
 TypeField: TypeField<'arena, ByteRange> = {
-    <label: RangedName> ":" <type_: Term> => TypeField { label, type_ },
+    <label: RangedName> ":" <r#type: Term> => TypeField { label, r#type },
 };
 
 ExprField: ExprField<'arena, ByteRange> = {

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -55,7 +55,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 .concat([
                     self.text("def"),
                     self.space(),
-                    match item.type_ {
+                    match item.r#type {
                         None => self.concat([
                             self.string_id(item.label.1),
                             self.ann_patterns(item.patterns),
@@ -269,7 +269,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                         self.space(),
                         self.text(":"),
                         self.space(),
-                        self.term_prec(Prec::Top, &field.type_),
+                        self.term_prec(Prec::Top, &field.r#type),
                     ])
                 }),
                 self.text(","),
@@ -392,11 +392,15 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                     None => self.nil(),
                 },
             ]),
-            FormatField::Computed { label, type_, expr } => self.concat([
+            FormatField::Computed {
+                label,
+                r#type,
+                expr,
+            } => self.concat([
                 self.text("let"),
                 self.space(),
                 self.string_id(label.1),
-                match type_ {
+                match r#type {
                     Some(r#type) => self.concat([
                         self.space(),
                         self.text(":"),


### PR DESCRIPTION
I opened a PR against LALRPOP to lex raw identifiers properly: https://github.com/lalrpop/lalrpop/pull/698. If it is accepted, we can use raw identifiers in our `grammar.lalrpop`. 