### PR TITLE
Fix ordering of `expected` and `found` types in elaboration::convert

### DIFF
--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -94,8 +94,8 @@ pub enum Message {
     /// Unification errors.
     FailedToUnify {
         range: ByteRange,
-        lhs: String,
-        rhs: String,
+        found: String,
+        expected: String,
         error: unification::Error,
     },
     BinOpMismatchedTypes {
@@ -212,9 +212,11 @@ impl Message {
                             match type_labels.next() {
                                 None => {
                                     let expr_label = interner.resolve(*expr_label).unwrap();
-                                    diagnostic_labels.push(primary_label(range).with_message(
-                                        format!("unexpected field `{expr_label}`",),
-                                    ));
+                                    diagnostic_labels.push(
+                                        primary_label(range).with_message(format!(
+                                            "unexpected field `{expr_label}`",
+                                        )),
+                                    );
                                     continue 'expr_labels;
                                 }
                                 Some(type_label) if expr_label == type_label => {
@@ -376,8 +378,8 @@ impl Message {
                 ]),
             Message::FailedToUnify {
                 range,
-                lhs,
-                rhs,
+                found,
+                expected,
                 error,
             } => {
                 use unification::{Error, RenameError, SpineError};
@@ -387,11 +389,11 @@ impl Message {
                     Error::Mismatch => Diagnostic::error()
                         .with_message("mismatched types")
                         .with_labels(vec![primary_label(range).with_message(format!(
-                            "type mismatch, expected `{lhs}`, found `{rhs}`"
+                            "type mismatch, expected `{expected}`, found `{found}`"
                         ))])
                         .with_notes(vec![[
-                            format!("expected `{lhs}`"),
-                            format!("   found `{rhs}`"),
+                            format!("expected `{expected}`"),
+                            format!("   found `{found}`"),
                         ]
                         .join("\n")]),
                     // TODO: reduce confusion around ‘problem spines’

--- a/tests/cmd/fathom-data.md
+++ b/tests/cmd/fathom-data.md
@@ -266,10 +266,10 @@ error: mismatched types
   ┌─ <FORMAT>:1:1
   │
 1 │ { x : U64 }
-  │ ^^^^^^^^^^^ type mismatch, expected `Type`, found `Format`
+  │ ^^^^^^^^^^^ type mismatch, expected `Format`, found `Type`
   │
-  = expected `Type`
-       found `Format`
+  = expected `Format`
+       found `Type`
 
 
 ```
@@ -284,10 +284,10 @@ error: mismatched types
   ┌─ <FORMAT>:1:1
   │
 1 │ offset16
-  │ ^^^^^^^^ type mismatch, expected `Pos -> Format -> Format`, found `Format`
+  │ ^^^^^^^^ type mismatch, expected `Format`, found `Pos -> Format -> Format`
   │
-  = expected `Pos -> Format -> Format`
-       found `Format`
+  = expected `Format`
+       found `Pos -> Format -> Format`
 
 
 ```

--- a/tests/fail/elaboration/boolean-literal/type-mismatch.snap
+++ b/tests/fail/elaboration/boolean-literal/type-mismatch.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/boolean-literal/type-mismatch.fathom:3:1
   │
 3 │ true : Void
-  │ ^^^^ type mismatch, expected `Bool`, found `Void`
+  │ ^^^^ type mismatch, expected `Void`, found `Bool`
   │
-  = expected `Bool`
-       found `Void`
+  = expected `Void`
+       found `Bool`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/arrow-body-type.snap
+++ b/tests/fail/elaboration/unification/mismatch/arrow-body-type.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/arrow-body-type.fathom:3:39
   │
 3 │ fun (A : Type) -> fun (a : A) -> A -> a
-  │                                       ^ type mismatch, expected `A`, found `Type`
+  │                                       ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/arrow-both.snap
+++ b/tests/fail/elaboration/unification/mismatch/arrow-both.snap
@@ -4,18 +4,18 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/arrow-both.fathom:3:34
   │
 3 │ fun (A : Type) -> fun (a : A) -> a -> a
-  │                                  ^ type mismatch, expected `A`, found `Type`
+  │                                  ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/arrow-both.fathom:3:39
   │
 3 │ fun (A : Type) -> fun (a : A) -> a -> a
-  │                                       ^ type mismatch, expected `A`, found `Type`
+  │                                       ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/arrow-param-type.snap
+++ b/tests/fail/elaboration/unification/mismatch/arrow-param-type.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/arrow-param-type.fathom:3:34
   │
 3 │ fun (A : Type) -> fun (a : A) -> a -> A
-  │                                  ^ type mismatch, expected `A`, found `Type`
+  │                                  ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/fun-literal-body-expr.snap
+++ b/tests/fail/elaboration/unification/mismatch/fun-literal-body-expr.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/fun-literal-body-expr.fathom:3:19
   │
 3 │ fun A => fun a => A : fun (A : Type) -> A -> A
-  │                   ^ type mismatch, expected `Type`, found `A`
+  │                   ^ type mismatch, expected `A`, found `Type`
   │
-  = expected `Type`
-       found `A`
+  = expected `A`
+       found `Type`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/fun-literal-param-ann.snap
+++ b/tests/fail/elaboration/unification/mismatch/fun-literal-param-ann.snap
@@ -4,10 +4,10 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/fun-literal-param-ann.fathom:3:19
   │
 3 │ fun A => fun (a : Type) => a : fun (A : Type) -> A -> A
-  │                   ^^^^ type mismatch, expected `Type`, found `A`
+  │                   ^^^^ type mismatch, expected `A`, found `Type`
   │
-  = expected `Type`
-       found `A`
+  = expected `A`
+       found `Type`
 
 error: cannot find `a` in scope
   ┌─ tests/fail/elaboration/unification/mismatch/fun-literal-param-ann.fathom:3:28

--- a/tests/fail/elaboration/unification/mismatch/fun-type-body-type.snap
+++ b/tests/fail/elaboration/unification/mismatch/fun-type-body-type.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/fun-type-body-type.fathom:3:34
   │
 3 │ fun (A : Type) -> fun (a : A) -> a
-  │                                  ^ type mismatch, expected `A`, found `Type`
+  │                                  ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/fun-type-both.snap
+++ b/tests/fail/elaboration/unification/mismatch/fun-type-both.snap
@@ -4,18 +4,18 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/fun-type-both.fathom:3:43
   │
 3 │ fun (A : Type) -> fun (a : A) -> fun (b : a) -> a
-  │                                           ^ type mismatch, expected `A`, found `Type`
+  │                                           ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/fun-type-both.fathom:3:49
   │
 3 │ fun (A : Type) -> fun (a : A) -> fun (b : a) -> a
-  │                                                 ^ type mismatch, expected `A`, found `Type`
+  │                                                 ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/fun-type-param-type.snap
+++ b/tests/fail/elaboration/unification/mismatch/fun-type-param-type.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/fun-type-param-type.fathom:3:43
   │
 3 │ fun (A : Type) -> fun (a : A) -> fun (b : a) -> A
-  │                                           ^ type mismatch, expected `A`, found `Type`
+  │                                           ^ type mismatch, expected `Type`, found `A`
   │
-  = expected `A`
-       found `Type`
+  = expected `Type`
+       found `A`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/match-equation-body-exprs.snap
+++ b/tests/fail/elaboration/unification/mismatch/match-equation-body-exprs.snap
@@ -16,10 +16,10 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/match-equation-body-exprs.fathom:5:10
   │
 5 │     _ => 4 : U64,
-  │          ^^^^^^^ type mismatch, expected `U64`, found `U32`
+  │          ^^^^^^^ type mismatch, expected `U32`, found `U64`
   │
-  = expected `U64`
-       found `U32`
+  = expected `U32`
+       found `U64`
 
 warning: unreachable pattern
   ┌─ tests/fail/elaboration/unification/mismatch/match-equation-body-exprs.fathom:6:5
@@ -31,9 +31,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/match-equation-body-exprs.fathom:6:10
   │
 6 │     _ => Type,
-  │          ^^^^ type mismatch, expected `Type`, found `U32`
+  │          ^^^^ type mismatch, expected `U32`, found `Type`
   │
-  = expected `Type`
-       found `U32`
+  = expected `U32`
+       found `Type`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/record-literal-singleton.snap
+++ b/tests/fail/elaboration/unification/mismatch/record-literal-singleton.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/record-literal-singleton.fathom:6:11
   │
 6 │ { thing = unit } : { thing : Type }
-  │           ^^^^ type mismatch, expected `()`, found `Type`
+  │           ^^^^ type mismatch, expected `Type`, found `()`
   │
-  = expected `()`
-       found `Type`
+  = expected `Type`
+       found `()`
 
 '''

--- a/tests/fail/elaboration/unification/mismatch/record-type-singleton.snap
+++ b/tests/fail/elaboration/unification/mismatch/record-type-singleton.snap
@@ -4,9 +4,9 @@ error: mismatched types
   ┌─ tests/fail/elaboration/unification/mismatch/record-type-singleton.fathom:6:11
   │
 6 │ { thing : unit }
-  │           ^^^^ type mismatch, expected `()`, found `Type`
+  │           ^^^^ type mismatch, expected `Type`, found `()`
   │
-  = expected `()`
-       found `Type`
+  = expected `Type`
+       found `()`
 
 '''

--- a/tests/fail/parse/error-recovery.snap
+++ b/tests/fail/parse/error-recovery.snap
@@ -12,9 +12,9 @@ error: mismatched types
   ┌─ tests/fail/parse/error-recovery.fathom:5:1
   │
 5 │ x : Type -> Type
-  │ ^ type mismatch, expected `Type`, found `Type -> Type`
+  │ ^ type mismatch, expected `Type -> Type`, found `Type`
   │
-  = expected `Type`
-       found `Type -> Type`
+  = expected `Type -> Type`
+       found `Type`
 
 '''


### PR DESCRIPTION
The ordering of the "expected" and "found" types when reporting a type mismatch was the wrong way around.

# Example
```fathom
false : U32
```
would produce 
```text
type mismatch, expected `Bool`, found `U32`
```

the correct order is
```text
type mismatch, expected `U32`, found `Bool`
```