### PR TITLE
Lex raw identifiers

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -117,6 +117,8 @@ Names start with a an ASCII letter (`a`..`z` or `A`..`Z`), and end with a
 sequence of ASCII letters (`a`..`z` or `A`..`Z`), numbers (`0`..`9`), or
 underscores (`_`).
 
+Names can be prefixed with `r#` to avoid clashing with keywords, for example `r#let`.
+
 During elaboration, names are resolved to variables bound by:
 
 - [let expressions](#let-expressions)

--- a/fathom/src/core/pretty.rs
+++ b/fathom/src/core/pretty.rs
@@ -29,6 +29,7 @@ use std::cell::RefCell;
 
 use crate::core::{Item, Module, Term};
 use crate::source::{StringId, StringInterner};
+use crate::surface::lexer::is_keyword;
 
 /// Term precedences
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -55,6 +56,7 @@ impl<'interner, 'arena> Context<'interner> {
 
     fn string_id(&'arena self, name: StringId) -> RcDoc {
         match self.interner.borrow().resolve(name) {
+            Some(name) if is_keyword(name) => RcDoc::text(format!("r#{name}")),
             Some(name) => RcDoc::text(name.to_owned()),
             None => RcDoc::text("#error"),
         }

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -17,7 +17,7 @@ lalrpop_mod!(
     grammar,
     "/surface/grammar.rs"
 );
-mod lexer;
+pub mod lexer;
 pub mod pretty;
 
 pub mod distillation;

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -6,11 +6,21 @@ use crate::{
     source::{BytePos, ByteRange},
 };
 
+pub const KEYWORDS: &[&str] = &[
+    "def", "else", "false", "fun", "if", "let", "match", "overlap", "then", "true", "Type", "where",
+];
+
+pub fn is_keyword(word: &str) -> bool {
+    KEYWORDS.iter().any(|keyword| word == *keyword)
+}
+
 #[derive(Clone, Debug, Logos)]
 pub enum Token<'source> {
     #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*")]
+    #[regex(r"r#[a-zA-Z_][a-zA-Z0-9_]*", |lex| &lex.slice()[2..])]
     Name(&'source str),
     #[regex(r"\?[a-zA-Z_][a-zA-Z0-9_]*", |lex| &lex.slice()[1..])]
+    #[regex(r"\?r#[a-zA-Z_][a-zA-Z0-9_]*", |lex| &lex.slice()[3..])]
     Hole(&'source str),
     #[regex(r#""([^"\\]|\\.)*""#, |lex| &lex.slice()[1..(lex.slice().len() - 1)])]
     StringLiteral(&'source str),

--- a/tests/succeed/raw-identifiers.fathom
+++ b/tests/succeed/raw-identifiers.fathom
@@ -1,0 +1,3 @@
+let r#def = false;
+let r#foo = r#def;
+foo

--- a/tests/succeed/raw-identifiers.snap
+++ b/tests/succeed/raw-identifiers.snap
@@ -1,0 +1,4 @@
+stdout = '''
+let r#def : Bool = false; let foo : Bool = r#def; foo : Bool
+'''
+stderr = ''


### PR DESCRIPTION
Allow keywords to be used as identifiers by prefixing them with `r#`, as in Rust (eg `r#let`)