### PR TITLE
Implicit args

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -8,7 +8,7 @@
 - [x] let expressions
 - [x] dependent function types
   - [x] condensed syntax for multiple parameters
-  - [ ] implicit parameters
+  - [x] implicit parameters
 - [x] records
   - [x] non-dependent
   - [x] dependent

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -381,8 +381,8 @@ impl<'arena, 'data> Context<'arena, 'data> {
             Value::Stuck(Head::LocalVar(_), _)
             | Value::Stuck(Head::MetaVar(_), _)
             | Value::Universe
-            | Value::FunType(_, _, _)
-            | Value::FunLit(_, _)
+            | Value::FunType(..)
+            | Value::FunLit(..)
             | Value::RecordType(_, _)
             | Value::RecordLit(_, _)
             | Value::ArrayLit(_)
@@ -419,22 +419,22 @@ impl<'arena, 'data> Context<'arena, 'data> {
             (Prim::FormatF32Le, []) => read_const(reader, span, read_f32le, Const::F32),
             (Prim::FormatF64Be, []) => read_const(reader, span, read_f64be, Const::F64),
             (Prim::FormatF64Le, []) => read_const(reader, span, read_f64le, Const::F64),
-            (Prim::FormatArray8, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
-            (Prim::FormatArray16, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
-            (Prim::FormatArray32, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
-            (Prim::FormatArray64, [FunApp(len), FunApp(format)]) => self.read_array(reader, span, len, format),
-            (Prim::FormatRepeatUntilEnd, [FunApp(format)]) => self.read_repeat_until_end(reader, format),
-            (Prim::FormatLimit8, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
-            (Prim::FormatLimit16, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
-            (Prim::FormatLimit32, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
-            (Prim::FormatLimit64, [FunApp(limit), FunApp(format)]) => self.read_limit(reader, limit, format),
-            (Prim::FormatLink, [FunApp(pos), FunApp(format)]) => self.read_link(span, pos, format),
-            (Prim::FormatDeref, [FunApp(format), FunApp(r#ref)]) => self.read_deref(format, r#ref),
+            (Prim::FormatArray8, [FunApp(_, len), FunApp(_, format)]) => self.read_array(reader, span, len, format),
+            (Prim::FormatArray16, [FunApp(_, len), FunApp(_, format)]) => self.read_array(reader, span, len, format),
+            (Prim::FormatArray32, [FunApp(_, len), FunApp(_, format)]) => self.read_array(reader, span, len, format),
+            (Prim::FormatArray64, [FunApp(_, len), FunApp(_, format)]) => self.read_array(reader, span, len, format),
+            (Prim::FormatRepeatUntilEnd, [FunApp(_,format)]) => self.read_repeat_until_end(reader, format),
+            (Prim::FormatLimit8, [FunApp(_, limit), FunApp(_, format)]) => self.read_limit(reader, limit, format),
+            (Prim::FormatLimit16, [FunApp(_, limit), FunApp(_, format)]) => self.read_limit(reader, limit, format),
+            (Prim::FormatLimit32, [FunApp(_, limit), FunApp(_, format)]) => self.read_limit(reader, limit, format),
+            (Prim::FormatLimit64, [FunApp(_, limit), FunApp(_, format)]) => self.read_limit(reader, limit, format),
+            (Prim::FormatLink, [FunApp(_, pos), FunApp(_, format)]) => self.read_link(span, pos, format),
+            (Prim::FormatDeref, [FunApp(_, format), FunApp(_, r#ref)]) => self.read_deref(format, r#ref),
             (Prim::FormatStreamPos, []) => read_stream_pos(reader, span),
-            (Prim::FormatSucceed, [_, FunApp(elem)]) => Ok(elem.clone()),
+            (Prim::FormatSucceed, [_, FunApp(_, elem)]) => Ok(elem.clone()),
             (Prim::FormatFail, []) => Err(ReadError::ReadFailFormat(span)),
-            (Prim::FormatUnwrap, [_, FunApp(option)]) => match option.match_prim_spine() {
-                Some((Prim::OptionSome, [FunApp(elem)])) => Ok(elem.clone()),
+            (Prim::FormatUnwrap, [_, FunApp(_, option)]) => match option.match_prim_spine() {
+                Some((Prim::OptionSome, [FunApp(_, elem)])) => Ok(elem.clone()),
                 Some((Prim::OptionNone, [])) => Err(ReadError::UnwrappedNone(span)),
                 _ => Err(ReadError::InvalidValue(span)),
             },

--- a/fathom/src/core/prim.rs
+++ b/fathom/src/core/prim.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::core::semantics::{ArcValue, Elim, ElimEnv, Value};
-use crate::core::{self, Const, Prim, UIntStyle};
+use crate::core::{self, Const, Plicity, Prim, UIntStyle};
 use crate::env::{self, SharedEnv, UniqueEnv};
 use crate::source::{Span, Spanned, StringId, StringInterner};
 
@@ -109,12 +109,19 @@ impl<'arena> Env<'arena> {
             FormatDeref,
             &core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("A"),
                 &FORMAT_TYPE,
                 &Term::FunType(
                     Span::Empty,
+                    Plicity::Explicit,
                     None,
-                    &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, RefType), &VAR0),
+                    &Term::FunApp(
+                        Span::Empty,
+                        Plicity::Explicit,
+                        &Term::Prim(Span::Empty, RefType),
+                        &VAR0,
+                    ),
                     &FORMAT_TYPE,
                 ),
             ),
@@ -124,9 +131,10 @@ impl<'arena> Env<'arena> {
             FormatSucceed,
             &core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("A"),
                 &UNIVERSE,
-                &Term::FunType(Span::Empty, None, &VAR0, &FORMAT_TYPE),
+                &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR0, &FORMAT_TYPE),
             ),
         );
         env.define_prim(FormatFail, &FORMAT_TYPE);
@@ -136,12 +144,19 @@ impl<'arena> Env<'arena> {
             // fun (A : Type) -> Option A@0 -> Format
             &core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("A"),
                 &UNIVERSE,
                 &Term::FunType(
                     Span::Empty,
+                    Plicity::Explicit,
                     None,
-                    &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR0),
+                    &Term::FunApp(
+                        Span::Empty,
+                        Plicity::Explicit,
+                        &Term::Prim(Span::Empty, OptionType),
+                        &VAR0,
+                    ),
                     &FORMAT_TYPE,
                 ),
             ),
@@ -285,13 +300,20 @@ impl<'arena> Env<'arena> {
             // fun (A : Type) -> A@0 -> Option A@1
             &core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("A"),
                 &UNIVERSE,
                 &Term::FunType(
                     Span::Empty,
+                    Plicity::Explicit,
                     None,
                     &VAR0,
-                    &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR1),
+                    &Term::FunApp(
+                        Span::Empty,
+                        Plicity::Explicit,
+                        &Term::Prim(Span::Empty, OptionType),
+                        &VAR1,
+                    ),
                 ),
             ),
         );
@@ -301,9 +323,15 @@ impl<'arena> Env<'arena> {
             // fun (A : Type) -> Option A@0
             &core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("A"),
                 &UNIVERSE,
-                &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR0),
+                &Term::FunApp(
+                    Span::Empty,
+                    Plicity::Explicit,
+                    &Term::Prim(Span::Empty, OptionType),
+                    &VAR0,
+                ),
             ),
         );
         env.define_prim(
@@ -312,25 +340,31 @@ impl<'arena> Env<'arena> {
             // fun (A : Type) (B : Type) -> B@0 -> (A@2 -> B@2) -> Option A@3 -> B@3
             scope.to_scope(core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("A"),
                 &UNIVERSE,
                 scope.to_scope(core::Term::FunType(
                     Span::Empty,
+                    Plicity::Explicit,
                     env.name("B"),
                     &UNIVERSE,
                     scope.to_scope(core::Term::FunType(
                         Span::Empty,
+                        Plicity::Explicit,
                         None,
                         &VAR0, // B@0
                         scope.to_scope(core::Term::FunType(
                             Span::Empty,
+                            Plicity::Explicit,
                             None,
-                            &Term::FunType(Span::Empty, None, &VAR2, &VAR2), // A@2 -> B@2
+                            &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR2, &VAR2), // A@2 -> B@2
                             scope.to_scope(core::Term::FunType(
                                 Span::Empty,
+                                Plicity::Explicit,
                                 None,
                                 &Term::FunApp(
                                     Span::Empty,
+                                    Plicity::Explicit,
                                     &Term::Prim(Span::Empty, OptionType),
                                     &VAR3,
                                 ), // Option A@3
@@ -347,26 +381,41 @@ impl<'arena> Env<'arena> {
         let find_type = |index_type, array_type| {
             scope.to_scope(core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("len"),
                 index_type,
                 scope.to_scope(core::Term::FunType(
                     Span::Empty,
+                    Plicity::Explicit,
                     env.name("A"),
                     &UNIVERSE,
                     scope.to_scope(core::Term::FunType(
                         Span::Empty,
+                        Plicity::Explicit,
                         None,
-                        &Term::FunType(Span::Empty, None, &VAR0, &BOOL_TYPE), // (A@0 -> Bool)
+                        &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR0, &BOOL_TYPE), // (A@0 -> Bool)
                         scope.to_scope(core::Term::FunType(
                             Span::Empty,
+                            Plicity::Explicit,
                             None,
                             // ArrayN len@2 A@1
                             scope.to_scope(Term::FunApp(
                                 Span::Empty,
-                                scope.to_scope(Term::FunApp(Span::Empty, array_type, &VAR2)),
+                                Plicity::Explicit,
+                                scope.to_scope(Term::FunApp(
+                                    Span::Empty,
+                                    Plicity::Explicit,
+                                    array_type,
+                                    &VAR2,
+                                )),
                                 &VAR1,
                             )),
-                            &Term::FunApp(Span::Empty, &Term::Prim(Span::Empty, OptionType), &VAR2), // Option A@2
+                            &Term::FunApp(
+                                Span::Empty,
+                                Plicity::Explicit,
+                                &Term::Prim(Span::Empty, OptionType),
+                                &VAR2,
+                            ), // Option A@2
                         )),
                     )),
                 )),
@@ -386,23 +435,33 @@ impl<'arena> Env<'arena> {
         let array_index_type = |index_type, array_type| {
             scope.to_scope(core::Term::FunType(
                 Span::Empty,
+                Plicity::Explicit,
                 env.name("len"),
                 index_type,
                 scope.to_scope(core::Term::FunType(
                     Span::Empty,
+                    Plicity::Explicit,
                     env.name("A"),
                     &UNIVERSE,
                     scope.to_scope(core::Term::FunType(
                         Span::Empty,
+                        Plicity::Explicit,
                         env.name("index"),
                         index_type,
                         scope.to_scope(core::Term::FunType(
                             Span::Empty,
+                            Plicity::Explicit,
                             None,
                             // ArrayN len@2 A@1
                             scope.to_scope(Term::FunApp(
                                 Span::Empty,
-                                scope.to_scope(Term::FunApp(Span::Empty, array_type, &VAR2)),
+                                Plicity::Explicit,
+                                scope.to_scope(Term::FunApp(
+                                    Span::Empty,
+                                    Plicity::Explicit,
+                                    array_type,
+                                    &VAR2,
+                                )),
                                 &VAR1,
                             )),
                             &VAR2, // A@2
@@ -474,8 +533,13 @@ impl<'interner, 'arena> EnvBuilder<'interner, 'arena> {
         self.define_prim(
             prim,
             (param_types.iter().rev()).fold(body_type, |r#type, param_type| {
-                self.scope
-                    .to_scope(core::Term::FunType(Span::Empty, None, param_type, r#type))
+                self.scope.to_scope(core::Term::FunType(
+                    Span::Empty,
+                    Plicity::Explicit,
+                    None,
+                    param_type,
+                    r#type,
+                ))
             }),
         );
     }
@@ -493,7 +557,7 @@ pub type Step = for<'arena> fn(&ElimEnv<'arena, '_>, &[Elim<'arena>]) -> Option<
 macro_rules! step {
     ($env:pat, [$($param:pat),*] => $body:expr) => {
         |$env, spine| match spine {
-            [$(Elim::FunApp($param)),*] => Some($body),
+            [$(Elim::FunApp(Plicity::Explicit, $param)),*] => Some($body),
             _ => return None,
         }
     };
@@ -698,7 +762,7 @@ pub fn step(prim: Prim) -> Step {
 
         Prim::OptionFold => step!(env, [_, _, on_none, on_some, option] => {
             match option.match_prim_spine()? {
-                (Prim::OptionSome, [Elim::FunApp(value)]) => env.fun_app(on_some.clone(), value.clone()),
+                (Prim::OptionSome, [Elim::FunApp(Plicity::Explicit, value)]) => env.fun_app(Plicity::Explicit,on_some.clone(), value.clone()),
                 (Prim::OptionNone, []) => on_none.clone(),
                 _ => return None,
             }
@@ -708,7 +772,7 @@ pub fn step(prim: Prim) -> Step {
             step!(env, [_, _, pred, array] => match array.as_ref() {
                 Value::ArrayLit(elems) => {
                     for elem in elems {
-                        match env.fun_app(pred.clone(), elem.clone()).as_ref() {
+                        match env.fun_app(Plicity::Explicit, pred.clone(), elem.clone()).as_ref() {
                             Value::ConstLit(Const::Bool(true)) => {
                                 // TODO: Is elem.span right here?
                                 return Some(Spanned::new(elem.span(), Arc::new(Value::prim(Prim::OptionSome, [elem.clone()]))))

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -8,6 +8,7 @@ use lalrpop_util::lalrpop_mod;
 use scoped_arena::Scope;
 
 use crate::{
+    core::Plicity,
     files::FileId,
     source::{BytePos, ByteRange, StringId, StringInterner},
 };
@@ -331,12 +332,6 @@ impl<'arena> Term<'arena, ByteRange> {
 
         (term, messages)
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Plicity {
-    Explicit,
-    Implicit,
 }
 
 #[derive(Debug, Clone)]

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -69,7 +69,7 @@ pub struct ItemDef<'arena, Range> {
     /// The label that identifies this definition
     label: (Range, StringId),
     /// Parameter patterns
-    patterns: &'arena [(Pattern<Range>, Option<&'arena Term<'arena, Range>>)],
+    params: &'arena [FunParam<'arena, Range>],
     /// An optional type annotation for the defined expression
     r#type: Option<&'arena Term<'arena, Range>>,
     /// The defined expression
@@ -206,26 +206,27 @@ pub enum Term<'arena, Range> {
     /// Arrow types.
     Arrow(
         Range,
+        Plicity,
         &'arena Term<'arena, Range>,
         &'arena Term<'arena, Range>,
     ),
     /// Dependent function types.
     FunType(
         Range,
-        &'arena [(Pattern<Range>, Option<&'arena Term<'arena, Range>>)],
+        &'arena [FunParam<'arena, Range>],
         &'arena Term<'arena, Range>,
     ),
     /// Function literals.
     FunLiteral(
         Range,
-        &'arena [(Pattern<Range>, Option<&'arena Term<'arena, Range>>)],
+        &'arena [FunParam<'arena, Range>],
         &'arena Term<'arena, Range>,
     ),
     /// Applications.
     App(
         Range,
         &'arena Term<'arena, Range>,
-        &'arena [Term<'arena, Range>],
+        &'arena [AppArg<'arena, Range>],
     ),
     /// Dependent record types.
     RecordType(Range, &'arena [TypeField<'arena, Range>]),
@@ -286,7 +287,7 @@ impl<'arena, Range: Clone> Term<'arena, Range> {
             | Term::If(range, _, _, _)
             | Term::Match(range, _, _)
             | Term::Universe(range)
-            | Term::Arrow(range, _, _)
+            | Term::Arrow(range, ..)
             | Term::FunType(range, _, _)
             | Term::FunLiteral(range, _, _)
             | Term::App(range, _, _)
@@ -330,6 +331,26 @@ impl<'arena> Term<'arena, ByteRange> {
 
         (term, messages)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Plicity {
+    Explicit,
+    Implicit,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunParam<'arena, Range> {
+    pub plicity: Plicity,
+    pub pattern: Pattern<Range>,
+    pub r#type: Option<Term<'arena, Range>>,
+}
+
+#[derive(Debug, Clone)]
+
+pub struct AppArg<'arena, Range> {
+    pub plicity: Plicity,
+    pub term: Term<'arena, Range>,
 }
 
 /// A field declaration in a record and offset format

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -2,7 +2,7 @@ use scoped_arena::Scope;
 use std::cell::RefCell;
 
 use crate::source::{ByteRange, BytePos, StringId, StringInterner};
-use crate::surface::{ExprField, FormatField, Item, ItemDef, Module, ParseMessage, Pattern, Term, TypeField, BinOp};
+use crate::surface::{ExprField, FormatField, Item, ItemDef, Module, ParseMessage, Pattern, Term, TypeField, BinOp, Plicity, FunParam, AppArg};
 use crate::surface::lexer::{Error as LexerError, Token};
 use crate::files::FileId;
 
@@ -36,6 +36,7 @@ extern {
         "false" => Token::KeywordFalse,
         "where" => Token::KeywordWhere,
 
+        "@" => Token::At,
         ":" => Token::Colon,
         "," => Token::Comma,
         "=" => Token::Equals,
@@ -74,11 +75,11 @@ pub Module: Module<'arena, ByteRange> = {
 };
 
 Item: Item<'arena, ByteRange> = {
-    <start: @L> "def" <label: RangedName> <patterns: AnnPattern*> <r#type: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
+    <start: @L> "def" <label: RangedName> <params: FunParam*> <r#type: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
         Item::Def(ItemDef {
             range: ByteRange::new(file_id, start, end),
             label,
-            patterns: scope.to_scope_from_iter(patterns),
+            params: scope.to_scope_from_iter(params),
             r#type: r#type.map(|r#type| scope.to_scope(r#type) as &_),
             expr: scope.to_scope(expr),
         })
@@ -96,11 +97,6 @@ Pattern: Pattern<ByteRange> = {
     <start: @L> <number: NumberLiteral> <end: @R> => Pattern::NumberLiteral(ByteRange::new(file_id, start, end), number),
     <start: @L> "true" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(file_id, start, end), true),
     <start: @L> "false" <end: @R> => Pattern::BooleanLiteral(ByteRange::new(file_id, start, end), false),
-};
-
-AnnPattern: (Pattern<ByteRange>, Option<&'arena Term<'arena, ByteRange>>) = {
-    <pattern: Pattern> => (pattern, None),
-    "(" <pattern: Pattern> ":" <r#type: LetTerm> ")" => (pattern, Some(scope.to_scope(r#type))),
 };
 
 pub Term: Term<'arena, ByteRange> = {
@@ -132,24 +128,25 @@ LetTerm: Term<'arena, ByteRange> = {
 
 FunTerm: Term<'arena, ByteRange> = {
     EqExpr,
-    <start: @L> <param_type: AppTerm> "->"  <body_type: FunTerm> <end: @R> => {
+    <start: @L> <plicity: Plicity> <param_type: AppTerm> "->"  <body_type: FunTerm> <end: @R> => {
         Term::Arrow(
             ByteRange::new(file_id, start, end),
+            plicity,
             scope.to_scope(param_type),
             scope.to_scope(body_type),
         )
     },
-    <start: @L> "fun" <patterns: AnnPattern+> "->"  <output_type: FunTerm> <end: @R> => {
+    <start: @L> "fun" <params: FunParam+> "->"  <output_type: FunTerm> <end: @R> => {
         Term::FunType(
             ByteRange::new(file_id, start, end),
-            scope.to_scope_from_iter(patterns),
+            scope.to_scope_from_iter(params),
             scope.to_scope(output_type),
         )
     },
-    <start: @L> "fun" <patterns: AnnPattern+> "=>" <output_type: LetTerm> <end: @R> => {
+    <start: @L> "fun" <params: FunParam+> "=>" <output_type: LetTerm> <end: @R> => {
         Term::FunLiteral(
             ByteRange::new(file_id, start, end),
-            scope.to_scope_from_iter(patterns),
+            scope.to_scope_from_iter(params),
             scope.to_scope(output_type),
         )
     },
@@ -183,14 +180,18 @@ MulExpr: Term<'arena, ByteRange> = {
 
 AppTerm: Term<'arena, ByteRange> = {
     ProjTerm,
-    <start: @L> <head_expr: ProjTerm> <arg_exprs: ProjTerm+> <end: @R> => {
+    <start: @L> <head_expr: ProjTerm> <args: AppArg+> <end: @R> => {
         Term::App(
             ByteRange::new(file_id, start, end),
             scope.to_scope(head_expr),
-            scope.to_scope_from_iter(arg_exprs),
+            scope.to_scope_from_iter(args),
         )
     },
 };
+
+AppArg: AppArg<'arena, ByteRange> = {
+    <plicity: Plicity> <term: ProjTerm> => AppArg {plicity, term},
+}
 
 ProjTerm: Term<'arena, ByteRange> = {
     AtomicTerm,
@@ -293,6 +294,17 @@ Tuple<Elem>: &'arena [Elem] = {
     "(" <term: Term> "," ")" => scope.to_scope_from_iter([term]),
     "(" <terms: Seq2<Term, ",">> ")" => terms,
 };
+
+#[inline]
+Plicity: Plicity = {
+    () => Plicity::Explicit,
+    "@" => Plicity::Implicit,
+}
+
+FunParam: FunParam<'arena, ByteRange> = {
+    <plicity: Plicity> <pattern: Pattern> => FunParam {plicity, pattern, r#type: None},
+    "(" <plicity: Plicity> <pattern: Pattern> ":" <r#type: LetTerm> ")" => FunParam{plicity, pattern, r#type: Some(r#type)},
+}
 
 #[inline]
 RangedName: (ByteRange, StringId) = {

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -52,6 +52,8 @@ pub enum Token<'source> {
     #[token("where")]
     KeywordWhere,
 
+    #[token("@")]
+    At,
     #[token(":")]
     Colon,
     #[token(",")]
@@ -174,6 +176,7 @@ impl<'source> Token<'source> {
             Token::KeywordTrue => "true",
             Token::KeywordType => "Type",
             Token::KeywordWhere => "where",
+            Token::At => "@",
             Token::Colon => ":",
             Token::Comma => ",",
             Token::Equals => "=>",

--- a/tests/fail/elaboration/implicit-args/app-plicity-mismatch.fathom
+++ b/tests/fail/elaboration/implicit-args/app-plicity-mismatch.fathom
@@ -1,0 +1,8 @@
+//~ exit-code = 1
+
+let id1 = fun (A : Type) (a : A) => a;
+let id2 = fun (@A : Type) (a : A) => a;
+
+let _ : Bool = id1 @Bool true;
+let _ : Bool = id2 @Bool @true;
+{}

--- a/tests/fail/elaboration/implicit-args/app-plicity-mismatch.snap
+++ b/tests/fail/elaboration/implicit-args/app-plicity-mismatch.snap
@@ -1,0 +1,19 @@
+stdout = ''
+stderr = '''
+error: implicit argument was applied to an explicit function
+  ┌─ tests/fail/elaboration/implicit-args/app-plicity-mismatch.fathom:6:21
+  │
+6 │ let _ : Bool = id1 @Bool true;
+  │                ---  ^^^^ implicit argument
+  │                │     
+  │                explicit function of type fun (A : Type) -> A -> A
+
+error: implicit argument was applied to an explicit function
+  ┌─ tests/fail/elaboration/implicit-args/app-plicity-mismatch.fathom:7:27
+  │
+7 │ let _ : Bool = id2 @Bool @true;
+  │                ---------  ^^^^ implicit argument
+  │                │           
+  │                explicit function of type Bool -> Bool
+
+'''

--- a/tests/fail/elaboration/implicit-args/unexpected-argument.fathom
+++ b/tests/fail/elaboration/implicit-args/unexpected-argument.fathom
@@ -1,0 +1,3 @@
+//~ exit-code = 1
+
+true @Bool

--- a/tests/fail/elaboration/implicit-args/unexpected-argument.snap
+++ b/tests/fail/elaboration/implicit-args/unexpected-argument.snap
@@ -1,0 +1,11 @@
+stdout = ''
+stderr = '''
+error: expression was applied to an unexpected argument
+  ┌─ tests/fail/elaboration/implicit-args/unexpected-argument.fathom:3:7
+  │
+3 │ true @Bool
+  │ ----  ^^^^ unexpected argument
+  │ │      
+  │ expression of type Bool
+
+'''

--- a/tests/succeed/implicit-args/generalize.fathom
+++ b/tests/succeed/implicit-args/generalize.fathom
@@ -1,0 +1,4 @@
+let id : fun (@A : Type) -> A -> A = fun a => a;
+let always : fun (@A : Type) (@B : Type) -> A -> B -> A = fun a b => a;
+let apply : fun (@A : Type) (@B : Type) -> (A -> B) -> A -> B = fun f x => f x;
+{}

--- a/tests/succeed/implicit-args/generalize.snap
+++ b/tests/succeed/implicit-args/generalize.snap
@@ -1,0 +1,8 @@
+stdout = '''
+let id : fun (@A : Type) -> A -> A = fun @A a => a;
+let always : fun (@A : Type) (@B : Type) -> A -> B -> A = fun @A @B a b => a;
+let apply : fun (@A : Type) (@B : Type) -> (A -> B) -> A -> B =
+fun @A @B f x => f x;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/implicit-args/insert-args.fathom
+++ b/tests/succeed/implicit-args/insert-args.fathom
@@ -1,0 +1,6 @@
+let id = fun (@A : Type) (a : A) => a;
+let always = fun (@A : Type) (@B : Type) (a : A) (b : B) => a;
+
+let _ = id false;
+let _ = always (0 : U32) false;
+{}

--- a/tests/succeed/implicit-args/insert-args.snap
+++ b/tests/succeed/implicit-args/insert-args.snap
@@ -1,0 +1,8 @@
+stdout = '''
+let id : fun (@A : Type) -> A -> A = fun @A a => a;
+let always : fun (@A : Type) (@B : Type) -> A -> B -> A = fun @A @B a b => a;
+let _ : Bool = id @Bool false;
+let _ : U32 = always @U32 @Bool 0 false;
+() : ()
+'''
+stderr = ''

--- a/tests/succeed/implicit-args/specialize.fathom
+++ b/tests/succeed/implicit-args/specialize.fathom
@@ -1,0 +1,18 @@
+let id = fun (@A : Type) (a : A) => a;
+let always = fun (@A : Type) (@B : Type) (a : A) (b : B) => a;
+let apply = fun (@A : Type) (@B : Type) (f : A -> B) (x : A) => f x;
+
+// No specialisation
+let _ = id;
+let _ = always;
+let _ = apply;
+
+// Full specialisation
+let _ : Bool -> Bool = id;
+let _ : Bool -> U32 -> Bool = always;
+let _ : (Bool -> U32) -> Bool -> U32 = apply;
+
+// Specialisation of higher order functions
+let _ = apply (always false) (0 : U32);
+
+{}

--- a/tests/succeed/implicit-args/specialize.snap
+++ b/tests/succeed/implicit-args/specialize.snap
@@ -1,0 +1,15 @@
+stdout = '''
+let id : fun (@A : Type) -> A -> A = fun @A a => a;
+let always : fun (@A : Type) (@B : Type) -> A -> B -> A = fun @A @B a b => a;
+let apply : fun (@A : Type) (@B : Type) -> (A -> B) -> A -> B =
+fun @A @B f x => f x;
+let _ : fun (@A : Type) -> A -> A = id;
+let _ : fun (@A : Type) (@B : Type) -> A -> B -> A = always;
+let _ : fun (@A : Type) (@B : Type) -> (A -> B) -> A -> B = apply;
+let _ : Bool -> Bool = id @Bool;
+let _ : Bool -> U32 -> Bool = always @Bool @U32;
+let _ : (Bool -> U32) -> Bool -> U32 = apply @Bool @U32;
+let _ : Bool = apply @U32 @Bool (always @Bool @U32 false) 0;
+() : ()
+'''
+stderr = ''


### PR DESCRIPTION
Implement implicit arguments in the style of [elaboration zoo](https://github.com/AndrasKovacs/elaboration-zoo/tree/master/04-implicit-args).

# New Syntax
- Implicit function types: `@A -> A` and `fun (@A : Type) -> A`
- Implicit function literals: `fun @x => x`
- Implicit function applications: `id @Bool`

# New Typing Judgements
- When synthesizing an explicit function application, insert implicit function applications for each implicit argument in the head type
- When checking a term against an implicit function type, insert implicit function applications for each implicit argument in the expected type
- When checking an explicit function literal against an implicit function type, wrap the checked term in an implicit function literal

I find it intuitive to think of inserting implicit applications as **specializing** the applied function, and wrapping in implicit function literals as **generalizing** the checked function, but I haven't checked against the literature to see if they are the technically correct terms.  