### PR TITLE
Wrap comments at 80 characters

### DIFF
--- a/fathom/src/alloc.rs
+++ b/fathom/src/alloc.rs
@@ -1,7 +1,8 @@
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 
-// TODO: investigate if this could be replaced with an existing crate. For example:
+// TODO: investigate if this could be replaced with an existing crate. For
+// example:
 //
 // - https://lib.rs/crates/slicevec
 // - https://lib.rs/crates/fixed-slice-vec
@@ -62,9 +63,9 @@ impl<'a, Elem> Deref for SliceVec<'a, Elem> {
         // We know this because:
         //
         // - `self.next_index` is always initialized to `0` in `SliceBuilder::new`
-        // - `self.next_index` is only incremented in `SliceBuilder::push`,
-        //    and in that case we make sure `self.elems[self.next_index]`
-        //    has been initialized before hand.
+        // - `self.next_index` is only incremented in `SliceBuilder::push`, and in that
+        //   case we make sure `self.elems[self.next_index]` has been initialized before
+        //   hand.
         unsafe { slice_assume_init_ref(&self.elems[..self.next_index]) }
     }
 }
@@ -76,20 +77,21 @@ impl<'a, Elem> From<SliceVec<'a, Elem>> for &'a [Elem] {
         // We know this because:
         //
         // - `self.next_index` is always initialized to `0` in `SliceBuilder::new`
-        // - `self.next_index` is only incremented in `SliceBuilder::push`,
-        //    and in that case we make sure `self.elems[self.next_index]`
-        //    has been initialized before hand.
+        // - `self.next_index` is only incremented in `SliceBuilder::push`, and in that
+        //   case we make sure `self.elems[self.next_index]` has been initialized before
+        //   hand.
         unsafe { slice_assume_init_ref(&slice.elems[..slice.next_index]) }
     }
 }
 
-// NOTE: This is the same implementation as `MaybeUninit::slice_assume_init_ref`,
-// which is currently unstable (see https://github.com/rust-lang/rust/issues/63569).
+// NOTE: This is the same implementation as
+// `MaybeUninit::slice_assume_init_ref`, which is currently unstable (see https://github.com/rust-lang/rust/issues/63569).
 #[allow(clippy::needless_lifetimes)] // These serve as important documentation
 pub unsafe fn slice_assume_init_ref<'a, T>(slice: &'a [MaybeUninit<T>]) -> &'a [T] {
-    // SAFETY: casting slice to a `*const [T]` is safe since the caller guarantees that
-    // `slice` is initialized, and`MaybeUninit` is guaranteed to have the same layout as `T`.
-    // The pointer obtained is valid since it refers to memory owned by `slice` which is a
-    // reference and thus guaranteed to be valid for reads.
+    // SAFETY: casting slice to a `*const [T]` is safe since the caller guarantees
+    // that `slice` is initialized, and`MaybeUninit` is guaranteed to have the
+    // same layout as `T`. The pointer obtained is valid since it refers to
+    // memory owned by `slice` which is a reference and thus guaranteed to be
+    // valid for reads.
     &*(slice as *const [MaybeUninit<T>] as *const [T])
 }

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -60,7 +60,8 @@ impl fmt::Display for Plicity {
 pub enum Term<'arena> {
     /// Item variable occurrences.
     ///
-    /// These refer to [items][Item] bound at the top-level of a [module][Module].
+    /// These refer to [items][Item] bound at the top-level of a
+    /// [module][Module].
     ItemVar(Span, Level),
     /// Local variable occurrences.
     ///

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -66,7 +66,8 @@ impl<'arena> From<BufferError> for ReadError<'arena> {
 pub struct Buffer<'data> {
     /// Offset from the starting position.
     start_offset: usize,
-    /// A slice of data, starting from an offset from the start of a larger buffer.
+    /// A slice of data, starting from an offset from the start of a larger
+    /// buffer.
     data: &'data [u8],
 }
 
@@ -99,7 +100,8 @@ impl<'data> Buffer<'data> {
         })
     }
 
-    /// Get a slice of the bytes in the buffer, relative to the start of the buffer.
+    /// Get a slice of the bytes in the buffer, relative to the start of the
+    /// buffer.
     fn get_relative<I: SliceIndex<[u8]>>(&self, index: I) -> Result<&'data I::Output, BufferError> {
         self.data
             .get(index)
@@ -155,7 +157,8 @@ impl<'data> BufferReader<'data> {
             .ok_or(BufferError::PositionOverflow)
     }
 
-    /// Remaining number of bytes from the current position to the end of the buffer.
+    /// Remaining number of bytes from the current position to the end of the
+    /// buffer.
     pub fn remaining_len(&self) -> usize {
         self.buffer.remaining_len() - self.relative_offset
     }
@@ -168,7 +171,8 @@ impl<'data> BufferReader<'data> {
         ))
     }
 
-    /// Set the offset of the reader relative to the start of the backing buffer.
+    /// Set the offset of the reader relative to the start of the backing
+    /// buffer.
     pub fn set_relative_offset(&mut self, relative_offset: usize) -> Result<(), BufferError> {
         (relative_offset <= self.buffer.remaining_len())
             .then(|| self.relative_offset = relative_offset)
@@ -184,7 +188,8 @@ impl<'data> BufferReader<'data> {
             .and_then(|relative_offset| self.set_relative_offset(relative_offset))
     }
 
-    /// Get a slice of the bytes in the buffer, relative to the current offset in the buffer.
+    /// Get a slice of the bytes in the buffer, relative to the current offset
+    /// in the buffer.
     fn get_relative<I: SliceIndex<[u8]>>(&self, index: I) -> Result<&'data I::Output, BufferError> {
         let data = self.buffer.get_relative(self.relative_offset..)?;
         data.get(index).ok_or(BufferError::UnexpectedEndOfBuffer)
@@ -200,7 +205,8 @@ impl<'data> BufferReader<'data> {
     /// Read an array of bytes and advance the offset into the buffer.
     pub fn read_byte_array<const N: usize>(&mut self) -> Result<&'data [u8; N], BufferError> {
         let slice = self.get_relative(..N)?;
-        // SAFETY: slice points to [u8; N]? Yes it's [u8] of length N (checked by BufferReader::get_relative)
+        // SAFETY: slice points to [u8; N]? Yes it's [u8] of length N (checked by
+        // BufferReader::get_relative)
         let array = unsafe { &*(slice.as_ptr() as *const [u8; N]) };
         self.relative_offset += N;
         Ok(array)

--- a/fathom/src/core/prim.rs
+++ b/fathom/src/core/prim.rs
@@ -369,17 +369,19 @@ impl<'arena> Env<'arena> {
                             Span::Empty,
                             Plicity::Explicit,
                             None,
-                            &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR2, &VAR2), // A@2 -> B@2
+                            // A@2 -> B@2
+                            &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR2, &VAR2),
                             scope.to_scope(core::Term::FunType(
                                 Span::Empty,
                                 Plicity::Explicit,
                                 None,
+                                // Option A@3
                                 &Term::FunApp(
                                     Span::Empty,
                                     Plicity::Explicit,
                                     &Term::Prim(Span::Empty, OptionType),
                                     &VAR3,
-                                ), // Option A@3
+                                ),
                                 &VAR3, // B@3
                             )),
                         )),
@@ -405,7 +407,8 @@ impl<'arena> Env<'arena> {
                         Span::Empty,
                         Plicity::Explicit,
                         None,
-                        &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR0, &BOOL_TYPE), // (A@0 -> Bool)
+                        // (A@0 -> Bool)
+                        &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR0, &BOOL_TYPE),
                         scope.to_scope(core::Term::FunType(
                             Span::Empty,
                             Plicity::Explicit,
@@ -422,12 +425,13 @@ impl<'arena> Env<'arena> {
                                 )),
                                 &VAR1,
                             )),
+                            // Option A@2
                             &Term::FunApp(
                                 Span::Empty,
                                 Plicity::Explicit,
                                 &Term::Prim(Span::Empty, OptionType),
                                 &VAR2,
-                            ), // Option A@2
+                            ),
                         )),
                     )),
                 )),
@@ -777,7 +781,9 @@ pub fn step(prim: Prim) -> Step {
 
         Prim::OptionFold => step!(env, [_, _, on_none, on_some, option] => {
             match option.match_prim_spine()? {
-                (Prim::OptionSome, [Elim::FunApp(Plicity::Explicit, value)]) => env.fun_app(Plicity::Explicit,on_some.clone(), value.clone()),
+                (Prim::OptionSome, [Elim::FunApp(Plicity::Explicit, value)]) => env.fun_app(
+Plicity::Explicit,
+                    on_some.clone(), value.clone()),
                 (Prim::OptionNone, []) => on_none.clone(),
                 _ => return None,
             }
@@ -787,7 +793,9 @@ pub fn step(prim: Prim) -> Step {
             step!(env, [_, _, pred, array] => match array.as_ref() {
                 Value::ArrayLit(elems) => {
                     for elem in elems {
-                        match env.fun_app(Plicity::Explicit, pred.clone(), elem.clone()).as_ref() {
+                        match env.fun_app(
+Plicity::Explicit,
+                             pred.clone(), elem.clone()).as_ref() {
                             Value::ConstLit(Const::Bool(true)) => {
                                 // TODO: Is elem.span right here?
                                 return Some(Spanned::new(elem.span(), Arc::new(Value::prim(Prim::OptionSome, [elem.clone()]))))

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -522,7 +522,8 @@ impl<'arena, 'env> ElimEnv<'arena, 'env> {
             // Beta-reduction
             Value::FunLit(fun_plicity, _, body_expr) => {
                 assert_eq!(arg_plicity, *fun_plicity, "Plicities must be equal");
-                self.apply_closure(body_expr, arg_expr) // FIXME: use span from head/arg exprs?
+                // FIXME: use span from head/arg exprs?
+                self.apply_closure(body_expr, arg_expr)
             }
             // The computation is stuck, preventing further reduction
             Value::Stuck(head, spine) => {

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -78,7 +78,8 @@ impl<'surface, 'core> Driver<'surface, 'core> {
 
         // Use the currently set codespan configuration
         let term_config = self.codespan_config.clone();
-        // Fetch the default hook (which prints the panic message and an optional backtrace)
+        // Fetch the default hook (which prints the panic message and an optional
+        // backtrace)
         let default_hook = std::panic::take_hook();
 
         std::panic::set_hook(Box::new(move |info| {

--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -187,7 +187,8 @@ impl<Entry> UniqueEnv<Entry> {
         self.entries.clear()
     }
 
-    /// Resize the environment to the desired length, filling new entries with `entry`.
+    /// Resize the environment to the desired length, filling new entries with
+    /// `entry`.
     pub fn resize(&mut self, new_len: EnvLen, entry: Entry)
     where
         Entry: Clone,
@@ -240,9 +241,9 @@ impl<Entry> SliceEnv<Entry> {
     /// The length of the environment.
     pub fn len(&self) -> EnvLen {
         // SAFETY:
-        // - The only way to construct a `SliceEnv` is via `UniqueEnv`. We
-        //   ensure that the length of the environment never exceeds the the
-        //   maximum `RawVar`, so this should never overflow.
+        // - The only way to construct a `SliceEnv` is via `UniqueEnv`. We ensure that
+        //   the length of the environment never exceeds the the maximum `RawVar`, so
+        //   this should never overflow.
         EnvLen(self.entries.len() as RawVar)
     }
 
@@ -321,8 +322,8 @@ impl<Entry> SharedEnv<Entry> {
     /// The length of the environment.
     pub fn len(&self) -> EnvLen {
         // SAFETY:
-        // - We ensure that the length of the environment never exceeds the the
-        //   maximum `RawVar`, so this should never overflow.
+        // - We ensure that the length of the environment never exceeds the the maximum
+        //   `RawVar`, so this should never overflow.
         EnvLen(self.entries.len() as RawVar)
     }
 

--- a/fathom/src/files.rs
+++ b/fathom/src/files.rs
@@ -5,8 +5,9 @@ use codespan_reporting::files::{Error, SimpleFile};
 use std::{num::NonZeroU32, ops::Range};
 
 /// File id.
-// 4 billion files should be enough for anyone, and `u16` doesn't save any size in `ByteRange` or `Span`.
-// `NonZeroU32` saves 4 bytes on the size of `Span` compared to `u32`.
+// - Use `u32` over `usize` because 4 billion files should be enough for anyone
+// - `u16` doesn't save any size in `ByteRange` or `Span` compared to `u32`
+// - `NonZeroU32` saves 4 bytes on the size of `Span` compared to `u32`
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct FileId(NonZeroU32);
 

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -63,11 +63,23 @@ impl StringInterner {
     /// let mut interner = StringInterner::new();
     /// assert_eq!(interner.get_alphabetic_name(0), interner.get_or_intern("a"));
     /// // ...
-    /// assert_eq!(interner.get_alphabetic_name(25), interner.get_or_intern("z"));
-    /// assert_eq!(interner.get_alphabetic_name(26), interner.get_or_intern("a1"));
+    /// assert_eq!(
+    ///     interner.get_alphabetic_name(25),
+    ///     interner.get_or_intern("z")
+    /// );
+    /// assert_eq!(
+    ///     interner.get_alphabetic_name(26),
+    ///     interner.get_or_intern("a1")
+    /// );
     /// // ...
-    /// assert_eq!(interner.get_alphabetic_name(51), interner.get_or_intern("z1"));
-    /// assert_eq!(interner.get_alphabetic_name(52), interner.get_or_intern("a2"));
+    /// assert_eq!(
+    ///     interner.get_alphabetic_name(51),
+    ///     interner.get_or_intern("z1")
+    /// );
+    /// assert_eq!(
+    ///     interner.get_alphabetic_name(52),
+    ///     interner.get_or_intern("a2")
+    /// );
     /// // ...
     /// ```
     pub fn get_alphabetic_name(&mut self, index: usize) -> StringId {
@@ -99,7 +111,8 @@ impl StringInterner {
         self.tuple_labels[index]
     }
 
-    /// Get or intern a slice of strings in the form `_{index}` for each index in `range`.
+    /// Get or intern a slice of strings in the form `_{index}` for each index
+    /// in `range`.
     pub fn get_tuple_labels(&mut self, range: Range<usize>) -> &[StringId] {
         self.reserve_tuple_labels(range.end.saturating_sub(1));
         &self.tuple_labels[range]
@@ -153,7 +166,8 @@ impl<T> Spanned<T> {
         self.span
     }
 
-    /// Merge the supplied span with the span of `other` and return `other` wrapped in that span.
+    /// Merge the supplied span with the span of `other` and return `other`
+    /// wrapped in that span.
     pub fn merge(span: Span, other: Spanned<T>) -> Spanned<T> {
         let Spanned {
             span: other_span,

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -59,9 +59,10 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
     }
 
     fn push_local(&mut self, name: Option<StringId>) -> StringId {
-        let name = name.unwrap_or_else(|| {
-            self.interner.borrow_mut().get_or_intern_static("_") // TODO: choose a better name?
-        });
+        let name =
+            name.unwrap_or_else(|| {
+                self.interner.borrow_mut().get_or_intern_static("_") // TODO: choose a better name?
+            });
 
         // TODO: avoid globals
         // TODO: ensure we chose a correctly bound name

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -85,10 +85,11 @@ impl<'arena> ItemEnv<'arena> {
 /// program, for example by function parameters, let bindings, or pattern
 /// matching.
 ///
-/// This environment behaves as a stack. As scopes are entered, it is important
-/// to remember to call either [`LocalEnv::push_def`] or [`LocalEnv::push_param`].
-/// On scope exit, it is important to remember to call [`LocalEnv::pop`].
-/// Multiple bindings can be removed at once with [`LocalEnv::truncate`].
+/// This environment behaves as a stack.
+/// - As scopes are entered, it is important to remember to call either
+///   [`LocalEnv::push_def`] or [`LocalEnv::push_param`].
+/// - On scope exit, it is important to remember to call [`LocalEnv::pop`].
+/// - Multiple bindings can be removed at once with [`LocalEnv::truncate`].
 ///
 /// [local variables]: core::Term::LocalVar
 struct LocalEnv<'arena> {
@@ -322,7 +323,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         Some((local_var, local_type))
     }
 
-    /// Push an unsolved term onto the context, to be updated later during unification.
+    /// Push an unsolved term onto the context, to be updated later during
+    /// unification.
     fn push_unsolved_term(
         &mut self,
         source: MetaSource,
@@ -335,7 +337,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         )
     }
 
-    /// Push an unsolved type onto the context, to be updated later during unification.
+    /// Push an unsolved type onto the context, to be updated later during
+    /// unification.
     fn push_unsolved_type(&mut self, source: MetaSource) -> ArcValue<'arena> {
         let r#type = self.push_unsolved_term(source, self.universe.clone());
         self.eval_env().eval(&r#type)
@@ -354,9 +357,12 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         for (expr, source) in Iterator::zip(meta_env.exprs.iter(), meta_env.sources.iter()) {
             match (expr, *source) {
                 // Avoid producing messages for some unsolved metavariable sources:
-                (None, MetaSource::HoleType(_, _)) => {} // should have an unsolved hole expression
-                (None, MetaSource::PlaceholderType(_)) => {} // should have an unsolved placeholder expression
-                (None, MetaSource::ReportedErrorType(_)) => {} // should already have an error reported
+                // Should have an unsolved hole expression
+                (None, MetaSource::HoleType(_, _)) => {}
+                // Should have an unsolved placeholder
+                (None, MetaSource::PlaceholderType(_)) => {}
+                // Should already have an error
+                (None, MetaSource::ReportedErrorType(_)) => {}
 
                 // For other sources, report an unsolved problem message
                 (None, source) => on_message(Message::UnsolvedMetaVar { source }),
@@ -575,7 +581,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
     //       coercions to the core language.
     fn convert(
         &mut self,
-        surface_range: ByteRange, // TODO: could be removed if we never encounter empty spans in the core term
+        // TODO: could be removed if we never encounter empty spans in the core term
+        surface_range: ByteRange,
         expr: core::Term<'arena>,
         from: &ArcValue<'arena>,
         to: &ArcValue<'arena>,
@@ -1251,7 +1258,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         (term, r#type)
     }
 
-    // Wrap `head_term` in implicit arguments while `head_type` is an implicit function
+    // Wrap `head_term` in implicit arguments while `head_type` is an implicit
+    // function
     fn fill_implicit_args(
         &mut self,
         head_range: ByteRange,
@@ -1463,7 +1471,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                             args.next().unwrap();
                         }
 
-                        // Tried to pass explicit arg where implicit arg was expected: insert implicit arg
+                        // Tried to pass explicit arg where implicit arg was expected: insert
+                        // implicit arg
                         Value::FunType(Plicity::Implicit, param_name, param_type, body_type) => {
                             (head_expr, head_type) = self.insert_implicit_app(
                                 (head_range, head_expr),

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -7,16 +7,16 @@
 //!
 //! 1. Traverse the terms within each module item and note dependencies on other
 //!    items.
-//!    *  Names in scope are tracked so that when a local name shadows an item
-//!       name we know not to add a dependency on the item.
+//!    * Names in scope are tracked so that when a local name shadows an item
+//!      name we know not to add a dependency on the item.
 //! 2. Build up a list of item indices that will indicate the order in which
 //!    they should be elaborated.
-//!    *  Recursively visit each item's dependencies and push the index of leaf
-//!       items to the output list. If an item is already in the list is it not
-//!       added again.
-//!    *  Keep track of the stack of items in the depth-first traversal. If we
-//!       re-enter an item already in the stack report an error indicating a
-//!       cycle has been detected.
+//!    * Recursively visit each item's dependencies and push the index of leaf
+//!      items to the output list. If an item is already in the list is it not
+//!      added again.
+//!    * Keep track of the stack of items in the depth-first traversal. If we
+//!      re-enter an item already in the stack report an error indicating a
+//!      cycle has been detected.
 
 use fxhash::{FxHashMap, FxHashSet};
 

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -458,16 +458,18 @@ impl Message {
             Message::UnsolvedMetaVar { source } => {
                 let (range, source_name) = match source {
                     MetaSource::ImplicitArg(range, _) => (range, "implicit argument"),
-                    MetaSource::HoleType(range, _) => (range, "hole type"), // should never appear in user-facing output
                     MetaSource::HoleExpr(range, _) => (range, "hole expression"),
-                    MetaSource::PlaceholderType(range) => (range, "placeholder type"), // should never appear in user-facing output
                     MetaSource::PlaceholderExpr(range) => (range, "placeholder expression"),
                     MetaSource::PlaceholderPatternType(range) => {
                         (range, "placeholder pattern type")
                     }
                     MetaSource::NamedPatternType(range, _) => (range, "named pattern type"),
                     MetaSource::MatchExprType(range) => (range, "match expression type"),
-                    MetaSource::ReportedErrorType(range) => (range, "error type"), // should never appear in user-facing output
+
+                    // The following should never appear in user-facing output:
+                    MetaSource::HoleType(range, _) => (range, "hole type"),
+                    MetaSource::PlaceholderType(range) => (range, "placeholder type"),
+                    MetaSource::ReportedErrorType(range) => (range, "error type"),
                 };
 
                 Diagnostic::error()

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -457,7 +457,8 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
     /// Pretty prints a delimited sequence of documents with a trailing
     /// separator if it is formatted over multiple lines.
-    /// If `space` is true, extra spaces are added before and after the delimiters
+    /// If `space` is true, extra spaces are added before and after the
+    /// delimiters
     pub fn sequence(
         &'arena self,
         space: bool,

--- a/fathom/tests/source_tests.rs
+++ b/fathom/tests/source_tests.rs
@@ -149,7 +149,8 @@ fn extract_test(input_file: PathBuf, default_mode: TestMode) -> libtest_mimic::T
     const CONFIG_COMMENT_START: &str = "//~";
 
     let input_source = std::fs::read_to_string(&input_file).unwrap();
-    // Collect the lines with CONFIG_COMMENT_START prefix, stripping the prefix in the process
+    // Collect the lines with CONFIG_COMMENT_START prefix, stripping the prefix in
+    // the process
     let config_source = input_source
         .lines()
         .filter_map(|line| line.split(CONFIG_COMMENT_START).nth(1))

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+format_code_in_doc_comments = true
+wrap_comments = true


### PR DESCRIPTION
`rustfmt` can wrap comments at 80 characters per line, but the feature must be enabled in `rustfmt.toml`