### PR TITLE
Use lexer modes to parse block comments

### DIFF
--- a/tests/fail/parse/unclosed-block-comment.snap
+++ b/tests/fail/parse/unclosed-block-comment.snap
@@ -9,6 +9,6 @@ error: unclosed block comment
 9 │ */ b
   │ ^^ last `*/`
   │
-  = Help: 1 more `*/` needed
+  = help: 1 more `*/` needed
 
 '''


### PR DESCRIPTION
This uses Logos’ [lexer modes](https://github.com/maciejhirsz/logos/blob/51c1f8c1bca990758e05c5600becc6d9c10bd6e4/tests/tests/lexer_modes.rs) to parse block comments.