### PR TITLE
Implicit function cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: cachix/install-nix-action@v17
 
       - name: Run cargo fmt
-        run: nix develop .#${{ matrix.rust-toolchain }} --command cargo fmt
+        run: nix develop .#${{ matrix.rust-toolchain }} --command cargo fmt --check
 
   cargo-clippy:
     runs-on: ubuntu-latest

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -729,20 +729,21 @@ id Type S32
 
 ### Implicit parameters
 
-Function parameters can be made *implicit* by prefixing them with `@`:
+Function parameters can be made _implicit_ by prefixing them with `@`:
 
 ```fathom
 fun (@A : Type) => A
 ```
 
-Implicit parameters will be filled in automatically when they can be inferred by the types of other terms:
+Implicit parameters will be filled in automatically when they can be inferred by
+the types of other terms:
 
 ```fathom
 let id = fun (@A : Type) (a : A) => a;
 id false
 ```
 
-Implicit parameters can be passed explictly by prefixing the argument with `@`:
+Implicit arguments can be passed explicitly by prefixing the argument with `@`:
 
 ```fathom
 id @Bool false

--- a/fathom/src/core/pretty.rs
+++ b/fathom/src/core/pretty.rs
@@ -180,10 +180,9 @@ impl<'interner, 'arena> Context<'interner> {
                             RcDoc::concat([
                                 RcDoc::concat([
                                     self.plicity(*plicity),
-                                    if let Some(name) = param_name {
-                                        self.string_id(*name)
-                                    } else {
-                                        RcDoc::nil()
+                                    match param_name {
+                                        Some(name) => self.string_id(*name),
+                                        None => RcDoc::text("_"),
                                     },
                                     RcDoc::space(),
                                     RcDoc::text(":"),
@@ -208,10 +207,9 @@ impl<'interner, 'arena> Context<'interner> {
                         RcDoc::text("fun"),
                         RcDoc::space(),
                         self.plicity(*plicity),
-                        if let Some(name) = param_name {
-                            self.string_id(*name)
-                        } else {
-                            RcDoc::nil()
+                        match param_name {
+                            Some(name) => self.string_id(*name),
+                            None => RcDoc::text("_"),
                         },
                         RcDoc::space(),
                         RcDoc::text("=>"),

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -68,7 +68,7 @@ pub struct ItemDef<'arena, Range> {
     /// The label that identifies this definition
     label: (Range, StringId),
     /// Parameter patterns
-    params: &'arena [FunParam<'arena, Range>],
+    params: &'arena [Param<'arena, Range>],
     /// An optional type annotation for the defined expression
     r#type: Option<&'arena Term<'arena, Range>>,
     /// The defined expression
@@ -212,20 +212,20 @@ pub enum Term<'arena, Range> {
     /// Dependent function types.
     FunType(
         Range,
-        &'arena [FunParam<'arena, Range>],
+        &'arena [Param<'arena, Range>],
         &'arena Term<'arena, Range>,
     ),
     /// Function literals.
     FunLiteral(
         Range,
-        &'arena [FunParam<'arena, Range>],
+        &'arena [Param<'arena, Range>],
         &'arena Term<'arena, Range>,
     ),
     /// Applications.
     App(
         Range,
         &'arena Term<'arena, Range>,
-        &'arena [AppArg<'arena, Range>],
+        &'arena [Arg<'arena, Range>],
     ),
     /// Dependent record types.
     RecordType(Range, &'arena [TypeField<'arena, Range>]),
@@ -333,15 +333,14 @@ impl<'arena> Term<'arena, ByteRange> {
 }
 
 #[derive(Debug, Clone)]
-pub struct FunParam<'arena, Range> {
+pub struct Param<'arena, Range> {
     pub plicity: Plicity,
     pub pattern: Pattern<Range>,
     pub r#type: Option<Term<'arena, Range>>,
 }
 
 #[derive(Debug, Clone)]
-
-pub struct AppArg<'arena, Range> {
+pub struct Arg<'arena, Range> {
     pub plicity: Plicity,
     pub term: Term<'arena, Range>,
 }

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -59,10 +59,10 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
     }
 
     fn push_local(&mut self, name: Option<StringId>) -> StringId {
-        let name =
-            name.unwrap_or_else(|| {
-                self.interner.borrow_mut().get_or_intern_static("_") // TODO: choose a better name?
-            });
+        let name = name.unwrap_or_else(|| {
+            // TODO: choose a better name?
+            self.interner.borrow_mut().get_or_intern_static("_")
+        });
 
         // TODO: avoid globals
         // TODO: ensure we chose a correctly bound name

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -6,13 +6,12 @@ use scoped_arena::Scope;
 
 use crate::alloc::SliceVec;
 use crate::core;
-use crate::core::{Const, UIntStyle};
+use crate::core::{Const, Plicity, UIntStyle};
 use crate::env::{self, EnvLen, Index, Level, UniqueEnv};
 use crate::source::{Span, StringId, StringInterner};
 use crate::surface::elaboration::MetaSource;
 use crate::surface::{
-    AppArg, BinOp, ExprField, FormatField, FunParam, Item, ItemDef, Module, Pattern, Plicity, Term,
-    TypeField,
+    Arg, BinOp, ExprField, FormatField, Item, ItemDef, Module, Param, Pattern, Term, TypeField,
 };
 
 /// Distillation context.
@@ -275,7 +274,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 let body_expr = self.check(body_expr);
                 self.truncate_local(initial_local_len);
 
-                let params = params.into_iter().map(|(plicity, name)| FunParam {
+                let params = params.into_iter().map(|(plicity, name)| Param {
                     plicity,
                     pattern: Pattern::Name((), name),
                     r#type: None,
@@ -427,7 +426,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                             core::LocalInfo::Def => {}
                             core::LocalInfo::Param => {
                                 let var = self.local_len().level_to_index(var).unwrap();
-                                args.push(AppArg {
+                                args.push(Arg {
                                     plicity: Plicity::Explicit,
                                     term: self.check(&core::Term::LocalVar(Span::Empty, var)),
                                 });
@@ -478,7 +477,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                             let param_type = self.check(param_type);
                             let param_name = self.freshen_name(*param_name, next_body_type);
                             let param_name = self.push_local(param_name);
-                            params.push(FunParam {
+                            params.push(Param {
                                 plicity: *plicity,
                                 pattern: Pattern::Name((), param_name),
                                 r#type: Some(param_type),
@@ -531,7 +530,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 let body_expr = self.synth(body_expr);
                 self.truncate_local(initial_local_len);
 
-                let params = params.into_iter().map(|(plicity, name)| FunParam {
+                let params = params.into_iter().map(|(plicity, name)| Param {
                     plicity,
                     pattern: Pattern::Name((), name),
                     r#type: None,
@@ -557,7 +556,7 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
 
                 while let core::Term::FunApp(_, plicity, next_head_expr, arg_expr) = head_expr {
                     head_expr = next_head_expr;
-                    args.push(AppArg {
+                    args.push(Arg {
                         plicity: *plicity,
                         term: self.check(arg_expr),
                     });

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -22,7 +22,7 @@ use fxhash::{FxHashMap, FxHashSet};
 
 use crate::source::{ByteRange, StringId};
 use crate::surface::elaboration::reporting::Message;
-use crate::surface::{elaboration, FormatField, FunParam, Item, Module, Pattern, Term};
+use crate::surface::{elaboration, FormatField, Item, Module, Param, Pattern, Term};
 
 enum Error {
     CycleDetected,
@@ -279,7 +279,7 @@ fn term_deps(
 }
 
 fn push_param_deps(
-    params: &[FunParam<'_, ByteRange>],
+    params: &[Param<'_, ByteRange>],
     item_names: &FxHashMap<StringId, usize>,
     local_names: &mut Vec<StringId>,
     deps: &mut Vec<StringId>,

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -2,7 +2,10 @@ use scoped_arena::Scope;
 use std::cell::RefCell;
 
 use crate::source::{ByteRange, BytePos, StringId, StringInterner};
-use crate::surface::{ExprField, FormatField, Item, ItemDef, Module, ParseMessage, Pattern, Term, TypeField, BinOp, Plicity, FunParam, AppArg};
+use crate::surface::{
+    Arg, BinOp, ExprField, FormatField, Item, ItemDef, Module, ParseMessage,
+    Pattern, Param, Plicity, Term, TypeField,
+};
 use crate::surface::lexer::{Error as LexerError, Token};
 use crate::files::FileId;
 
@@ -75,7 +78,7 @@ pub Module: Module<'arena, ByteRange> = {
 };
 
 Item: Item<'arena, ByteRange> = {
-    <start: @L> "def" <label: RangedName> <params: FunParam*> <r#type: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
+    <start: @L> "def" <label: RangedName> <params: Param*> <r#type: (":" <LetTerm>)?> "=" <expr: Term> ";" <end: @R> => {
         Item::Def(ItemDef {
             range: ByteRange::new(file_id, start, end),
             label,
@@ -136,14 +139,14 @@ FunTerm: Term<'arena, ByteRange> = {
             scope.to_scope(body_type),
         )
     },
-    <start: @L> "fun" <params: FunParam+> "->"  <output_type: FunTerm> <end: @R> => {
+    <start: @L> "fun" <params: Param+> "->"  <output_type: FunTerm> <end: @R> => {
         Term::FunType(
             ByteRange::new(file_id, start, end),
             scope.to_scope_from_iter(params),
             scope.to_scope(output_type),
         )
     },
-    <start: @L> "fun" <params: FunParam+> "=>" <output_type: LetTerm> <end: @R> => {
+    <start: @L> "fun" <params: Param+> "=>" <output_type: LetTerm> <end: @R> => {
         Term::FunLiteral(
             ByteRange::new(file_id, start, end),
             scope.to_scope_from_iter(params),
@@ -180,7 +183,7 @@ MulExpr: Term<'arena, ByteRange> = {
 
 AppTerm: Term<'arena, ByteRange> = {
     ProjTerm,
-    <start: @L> <head_expr: ProjTerm> <args: AppArg+> <end: @R> => {
+    <start: @L> <head_expr: ProjTerm> <args: Arg+> <end: @R> => {
         Term::App(
             ByteRange::new(file_id, start, end),
             scope.to_scope(head_expr),
@@ -188,10 +191,6 @@ AppTerm: Term<'arena, ByteRange> = {
         )
     },
 };
-
-AppArg: AppArg<'arena, ByteRange> = {
-    <plicity: Plicity> <term: ProjTerm> => AppArg {plicity, term},
-}
 
 ProjTerm: Term<'arena, ByteRange> = {
     AtomicTerm,
@@ -299,12 +298,16 @@ Tuple<Elem>: &'arena [Elem] = {
 Plicity: Plicity = {
     () => Plicity::Explicit,
     "@" => Plicity::Implicit,
-}
+};
 
-FunParam: FunParam<'arena, ByteRange> = {
-    <plicity: Plicity> <pattern: Pattern> => FunParam {plicity, pattern, r#type: None},
-    "(" <plicity: Plicity> <pattern: Pattern> ":" <r#type: LetTerm> ")" => FunParam{plicity, pattern, r#type: Some(r#type)},
-}
+Param: Param<'arena, ByteRange> = {
+    <plicity: Plicity> <pattern: Pattern> => Param { plicity, pattern, r#type: None },
+    "(" <plicity: Plicity> <pattern: Pattern> ":" <r#type: LetTerm> ")" => Param { plicity, pattern, r#type: Some(r#type) },
+};
+
+Arg: Arg<'arena, ByteRange> = {
+    <plicity: Plicity> <term: ProjTerm> => Arg {plicity, term},
+};
 
 #[inline]
 RangedName: (ByteRange, StringId) = {


### PR DESCRIPTION
Some cleanups to the implementation of implicit functions that were added in #439. I’ve broken the dependency on `core::Plicity` in the surface syntax, adjusted some names, and cleaned up the insertion of implicit arguments somewhat (inspired by [elaboration-zoo’s implementation](https://github.com/AndrasKovacs/elaboration-zoo/blob/master/04-implicit-args/Elaboration.hs)).