### PR TITLE
Use implicit parameters in primitives and opentype format

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -616,29 +616,29 @@ Links formats are [represented](#format-representations) as typed
 Deref formats allow [references](#references) to other parts of the stream to be
 included in resulting parsed output.
 
-- `deref : fun (f : Format) -> Ref f -> Format`
+- `deref : fun (@f : Format) -> Ref f -> Format`
 
 #### Representation of deref formats
 
 Dereferences are [represented](#format-representations) after parsing using the
 representation of the referenced format.
 
-| format             | `Repr` format |
-| ------------------ | ------------- |
-| `deref format ref` | `Repr format` |
+| format              | `Repr` format |
+| ------------------- | ------------- |
+| `deref @format ref` | `Repr format` |
 
 ### Succeed format
 
 The succeed format consumes no input during parsing, allowing values to be
 embedded in the resulting parsed output.
 
-- `succeed : fun (A : Type) -> A -> Format`
+- `succeed : fun (@A : Type) -> A -> Format`
 
 #### Representation of succeed formats
 
-| format        | `Repr` format |
-| ------------- | ------------- |
-| `succeed A a` | `A`           |
+| format         | `Repr` format |
+| -------------- | ------------- |
+| `succeed @A a` | `A`           |
 
 ### Fail format
 
@@ -661,13 +661,13 @@ The unwrap format consumes no input during parsing, succeeding with the data
 contained in a the `some` case of an [option](#options), or otherwise causing a
 parse failure.
 
-- `unwrap : fun (A : Type) -> Option A -> Format`
+- `unwrap : fun (@A : Type) -> Option A -> Format`
 
 #### Representation of unwrap formats
 
-| format              | `Repr` format |
-| ------------------- | ------------- |
-| `unwrap A option_a` | `A`           |
+| format               | `Repr` format |
+| -------------------- | ------------- |
+| `unwrap @A option_a` | `A`           |
 
 ## Functions
 
@@ -1082,14 +1082,14 @@ Data that may not be present can be formed with the following primitive:
 
 Optional data can be introduced with the `some` or `none` primitives:
 
-- `some : fun (A : Type) -> A -> Option A`
-- `none : fun (A : Type) -> Option A`
+- `some : fun (@A : Type) -> A -> Option A`
+- `none : fun (@A : Type) -> Option A`
 
 ### Option operations
 
 The following operations are defined for option types:
 
-- `option_fold : fun (A : Type) (B : Type) -> B -> (A -> B) -> Option A -> B`
+- `option_fold : fun (@A : Type) (@B : Type) -> B -> (A -> B) -> Option A -> B`
 
 ## Arrays
 
@@ -1139,10 +1139,10 @@ function to each element of the array. If the function returns true, then
 `array*_find` returns `some element`. If they all return false, it returns
 `none`.
 
-- `array8_find : fun (len : U8) (A : Type) -> (A -> Bool) -> Array8 len A -> Option A`
-- `array16_find : fun (len : U16) (A : Type) -> (A -> Bool) -> Array16 len A -> Option A`
-- `array32_find : fun (len : U32) (A : Type) -> (A -> Bool) -> Array32 len A -> Option A`
-- `array64_find : fun (len : U64) (A : Type) -> (A -> Bool) -> Array64 len A -> Option A`
+- `array8_find : fun (@len : U8) (@A : Type) -> (A -> Bool) -> Array8 len A -> Option A`
+- `array16_find : fun (@len : U16) (@A : Type) -> (A -> Bool) -> Array16 len A -> Option A`
+- `array32_find : fun (@len : U32) (@A : Type) -> (A -> Bool) -> Array32 len A -> Option A`
+- `array64_find : fun (@len : U64) (@A : Type) -> (A -> Bool) -> Array64 len A -> Option A`
 
 #### index
 
@@ -1150,10 +1150,10 @@ function to each element of the array. If the function returns true, then
 operation will not evaluate fully if the index is out of bounds. If this
 happens when parsing a binary format, a parse failure will be triggered.
 
-- `array8_index : fun (len : U8) (A : Type) (index : U8) -> Array8 len A -> A`
-- `array16_index : fun (len : U16) (A : Type) (index : U16) -> Array16 len A -> A`
-- `array32_index : fun (len : U32) (A : Type) (index : U32) -> Array32 len A -> A`
-- `array64_index : fun (len : U64) (A : Type) (index : U64) -> Array64 len A -> A`
+- `array8_index : fun (@len : U8) (@A : Type) (index : U8) -> Array8 len A -> A`
+- `array16_index : fun (@len : U16) (@A : Type) (index : U16) -> Array16 len A -> A`
+- `array32_index : fun (@len : U32) (@A : Type) (index : U32) -> Array32 len A -> A`
+- `array64_index : fun (@len : U64) (@A : Type) (index : U64) -> Array64 len A -> A`
 
 ## Positions
 
@@ -1195,4 +1195,4 @@ The void type is be used to mark terms that can never be constructed:
 
 It can be eliminated by the `absurd` function:
 
-- `absurd : fun (A : Type) -> Void -> A`
+- `absurd : fun (@A : Type) -> Void -> A`

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -440,8 +440,8 @@ impl<'arena, 'data> Context<'arena, 'data> {
             (Prim::FormatSucceed, [_, FunApp(_, elem)]) => Ok(elem.clone()),
             (Prim::FormatFail, []) => Err(ReadError::ReadFailFormat(span)),
             (Prim::FormatUnwrap, [_, FunApp(_, option)]) => match option.match_prim_spine() {
-                Some((Prim::OptionSome, [FunApp(_, elem)])) => Ok(elem.clone()),
-                Some((Prim::OptionNone, [])) => Err(ReadError::UnwrappedNone(span)),
+                Some((Prim::OptionSome, [_, FunApp(_, elem)])) => Ok(elem.clone()),
+                Some((Prim::OptionNone, [_])) => Err(ReadError::UnwrappedNone(span)),
                 _ => Err(ReadError::InvalidValue(span)),
             },
             _ => Err(ReadError::InvalidFormat(span)),

--- a/fathom/src/core/prim.rs
+++ b/fathom/src/core/prim.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use fxhash::FxHashMap;
 use scoped_arena::Scope;
 
-use crate::core::semantics::{ArcValue, Elim, ElimEnv, Value};
+use crate::core::semantics::{ArcValue, Elim, ElimEnv, Head, Value};
 use crate::core::{self, Const, Plicity, Prim, UIntStyle};
 use crate::env::{self, SharedEnv, UniqueEnv};
 use crate::source::{Span, Spanned, StringId, StringInterner};
@@ -58,17 +58,6 @@ impl<'arena> Env<'arena> {
         let mut env = EnvBuilder::new(interner, scope);
 
         env.define_prim(VoidType, &UNIVERSE);
-        // fun (A : Type) -> Void -> A
-        env.define_prim(
-            Absurd,
-            &core::Term::FunType(
-                Span::Empty,
-                Plicity::Explicit,
-                env.name("A"),
-                &UNIVERSE,
-                &core::Term::FunType(Span::Empty, Plicity::Explicit, None, &VOID_TYPE, &VAR1),
-            ),
-        );
         env.define_prim(BoolType, &UNIVERSE);
         env.define_prim(U8Type, &UNIVERSE);
         env.define_prim(U16Type, &UNIVERSE);
@@ -122,8 +111,8 @@ impl<'arena> Env<'arena> {
             FormatDeref,
             &core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
-                env.name("A"),
+                Plicity::Implicit,
+                env.name("f"),
                 &FORMAT_TYPE,
                 &Term::FunType(
                     Span::Empty,
@@ -144,7 +133,7 @@ impl<'arena> Env<'arena> {
             FormatSucceed,
             &core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
+                Plicity::Implicit,
                 env.name("A"),
                 &UNIVERSE,
                 &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR0, &FORMAT_TYPE),
@@ -153,11 +142,11 @@ impl<'arena> Env<'arena> {
         env.define_prim(FormatFail, &FORMAT_TYPE);
         env.define_prim(
             FormatUnwrap,
-            // fun (A : Type) -> Option A   -> Format
-            // fun (A : Type) -> Option A@0 -> Format
+            // fun (@A : Type) -> Option A   -> Format
+            // fun (@A : Type) -> Option A@0 -> Format
             &core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
+                Plicity::Implicit,
                 env.name("A"),
                 &UNIVERSE,
                 &Term::FunType(
@@ -175,6 +164,18 @@ impl<'arena> Env<'arena> {
             ),
         );
         env.define_prim_fun(FormatRepr, [&FORMAT_TYPE], &UNIVERSE);
+
+        // fun (@A : Type) -> Void -> A
+        env.define_prim(
+            Absurd,
+            &core::Term::FunType(
+                Span::Empty,
+                Plicity::Implicit,
+                env.name("A"),
+                &UNIVERSE,
+                &core::Term::FunType(Span::Empty, Plicity::Explicit, None, &VOID_TYPE, &VAR1),
+            ),
+        );
 
         env.define_prim_fun(BoolEq, [&BOOL_TYPE, &BOOL_TYPE], &BOOL_TYPE);
         env.define_prim_fun(BoolNeq, [&BOOL_TYPE, &BOOL_TYPE], &BOOL_TYPE);
@@ -309,11 +310,11 @@ impl<'arena> Env<'arena> {
 
         env.define_prim(
             OptionSome,
-            // fun (A : Type) -> A   -> Option A
-            // fun (A : Type) -> A@0 -> Option A@1
+            // fun (@A : Type) -> A   -> Option A
+            // fun (@A : Type) -> A@0 -> Option A@1
             &core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
+                Plicity::Implicit,
                 env.name("A"),
                 &UNIVERSE,
                 &Term::FunType(
@@ -332,11 +333,11 @@ impl<'arena> Env<'arena> {
         );
         env.define_prim(
             OptionNone,
-            // fun (A : Type) -> Option A
-            // fun (A : Type) -> Option A@0
+            // fun (@A : Type) -> Option A
+            // fun (@A : Type) -> Option A@0
             &core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
+                Plicity::Implicit,
                 env.name("A"),
                 &UNIVERSE,
                 &Term::FunApp(
@@ -349,16 +350,16 @@ impl<'arena> Env<'arena> {
         );
         env.define_prim(
             OptionFold,
-            // fun (A : Type) (B : Type) -> B   -> (A   -> B  ) -> Option A   -> B
-            // fun (A : Type) (B : Type) -> B@0 -> (A@2 -> B@2) -> Option A@3 -> B@3
+            // fun (@A : Type) (@B : Type) -> B   -> (A   -> B  ) -> Option A   -> B
+            // fun (@A : Type) (@B : Type) -> B@0 -> (A@2 -> B@2) -> Option A@3 -> B@3
             scope.to_scope(core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
+                Plicity::Implicit,
                 env.name("A"),
                 &UNIVERSE,
                 scope.to_scope(core::Term::FunType(
                     Span::Empty,
-                    Plicity::Explicit,
+                    Plicity::Implicit,
                     env.name("B"),
                     &UNIVERSE,
                     scope.to_scope(core::Term::FunType(
@@ -391,17 +392,18 @@ impl<'arena> Env<'arena> {
             )),
         );
 
-        // fun (len : UN) (A : Type) -> (A   -> Bool) -> ArrayN len   A   -> Option A
-        // fun (len : UN) (A : Type) -> (A@0 -> Bool) -> ArrayN len@2 A@1 -> Option A@2
+        // fun (@len : UN) (@A : Type) -> (A   -> Bool) -> ArrayN len   A   -> Option A
+        // fun (@len : UN) (@A : Type) -> (A@0 -> Bool) -> ArrayN len@2 A@1 -> Option
+        // A@2
         let find_type = |index_type, array_type| {
             scope.to_scope(core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
+                Plicity::Implicit,
                 env.name("len"),
                 index_type,
                 scope.to_scope(core::Term::FunType(
                     Span::Empty,
-                    Plicity::Explicit,
+                    Plicity::Implicit,
                     env.name("A"),
                     &UNIVERSE,
                     scope.to_scope(core::Term::FunType(
@@ -447,17 +449,17 @@ impl<'arena> Env<'arena> {
         env.define_prim(Array32Find, array32_find_type);
         env.define_prim(Array64Find, array64_find_type);
 
-        // fun (len : UN) -> (A : Type) -> (index : UN) -> ArrayN len   A   -> A
-        // fun (len : UN) -> (A : Type) -> (index : UN) -> ArrayN len@2 A@1 -> A@2
+        // fun (@len : UN) (@A : Type) (index : UN) -> ArrayN len   A   -> A
+        // fun (@len : UN) (@A : Type) (index : UN) -> ArrayN len@2 A@1 -> A@2
         let array_index_type = |index_type, array_type| {
             scope.to_scope(core::Term::FunType(
                 Span::Empty,
-                Plicity::Explicit,
+                Plicity::Implicit,
                 env.name("len"),
                 index_type,
                 scope.to_scope(core::Term::FunType(
                     Span::Empty,
-                    Plicity::Explicit,
+                    Plicity::Implicit,
                     env.name("A"),
                     &UNIVERSE,
                     scope.to_scope(core::Term::FunType(
@@ -574,7 +576,7 @@ pub type Step = for<'arena> fn(&ElimEnv<'arena, '_>, &[Elim<'arena>]) -> Option<
 macro_rules! step {
     ($env:pat, [$($param:pat),*] => $body:expr) => {
         |$env, spine| match spine {
-            [$(Elim::FunApp(Plicity::Explicit, $param)),*] => Some($body),
+            [$(Elim::FunApp(_, $param)),*] => Some($body),
             _ => return None,
         }
     };
@@ -798,20 +800,22 @@ pub fn step(prim: Prim) -> Step {
                             Plicity::Explicit,
                             pred.clone(), elem.clone()).as_ref() {
                             Value::ConstLit(Const::Bool(true)) => {
-                                // TODO: Is elem.span right here?
-                                return Some(Spanned::new(
-                                    elem.span(),
-                                    Arc::new(Value::prim(Prim::OptionSome, [
-                                        elem_type.clone(),
-                                        elem.clone(),
-                                    ])),
-                                ));
+                                return Some(Spanned::empty(Arc::new(Value::Stuck(
+                                    Head::Prim(Prim::OptionSome),
+                                    vec![
+                                        Elim::FunApp(Plicity::Implicit, elem_type.clone()),
+                                        Elim::FunApp(Plicity::Explicit, elem.clone()),
+                                    ],
+                                ))));
                             },
                             Value::ConstLit(Const::Bool(false)) => {}
                             _ => return None,
                         }
                     }
-                    Spanned::empty(Arc::new(Value::prim(Prim::OptionNone, [elem_type.clone()])))
+                    Spanned::empty(Arc::new(Value::Stuck(
+                        Head::Prim(Prim::OptionNone),
+                        vec![Elim::FunApp(Plicity::Implicit, elem_type.clone())],
+                    )))
                 }
                 _ => return None,
             })

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -88,7 +88,7 @@ def table_directory (file_start : Pos) = {
             fun (table_id : Repr tag) =>
             fun (table_format : Format) => {
                 // TODO: let formats
-                table_record <- unwrap (Repr table_record) (find_table table_records table_id),
+                table_record <- unwrap (find_table table_records table_id),
                 link <- link_table file_start table_record table_format,
             };
 
@@ -96,14 +96,14 @@ def table_directory (file_start : Pos) = {
             fun (table_id : Repr tag) =>
             fun (table_format : (U32 -> Format)) => {
                 // TODO: let formats
-                table_record <- unwrap (Repr table_record) (find_table table_records table_id),
+                table_record <- unwrap (find_table table_records table_id),
                 link <- link_table file_start table_record (table_format table_record.length),
             };
 
         let optional_table =
             fun (table_id : Repr tag) =>
             fun (table_format : Format) =>
-                option_fold (Repr table_record) Format {}
+                option_fold ({} : Format)
                     (fun record => link_table file_start record table_format)
                     (find_table table_records table_id);
 
@@ -117,8 +117,8 @@ def table_directory (file_start : Pos) = {
             maxp <- required_table "maxp" maxp_table,
             htmx <- required_table "hmtx" {
                 // TODO: let formats
-                hhea <- deref _ hhea.link,
-                maxp <- deref (limit32 maxp.table_record.length maxp_table) maxp.link,
+                hhea <- deref hhea.link,
+                maxp <- deref maxp.link,
                 table <- htmx_table
                     hhea.number_of_long_horizontal_metrics
                     maxp.num_glyphs,
@@ -134,15 +134,15 @@ def table_directory (file_start : Pos) = {
             fpgm <- optional_table "fpgm" unknown_table,
             glyf <- optional_table "glyf" {
                 // TODO: let formats
-                maxp <- deref (limit32 maxp.table_record.length maxp_table) maxp.link,
+                maxp <- deref maxp.link,
                 table <- glyf_table 1,
                 // TODO: use `loca` entries when parsing the glyphs
                 // table <- glyf_table maxp.num_glyphs,
             },
             loca <- optional_table "loca" {
                 // TODO: let formats
-                maxp <- deref (limit32 maxp.table_record.length maxp_table) maxp.link,
-                head <- deref _ head.link,
+                maxp <- deref maxp.link,
+                head <- deref head.link,
                 table <- loca_table maxp.num_glyphs head.index_to_loc_format,
             },
             prep <- optional_table "prep" unknown_table,
@@ -298,8 +298,8 @@ def find_table =
         // TODO: make use of `table_record.search_range`
         // TODO: make use of `table_record.entry_selector`
         // TODO: make use of `table_record.range_shift`
-        array16_find _ (Repr table_record)
-            (fun table_record => table_record.table_id == table_id)
+        array16_find
+            (fun (table_record : Repr table_record) => table_record.table_id == table_id)
             table_records;
 
 /// Create a link to the given `table_format`.
@@ -2802,7 +2802,7 @@ def simple_glyph (number_of_contours : U16) = {
     instruction_length <- u16be,
     /// Array of instruction byte code for the glyph.
     instructions <- array16 instruction_length u8,
-    let last_end_point_index = array16_index _ _ (number_of_contours - (1 : U16)) end_pts_of_contours,
+    let last_end_point_index = array16_index (number_of_contours - (1 : U16)) end_pts_of_contours,
     let number_of_coords = last_end_point_index + (1 : U16),
     /// Array of flag elements.
     // flags[variable] <- uint8,

--- a/formats/opentype.fathom
+++ b/formats/opentype.fathom
@@ -88,7 +88,7 @@ def table_directory (file_start : Pos) = {
             fun (table_id : Repr tag) =>
             fun (table_format : Format) => {
                 // TODO: let formats
-                table_record <- unwrap (Repr table_record) (find_table _ table_records table_id),
+                table_record <- unwrap (Repr table_record) (find_table table_records table_id),
                 link <- link_table file_start table_record table_format,
             };
 
@@ -96,7 +96,7 @@ def table_directory (file_start : Pos) = {
             fun (table_id : Repr tag) =>
             fun (table_format : (U32 -> Format)) => {
                 // TODO: let formats
-                table_record <- unwrap (Repr table_record) (find_table _ table_records table_id),
+                table_record <- unwrap (Repr table_record) (find_table table_records table_id),
                 link <- link_table file_start table_record (table_format table_record.length),
             };
 
@@ -105,7 +105,7 @@ def table_directory (file_start : Pos) = {
             fun (table_format : Format) =>
                 option_fold (Repr table_record) Format {}
                     (fun record => link_table file_start record table_format)
-                    (find_table _ table_records table_id);
+                    (find_table table_records table_id);
 
         {
             // Required Tables
@@ -291,7 +291,7 @@ def table_record = {
 
 /// Find a table record using the given `table_id`.
 def find_table =
-    fun (num_tables : U16) =>
+    fun (@num_tables : U16) =>
     fun (table_records : Array16 num_tables (Repr table_record)) =>
     fun (table_id : Repr tag) =>
         // TODO: accelerate using binary search

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -6,7 +6,7 @@ def table_record : Format = {
     offset <- u32be,
     length <- u32be,
 };
-def find_table : fun (num_tables : U16) -> Array16 num_tables {
+def find_table : fun (@num_tables : U16) -> Array16 num_tables {
     table_id : U32,
     checksum : U32,
     offset : U32,
@@ -17,7 +17,7 @@ def find_table : fun (num_tables : U16) -> Array16 num_tables {
     offset : U32,
     length : U32,
 } =
-fun num_tables table_records table_id => array16_find num_tables (Repr table_record) (fun table_record => table_record.table_id == table_id) table_records;
+fun @num_tables table_records table_id => array16_find num_tables (Repr table_record) (fun table_record => table_record.table_id == table_id) table_records;
 def link_table : Pos -> {
     table_id : U32,
     checksum : U32,
@@ -1037,16 +1037,16 @@ def table_directory : Pos -> Format = fun file_start => {
     table_records <- array16 num_tables table_record,
     table_links <- let required_table : U32 -> Format -> Format =
     fun table_id table_format => {
-        table_record <- unwrap (Repr table_record) (find_table num_tables table_records table_id),
+        table_record <- unwrap (Repr table_record) (find_table @num_tables table_records table_id),
         link <- link_table file_start table_record table_format,
     };
     let required_table_with_len : U32 -> (U32 -> Format) -> Format =
     fun table_id table_format => {
-        table_record <- unwrap (Repr table_record) (find_table num_tables table_records table_id),
+        table_record <- unwrap (Repr table_record) (find_table @num_tables table_records table_id),
         link <- link_table file_start table_record (table_format table_record.length),
     };
     let optional_table : U32 -> Format -> Format =
-    fun table_id table_format => option_fold (Repr table_record) Format () (fun record => link_table file_start record table_format) (find_table num_tables table_records table_id);
+    fun table_id table_format => option_fold (Repr table_record) Format () (fun record => link_table file_start record table_format) (find_table @num_tables table_records table_id);
     {
         cmap <- required_table "cmap" cmap_table,
         head <- required_table "head" head_table,

--- a/formats/opentype.snap
+++ b/formats/opentype.snap
@@ -16,8 +16,12 @@ def find_table : fun (@num_tables : U16) -> Array16 num_tables {
     checksum : U32,
     offset : U32,
     length : U32,
-} =
-fun @num_tables table_records table_id => array16_find num_tables (Repr table_record) (fun table_record => table_record.table_id == table_id) table_records;
+} = fun @num_tables table_records table_id => array16_find @num_tables @{
+    table_id : U32,
+    checksum : U32,
+    offset : U32,
+    length : U32,
+} (fun table_record => table_record.table_id == table_id) table_records;
 def link_table : Pos -> {
     table_id : U32,
     checksum : U32,
@@ -374,7 +378,7 @@ def simple_glyph : U16 -> Format = fun number_of_contours => {
     end_pts_of_contours <- array16 number_of_contours u16be,
     instruction_length <- u16be,
     instructions <- array16 instruction_length u8,
-    let last_end_point_index : U16 = array16_index number_of_contours U16 (number_of_contours - (1 :
+    let last_end_point_index : U16 = array16_index @number_of_contours @U16 (number_of_contours - (1 :
     U16)) end_pts_of_contours,
     let number_of_coords : U16 = last_end_point_index + (1 : U16),
 };
@@ -1037,23 +1041,38 @@ def table_directory : Pos -> Format = fun file_start => {
     table_records <- array16 num_tables table_record,
     table_links <- let required_table : U32 -> Format -> Format =
     fun table_id table_format => {
-        table_record <- unwrap (Repr table_record) (find_table @num_tables table_records table_id),
+        table_record <- unwrap @{
+            table_id : U32,
+            checksum : U32,
+            offset : U32,
+            length : U32,
+        } (find_table @num_tables table_records table_id),
         link <- link_table file_start table_record table_format,
     };
     let required_table_with_len : U32 -> (U32 -> Format) -> Format =
     fun table_id table_format => {
-        table_record <- unwrap (Repr table_record) (find_table @num_tables table_records table_id),
+        table_record <- unwrap @{
+            table_id : U32,
+            checksum : U32,
+            offset : U32,
+            length : U32,
+        } (find_table @num_tables table_records table_id),
         link <- link_table file_start table_record (table_format table_record.length),
     };
     let optional_table : U32 -> Format -> Format =
-    fun table_id table_format => option_fold (Repr table_record) Format () (fun record => link_table file_start record table_format) (find_table @num_tables table_records table_id);
+    fun table_id table_format => option_fold @{
+        table_id : U32,
+        checksum : U32,
+        offset : U32,
+        length : U32,
+    } @Format () (fun record => link_table file_start record table_format) (find_table @num_tables table_records table_id);
     {
         cmap <- required_table "cmap" cmap_table,
         head <- required_table "head" head_table,
         hhea <- required_table "hhea" hhea_table,
         maxp <- required_table "maxp" maxp_table,
         htmx <- required_table "hmtx" {
-            hhea <- deref (limit32 hhea.table_record.length {
+            hhea <- deref @(limit32 hhea.table_record.length {
                 major_version <- u16be where major_version == (1 : U16),
                 minor_version <- u16be,
                 ascent <- s16be,
@@ -1072,7 +1091,29 @@ def table_directory : Pos -> Format = fun file_start => {
                 metric_data_format <- s16be,
                 number_of_long_horizontal_metrics <- u16be,
             }) hhea.link,
-            maxp <- deref (limit32 maxp.table_record.length maxp_table) maxp.link,
+            maxp <- deref @(limit32 maxp.table_record.length {
+                version <- u32be,
+                num_glyphs <- u16be,
+                data <- match version {
+                    0x10000 => {
+                        max_points <- u16be,
+                        max_contours <- u16be,
+                        max_composite_points <- u16be,
+                        max_composite_contours <- u16be,
+                        max_zones <- u16be,
+                        max_twilight_points <- u16be,
+                        max_storage <- u16be,
+                        max_function_defs <- u16be,
+                        max_instruction_defs <- u16be,
+                        max_stack_elements <- u16be,
+                        max_size_of_instructions <- u16be,
+                        max_component_elements <- u16be,
+                        max_component_depth <- u16be where max_component_depth <= (16 :
+                        U16),
+                    },
+                    _ => (),
+                },
+            }) maxp.link,
             table <- htmx_table hhea.number_of_long_horizontal_metrics maxp.num_glyphs,
         },
         name <- required_table "name" name_table,
@@ -1081,12 +1122,56 @@ def table_directory : Pos -> Format = fun file_start => {
         cvt <- optional_table "cvt " unknown_table,
         fpgm <- optional_table "fpgm" unknown_table,
         glyf <- optional_table "glyf" {
-            maxp <- deref (limit32 maxp.table_record.length maxp_table) maxp.link,
+            maxp <- deref @(limit32 maxp.table_record.length {
+                version <- u32be,
+                num_glyphs <- u16be,
+                data <- match version {
+                    0x10000 => {
+                        max_points <- u16be,
+                        max_contours <- u16be,
+                        max_composite_points <- u16be,
+                        max_composite_contours <- u16be,
+                        max_zones <- u16be,
+                        max_twilight_points <- u16be,
+                        max_storage <- u16be,
+                        max_function_defs <- u16be,
+                        max_instruction_defs <- u16be,
+                        max_stack_elements <- u16be,
+                        max_size_of_instructions <- u16be,
+                        max_component_elements <- u16be,
+                        max_component_depth <- u16be where max_component_depth <= (16 :
+                        U16),
+                    },
+                    _ => (),
+                },
+            }) maxp.link,
             table <- glyf_table 1,
         },
         loca <- optional_table "loca" {
-            maxp <- deref (limit32 maxp.table_record.length maxp_table) maxp.link,
-            head <- deref (limit32 head.table_record.length {
+            maxp <- deref @(limit32 maxp.table_record.length {
+                version <- u32be,
+                num_glyphs <- u16be,
+                data <- match version {
+                    0x10000 => {
+                        max_points <- u16be,
+                        max_contours <- u16be,
+                        max_composite_points <- u16be,
+                        max_composite_contours <- u16be,
+                        max_zones <- u16be,
+                        max_twilight_points <- u16be,
+                        max_storage <- u16be,
+                        max_function_defs <- u16be,
+                        max_instruction_defs <- u16be,
+                        max_stack_elements <- u16be,
+                        max_size_of_instructions <- u16be,
+                        max_component_elements <- u16be,
+                        max_component_depth <- u16be where max_component_depth <= (16 :
+                        U16),
+                    },
+                    _ => (),
+                },
+            }) maxp.link,
+            head <- deref @(limit32 head.table_record.length {
                 major_version <- u16be where major_version == (1 : U16),
                 minor_version <- u16be,
                 font_revision <- u32be,

--- a/formats/unwrap-none.fathom
+++ b/formats/unwrap-none.fathom
@@ -1,4 +1,4 @@
 def main = {
     let ary : Array16 3 U16 = [1, 2, 3],
-    x <- unwrap U16 (array16_find _ U16 (fun el => el == (4 : U16)) ary),
+    x <- unwrap (array16_find (fun (el : U16) => el == (4 : U16)) ary),
 };

--- a/formats/unwrap-none.snap
+++ b/formats/unwrap-none.snap
@@ -1,7 +1,7 @@
 stdout = '''
 def main : Format = {
     let ary : Array16 3 U16 = [1, 2, 3],
-    x <- unwrap U16 (array16_find 3 U16 (fun el => el == (4 : U16)) ary),
+    x <- unwrap @U16 (array16_find @3 @U16 (fun el => el == (4 : U16)) ary),
 };
 '''
 stderr = ''

--- a/tests/succeed/format-deref/simple.fathom
+++ b/tests/succeed/format-deref/simple.fathom
@@ -1,7 +1,7 @@
 {
   start <- stream_pos,
   link <- link start u16be,
-  len <- deref _ link,
+  len <- deref link,
   _reserved <- u16be,
   data <- array16 len u16be,
 }

--- a/tests/succeed/format-deref/simple.snap
+++ b/tests/succeed/format-deref/simple.snap
@@ -2,7 +2,7 @@ stdout = '''
 {
     start <- stream_pos,
     link <- link start u16be,
-    len <- deref u16be link,
+    len <- deref @u16be link,
     _reserved <- u16be,
     data <- array16 len u16be,
 } : Format

--- a/tests/succeed/format-repr/primitives.fathom
+++ b/tests/succeed/format-repr/primitives.fathom
@@ -17,23 +17,23 @@ let test_f32le_repr : Repr f32le -> F32 = fun x => x;
 let test_f64be_repr : Repr f64be -> F64 = fun x => x;
 let test_f64le_repr : Repr f64le -> F64 = fun x => x;
 
-let test_array8 : fun n -> fun f -> Repr (array8 n f) -> Array8 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_array16 : fun n -> fun f -> Repr (array16 n f) -> Array16 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_array32 : fun n -> fun f -> Repr (array32 n f) -> Array32 n (Repr f) = fun _ => fun _ => fun x => x;
-let test_array64 : fun n -> fun f -> Repr (array64 n f) -> Array64 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array8 : fun n f -> Repr (array8 n f) -> Array8 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array16 : fun n f -> Repr (array16 n f) -> Array16 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array32 : fun n f -> Repr (array32 n f) -> Array32 n (Repr f) = fun _ => fun _ => fun x => x;
+let test_array64 : fun n f -> Repr (array64 n f) -> Array64 n (Repr f) = fun _ => fun _ => fun x => x;
 
 let test_repeat_until_end : fun f -> Repr (repeat_until_end f) -> Array (Repr f) = fun _ => fun x => x;
 
-let test_limit8 : fun n -> fun f -> Repr (limit8 n f) -> Repr f = fun _ => fun _ => fun x => x;
-let test_limit16 : fun n -> fun f -> Repr (limit16 n f) -> Repr f = fun _ => fun _ => fun x => x;
-let test_limit32 : fun n -> fun f -> Repr (limit32 n f) -> Repr f = fun _ => fun _ => fun x => x;
-let test_limit64 : fun n -> fun f -> Repr (limit64 n f) -> Repr f = fun _ => fun _ => fun x => x;
+let test_limit8 : fun n f -> Repr (limit8 n f) -> Repr f = fun _ => fun _ => fun x => x;
+let test_limit16 : fun n f -> Repr (limit16 n f) -> Repr f = fun _ => fun _ => fun x => x;
+let test_limit32 : fun n f -> Repr (limit32 n f) -> Repr f = fun _ => fun _ => fun x => x;
+let test_limit64 : fun n f -> Repr (limit64 n f) -> Repr f = fun _ => fun _ => fun x => x;
 
-let test_link : fun pos -> fun f -> Repr (link pos f) -> Ref f = fun _ => fun _ => fun x => x;
-let test_deref : fun f -> fun ref -> Repr (deref f ref) -> Repr f = fun _ => fun _ => fun x => x;
+let test_link : fun pos f -> Repr (link pos f) -> Ref f = fun _ => fun _ => fun x => x;
+let test_deref : fun f (ref : Ref f) -> Repr (deref ref) -> Repr f = fun _ => fun _ => fun x => x;
 let test_stream_pos : Repr stream_pos -> Pos = fun x => x;
-let test_succeed : Repr (succeed S32 42) -> S32 = fun x => x;
+let test_succeed : Repr (succeed (42 : S32)) -> S32 = fun x => x;
 let test_fail : Repr fail -> Void = fun x => x;
-let test_unwrap : fun A -> fun opt_a -> Repr (unwrap A opt_a) -> A = fun _ => fun _ => fun x => x;
+let test_unwrap : fun A (opt_a : Option A) -> Repr (unwrap opt_a) -> A = fun _ => fun _ => fun x => x;
 
 Type

--- a/tests/succeed/primitives.fathom
+++ b/tests/succeed/primitives.fathom
@@ -1,5 +1,4 @@
 let _ = Void : Type;
-let _ = absurd;
 
 let _ = Bool : Type;
 
@@ -62,12 +61,14 @@ let _ = array16 : U16 -> Format -> Format;
 let _ = array32 : U32 -> Format -> Format;
 let _ = array64 : U64 -> Format -> Format;
 let _ = link : Pos -> Format -> Format;
-let _ = deref : fun (f : Format) -> Ref f -> Format;
+let _ = deref : fun (@f : Format) -> Ref f -> Format;
 let _ = stream_pos : Format;
-let _ = succeed : fun (Elem : Type) -> Elem -> Format;
+let _ = succeed : fun (@A : Type) -> A -> Format;
 let _ = fail : Format;
-let _ = unwrap : fun (A : Type) -> Option A -> Format;
+let _ = unwrap : fun (@A : Type) -> Option A -> Format;
 let _ = Repr : Format -> Type;
+
+let _ = absurd : fun (@A : Type) -> Void -> A;
 
 let _ = bool_eq : Bool -> Bool -> Bool;
 let _ = bool_neq : Bool -> Bool -> Bool;
@@ -200,19 +201,19 @@ let _ = s64_div : S64 -> S64 -> S64;
 let _ = s64_abs : S64 -> S64;
 let _ = s64_unsigned_abs : S64 -> U64;
 
-let _ = some : fun (A : Type) -> A -> Option A;
-let _ = none : fun (A : Type) -> Option A;
-let _ = option_fold : fun (A : Type) (B : Type) -> B -> (A -> B) -> Option A -> B;
+let _ = some : fun (@A : Type) -> A -> Option A;
+let _ = none : fun (@A : Type) -> Option A;
+let _ = option_fold : fun (@A : Type) (@B : Type) -> B -> (A -> B) -> Option A -> B;
 
-let _ = array8_find : fun (len : U8) (A : Type) -> (A -> Bool) -> Array8 len A -> Option A;
-let _ = array16_find : fun (len : U16) (A : Type) -> (A -> Bool) -> Array16 len A -> Option A;
-let _ = array32_find : fun (len : U32) (A : Type) -> (A -> Bool) -> Array32 len A -> Option A;
-let _ = array64_find : fun (len : U64) (A : Type) -> (A -> Bool) -> Array64 len A -> Option A;
+let _ = array8_find : fun (@len : U8) (@A : Type) -> (A -> Bool) -> Array8 len A -> Option A;
+let _ = array16_find : fun (@len : U16) (@A : Type) -> (A -> Bool) -> Array16 len A -> Option A;
+let _ = array32_find : fun (@len : U32) (@A : Type) -> (A -> Bool) -> Array32 len A -> Option A;
+let _ = array64_find : fun (@len : U64) (@A : Type) -> (A -> Bool) -> Array64 len A -> Option A;
 
-let _ = array8_index : fun (len : U8) (A : Type) -> U8 -> Array8 len A -> A;
-let _ = array16_index : fun (len : U16) (A : Type) -> U16 -> Array16 len A -> A;
-let _ = array32_index : fun (len : U32) (A : Type) -> U32 -> Array32 len A -> A;
-let _ = array64_index : fun (len : U64) (A : Type) -> U64 -> Array64 len A -> A;
+let _ = array8_index : fun (@len : U8) (@A : Type) -> U8 -> Array8 len A -> A;
+let _ = array16_index : fun (@len : U16) (@A : Type) -> U16 -> Array16 len A -> A;
+let _ = array32_index : fun (@len : U32) (@A : Type) -> U32 -> Array32 len A -> A;
+let _ = array64_index : fun (@len : U64) (@A : Type) -> U64 -> Array64 len A -> A;
 
 let _ = pos_add_u8 : Pos -> U8 -> Pos;
 let _ = pos_add_u16 : Pos -> U16 -> Pos;

--- a/tests/succeed/primitives.snap
+++ b/tests/succeed/primitives.snap
@@ -1,6 +1,5 @@
 stdout = '''
 let _ : Type = Void;
-let _ : fun (A : Type) -> Void -> A = absurd;
 let _ : Type = Bool;
 let _ : Type = U8;
 let _ : Type = U16;
@@ -59,12 +58,13 @@ let _ : U16 -> Format -> Format = array16;
 let _ : U32 -> Format -> Format = array32;
 let _ : U64 -> Format -> Format = array64;
 let _ : Pos -> Format -> Format = link;
-let _ : fun (f : Format) -> Ref f -> Format = deref;
+let _ : fun (@f : Format) -> Ref f -> Format = deref;
 let _ : Format = stream_pos;
-let _ : fun (Elem : Type) -> Elem -> Format = succeed;
+let _ : fun (@A : Type) -> A -> Format = succeed;
 let _ : Format = fail;
-let _ : fun (A : Type) -> Option A -> Format = unwrap;
+let _ : fun (@A : Type) -> Option A -> Format = unwrap;
 let _ : Format -> Type = Repr;
+let _ : fun (@A : Type) -> Void -> A = absurd;
 let _ : Bool -> Bool -> Bool = bool_eq;
 let _ : Bool -> Bool -> Bool = bool_neq;
 let _ : Bool -> Bool = bool_not;
@@ -187,22 +187,25 @@ let _ : S64 -> S64 -> S64 = s64_mul;
 let _ : S64 -> S64 -> S64 = s64_div;
 let _ : S64 -> S64 = s64_abs;
 let _ : S64 -> U64 = s64_unsigned_abs;
-let _ : fun (A : Type) -> A -> Option A = some;
-let _ : fun (A : Type) -> Option A = none;
-let _ : fun (A : Type) (B : Type) -> B -> (A -> B) -> Option A -> B =
+let _ : fun (@A : Type) -> A -> Option A = some;
+let _ : fun (@A : Type) -> Option A = none;
+let _ : fun (@A : Type) (@B : Type) -> B -> (A -> B) -> Option A -> B =
 option_fold;
-let _ : fun (len : U8) (A : Type) -> (A -> Bool) -> Array8 len A -> Option A =
+let _ : fun (@len : U8) (@A : Type) -> (A -> Bool) -> Array8 len A -> Option A =
 array8_find;
-let _ : fun (len : U16) (A : Type) -> (A -> Bool) -> Array16 len A -> Option A =
-array16_find;
-let _ : fun (len : U32) (A : Type) -> (A -> Bool) -> Array32 len A -> Option A =
-array32_find;
-let _ : fun (len : U64) (A : Type) -> (A -> Bool) -> Array64 len A -> Option A =
-array64_find;
-let _ : fun (len : U8) (A : Type) -> U8 -> Array8 len A -> A = array8_index;
-let _ : fun (len : U16) (A : Type) -> U16 -> Array16 len A -> A = array16_index;
-let _ : fun (len : U32) (A : Type) -> U32 -> Array32 len A -> A = array32_index;
-let _ : fun (len : U64) (A : Type) -> U64 -> Array64 len A -> A = array64_index;
+let _ : fun (@len : U16) (@A : Type) -> (A -> Bool) -> Array16 len A ->
+Option A = array16_find;
+let _ : fun (@len : U32) (@A : Type) -> (A -> Bool) -> Array32 len A ->
+Option A = array32_find;
+let _ : fun (@len : U64) (@A : Type) -> (A -> Bool) -> Array64 len A ->
+Option A = array64_find;
+let _ : fun (@len : U8) (@A : Type) -> U8 -> Array8 len A -> A = array8_index;
+let _ : fun (@len : U16) (@A : Type) -> U16 -> Array16 len A -> A =
+array16_index;
+let _ : fun (@len : U32) (@A : Type) -> U32 -> Array32 len A -> A =
+array32_index;
+let _ : fun (@len : U64) (@A : Type) -> U64 -> Array64 len A -> A =
+array64_index;
 let _ : Pos -> U8 -> Pos = pos_add_u8;
 let _ : Pos -> U16 -> Pos = pos_add_u16;
 let _ : Pos -> U32 -> Pos = pos_add_u32;


### PR DESCRIPTION
This uses implicit parameters to clean up some functions in the opentype format description, and updates the primitives to make use of implicit parameters.