### PR TITLE
Add `absurd`, the eliminator for `Void`

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1167,6 +1167,10 @@ and can be dereferenced later on with a [deref format](#deref-formats).
 
 ## Void
 
-The void type is be used to mark terms that must never be constructed:
+The void type is be used to mark terms that can never be constructed:
 
 - `Void : Type`
+
+It can be eliminated by the `absurd` function:
+
+- `absurd : fun (A : Type) -> Void -> A`

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -302,6 +302,9 @@ def_prims! {
     /// Void type.
     VoidType => "Void",
 
+    /// Void eliminator.
+    Absurd => "absurd",
+
     /// Type of booleans.
     BoolType => "Bool",
     /// Type of unsigned, 8-bit integers.

--- a/tests/succeed/primitives.fathom
+++ b/tests/succeed/primitives.fathom
@@ -1,4 +1,5 @@
 let _ = Void : Type;
+let _ = absurd;
 
 let _ = Bool : Type;
 

--- a/tests/succeed/primitives.snap
+++ b/tests/succeed/primitives.snap
@@ -1,5 +1,6 @@
 stdout = '''
 let _ : Type = Void;
+let _ : fun (A : Type) -> Void -> A = absurd;
 let _ : Type = Bool;
 let _ : Type = U8;
 let _ : Type = U16;


### PR DESCRIPTION
Felt we should have this for completeness, though of course it should be impossible to use. 