### PR TITLE
Reduce size of `ByteRange` and `Span`

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -713,4 +713,10 @@ mod tests {
         assert!(!std::mem::needs_drop::<Term<'_>>());
         assert!(!std::mem::needs_drop::<Term<'_>>());
     }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn term_size() {
+        assert_eq!(std::mem::size_of::<Term>(), 56);
+    }
 }

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -1310,4 +1310,10 @@ mod tests {
             Elim::ConstMatch(..) => {}
         }
     }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn value_size() {
+        assert_eq!(std::mem::size_of::<Value>(), 72);
+    }
 }

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 
 use crate::core;
 use crate::core::binary::{self, BufferError, ReadError};
-use crate::source::{ByteRange, FileId, Span, StringInterner};
+use crate::files::{FileId, Files};
+use crate::source::{ByteRange, Span, StringInterner};
 use crate::surface::{self, elaboration};
 use crate::BUG_REPORT_URL;
 
@@ -27,7 +28,7 @@ impl Status {
 }
 
 pub struct Driver<'surface, 'core> {
-    files: SimpleFiles<String, String>,
+    files: Files<String, String>,
     interner: RefCell<StringInterner>,
     surface_scope: scoped_arena::Scope<'surface>,
     core_scope: scoped_arena::Scope<'core>,
@@ -47,7 +48,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
             interner: RefCell::new(StringInterner::new()),
             surface_scope: scoped_arena::Scope::new(),
             core_scope: scoped_arena::Scope::new(),
-            files: SimpleFiles::new(),
+            files: Files::new(),
 
             allow_errors: false,
             seen_errors: RefCell::new(false),

--- a/fathom/src/files.rs
+++ b/fathom/src/files.rs
@@ -1,0 +1,94 @@
+//! A reimplementation of `codespan-reporting::files::SimpleFiles` that uses
+//! `FileId` as the file id, instead of `usize`.
+
+use codespan_reporting::files::{Error, SimpleFile};
+use std::{num::NonZeroU32, ops::Range};
+
+/// File id.
+// 4 billion files should be enough for anyone, and `u16` doesn't save any size in `ByteRange` or `Span`.
+// `NonZeroU32` saves 4 bytes on the size of `Span` compared to `u32`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct FileId(NonZeroU32);
+
+impl TryFrom<u32> for FileId {
+    type Error = <NonZeroU32 as TryFrom<u32>>::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        let id = NonZeroU32::try_from(value)?;
+        Ok(Self(id))
+    }
+}
+
+impl From<FileId> for NonZeroU32 {
+    fn from(value: FileId) -> Self {
+        value.0
+    }
+}
+
+impl From<FileId> for u32 {
+    fn from(value: FileId) -> Self {
+        value.0.get()
+    }
+}
+
+impl From<FileId> for usize {
+    fn from(value: FileId) -> Self {
+        value.0.get() as usize
+    }
+}
+
+pub struct Files<Name, Source> {
+    files: Vec<SimpleFile<Name, Source>>,
+}
+
+impl<Name, Source> Files<Name, Source>
+where
+    Name: std::fmt::Display,
+    Source: AsRef<str>,
+{
+    /// Create a new files database.
+    pub fn new() -> Files<Name, Source> {
+        Files { files: Vec::new() }
+    }
+
+    /// Add a file to the database, returning the handle that can be used to
+    /// refer to it again.
+    pub fn add(&mut self, name: Name, source: Source) -> FileId {
+        self.files.push(SimpleFile::new(name, source));
+        let len = u32::try_from(self.files.len())
+            .expect("Too many files (maximum amount of files is `u32::MAX`)");
+        FileId::try_from(len).unwrap()
+    }
+
+    /// Get the file corresponding to the given id.
+    pub fn get(&self, file_id: FileId) -> Result<&SimpleFile<Name, Source>, Error> {
+        let index = usize::from(file_id) - 1;
+        self.files.get(index).ok_or(Error::FileMissing)
+    }
+}
+
+impl<'a, Name, Source> codespan_reporting::files::Files<'a> for Files<Name, Source>
+where
+    Name: 'a + std::fmt::Display + Clone,
+    Source: 'a + AsRef<str>,
+{
+    type FileId = FileId;
+    type Name = Name;
+    type Source = &'a str;
+
+    fn name(&self, file_id: FileId) -> Result<Name, Error> {
+        Ok(self.get(file_id)?.name().clone())
+    }
+
+    fn source(&self, file_id: FileId) -> Result<&str, Error> {
+        Ok(self.get(file_id)?.source().as_ref())
+    }
+
+    fn line_index(&self, file_id: FileId, byte_index: usize) -> Result<usize, Error> {
+        self.get(file_id)?.line_index((), byte_index)
+    }
+
+    fn line_range(&self, file_id: FileId, line_index: usize) -> Result<Range<usize>, Error> {
+        self.get(file_id)?.line_range((), line_index)
+    }
+}

--- a/fathom/src/lib.rs
+++ b/fathom/src/lib.rs
@@ -6,6 +6,7 @@
 // Supporting modules
 mod alloc;
 pub mod env;
+pub mod files;
 pub mod source;
 
 // Intermediate languages

--- a/fathom/src/main.rs
+++ b/fathom/src/main.rs
@@ -115,7 +115,7 @@ fn unwrap_or_exit<T>(option: Option<T>) -> T {
     option.unwrap_or_else(|| std::process::exit(fathom::Status::Error.exit_code()))
 }
 
-fn load_file_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> fathom::source::FileId {
+fn load_file_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> fathom::files::FileId {
     unwrap_or_exit(match file {
         PathOrStdin::StdIn => driver.load_source("<stdin>".to_owned(), std::io::stdin()),
         PathOrStdin::Path(path) => driver.load_source_path(&path),
@@ -124,7 +124,7 @@ fn load_file_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> fathom::
 
 fn read_bytes_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> Vec<u8> {
     unwrap_or_exit(match file {
-        PathOrStdin::StdIn => driver.read_bytes("<stdio>".to_owned(), std::io::stdin()),
+        PathOrStdin::StdIn => driver.read_bytes("<stdin>".to_owned(), std::io::stdin()),
         PathOrStdin::Path(path) => driver.read_bytes_path(&path),
     })
 }

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -2,6 +2,8 @@
 
 use std::ops::{Deref, DerefMut, Range};
 
+use crate::files::FileId;
+
 // Interned strings.
 pub type StringId = string_interner::symbol::SymbolU16;
 
@@ -75,9 +77,6 @@ impl StringInterner {
         labels == self.get_tuple_labels(0..labels.len())
     }
 }
-
-/// File id.
-pub type FileId = usize; // TODO: use wrapper struct
 
 #[derive(Debug, Clone)]
 pub struct Spanned<T> {
@@ -162,7 +161,7 @@ impl From<Option<ByteRange>> for Span {
 }
 
 /// Byte offsets into source files.
-pub type BytePos = usize;
+pub type BytePos = u32;
 
 /// Byte ranges in source files.
 #[derive(Debug, Copy, Clone)]
@@ -208,6 +207,23 @@ impl ByteRange {
 
 impl From<ByteRange> for std::ops::Range<usize> {
     fn from(range: ByteRange) -> Self {
-        range.start..range.end
+        (range.start as usize)..(range.end as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// `ByteRange` is used a lot. Ensure it doesn't grow accidentally.
+    fn byte_range_size() {
+        assert_eq!(std::mem::size_of::<ByteRange>(), 12);
+    }
+
+    #[test]
+    /// `Span` is used a lot. Ensure it doesn't grow accidentally.
+    fn span_size() {
+        assert_eq!(std::mem::size_of::<Span>(), 12);
     }
 }

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -2,7 +2,8 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use itertools::Itertools;
 use std::cell::RefCell;
 
-use crate::source::{ByteRange, FileId, StringId, StringInterner};
+use crate::files::FileId;
+use crate::source::{ByteRange, StringId, StringInterner};
 use crate::surface::elaboration::{unification, MetaSource};
 use crate::surface::BinOp;
 use crate::BUG_REPORT_URL;

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -1,9 +1,10 @@
 use scoped_arena::Scope;
 use std::cell::RefCell;
 
-use crate::source::{ByteRange, FileId, StringId, StringInterner};
+use crate::source::{ByteRange, BytePos, StringId, StringInterner};
 use crate::surface::{ExprField, FormatField, Item, ItemDef, Module, ParseMessage, Pattern, Term, TypeField, BinOp};
 use crate::surface::lexer::{Error as LexerError, Token};
+use crate::files::FileId;
 
 grammar<'arena, 'source>(
     interner: &RefCell<StringInterner>,
@@ -13,7 +14,7 @@ grammar<'arena, 'source>(
 );
 
 extern {
-    type Location = usize;
+    type Location = BytePos;
     type Error = LexerError;
 
     enum Token<'source> {


### PR DESCRIPTION
By using `u32` instead of `usize` for `BytePos`, and `NonZeroU32` instead of `usize` for `FileId`, we can significantly reduce the size of `ByteRange` and `Span`. This also reduces the size of types that carry `ByteRange` or `Span`:

# Size reductions
- `source::ByteRange`: 24 bytes to 12 bytes
- `source::Span`: 24 bytes to 12 byes
- `surface::Term<ByteRange>`: 80 bytes to 56 bytes
- `surface::Pattern<ByteRange>`: 32 bytes to 16 bytes
- `core::Term`: 72 bytes to 56 bytes
- `semantics::Value`: 80 bytes to 72 bytes
- `elaboration::CheckedPattern`: 40 bytes to 32 bytes