### PR TITLE
Shrink surface and core AST types by replacing tuples of references with references to tuples

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -195,9 +195,8 @@ pub enum Term<'arena> {
     /// in lexicographic order.
     ConstMatch(
         Span,
-        &'arena Term<'arena>,
+        &'arena (Term<'arena>, Option<(Option<StringId>, Term<'arena>)>),
         &'arena [(Const, Term<'arena>)],
-        Option<&'arena (Option<StringId>, Term<'arena>)>,
     ),
 }
 
@@ -265,10 +264,12 @@ impl<'arena> Term<'arena> {
             Term::FormatCond(_, _, (format, pred)) => {
                 format.binds_local(var) || pred.binds_local(var.prev())
             }
-            Term::ConstMatch(_, scrut, branches, default_expr) => {
+            Term::ConstMatch(_, (scrut, default_expr), branches) => {
                 scrut.binds_local(var)
                     || branches.iter().any(|(_, term)| term.binds_local(var))
-                    || default_expr.map_or(false, |(_, term)| term.binds_local(var.prev()))
+                    || default_expr
+                        .as_ref()
+                        .map_or(false, |(_, term)| term.binds_local(var.prev()))
             }
         }
     }

--- a/fathom/src/core/pretty.rs
+++ b/fathom/src/core/pretty.rs
@@ -137,7 +137,7 @@ impl<'interner, 'arena> Context<'interner> {
             Term::InsertedMeta(_, level, info) => {
                 RcDoc::text(format!("InsertedMeta({level:?}, {info:?})"))
             }
-            Term::Ann(_, expr, r#type) => self.paren(
+            Term::Ann(_, (expr, r#type)) => self.paren(
                 prec > Prec::Top,
                 RcDoc::concat([
                     RcDoc::concat([
@@ -150,7 +150,7 @@ impl<'interner, 'arena> Context<'interner> {
                     self.term_prec(Prec::Top, r#type),
                 ]),
             ),
-            Term::Let(_, def_pattern, def_type, def_expr, body_expr) => self.paren(
+            Term::Let(_, def_pattern, (def_type, def_expr, body_expr)) => self.paren(
                 prec > Prec::Let,
                 RcDoc::concat([
                     RcDoc::concat([
@@ -169,7 +169,7 @@ impl<'interner, 'arena> Context<'interner> {
                 ]),
             ),
             Term::Universe(_) => RcDoc::text("Type"),
-            Term::FunType(_, plicity, param_name, param_type, body_type) => self.paren(
+            Term::FunType(_, plicity, param_name, (param_type, body_type)) => self.paren(
                 prec > Prec::Fun,
                 RcDoc::concat([
                     RcDoc::concat([
@@ -220,7 +220,7 @@ impl<'interner, 'arena> Context<'interner> {
                     self.term_prec(Prec::Let, body_expr),
                 ]),
             ),
-            Term::FunApp(_, plicity, head_expr, arg_expr) => self.paren(
+            Term::FunApp(_, plicity, (head_expr, arg_expr)) => self.paren(
                 prec > Prec::App,
                 RcDoc::concat([
                     self.plicity(*plicity),
@@ -278,7 +278,7 @@ impl<'interner, 'arena> Context<'interner> {
                 RcDoc::text(","),
                 RcDoc::text("}"),
             ),
-            Term::FormatCond(_, label, format, cond) => RcDoc::concat([
+            Term::FormatCond(_, label, (format, cond)) => RcDoc::concat([
                 RcDoc::text("{"),
                 RcDoc::space(),
                 self.string_id(*label),
@@ -325,7 +325,7 @@ impl<'interner, 'arena> Context<'interner> {
                     .chain(default_expr.iter().map(|&(name, default)| {
                         RcDoc::concat([
                             match name {
-                                Some(name) => self.string_id(name),
+                                Some(name) => self.string_id(*name),
                                 None => RcDoc::text("_"),
                             },
                             RcDoc::space(),

--- a/fathom/src/core/pretty.rs
+++ b/fathom/src/core/pretty.rs
@@ -303,7 +303,7 @@ impl<'interner, 'arena> Context<'interner> {
                 RcDoc::text("}"),
             ),
             Term::Prim(_, prim) => RcDoc::text(format!("{prim:?}")),
-            Term::ConstMatch(_, scrutinee, branches, default_expr) => self.sequence(
+            Term::ConstMatch(_, (scrutinee, default_expr), branches) => self.sequence(
                 RcDoc::concat([
                     RcDoc::text("match"),
                     RcDoc::space(),
@@ -322,7 +322,7 @@ impl<'interner, 'arena> Context<'interner> {
                             self.term_prec(Prec::Top, body_expr),
                         ])
                     })
-                    .chain(default_expr.iter().map(|&(name, default)| {
+                    .chain(default_expr.iter().map(|(name, default)| {
                         RcDoc::concat([
                             match name {
                                 Some(name) => self.string_id(*name),

--- a/fathom/src/core/prim.rs
+++ b/fathom/src/core/prim.rs
@@ -57,451 +57,499 @@ impl<'arena> Env<'arena> {
 
         let mut env = EnvBuilder::new(interner, scope);
 
-        env.define_prim(VoidType, &UNIVERSE);
-        env.define_prim(BoolType, &UNIVERSE);
-        env.define_prim(U8Type, &UNIVERSE);
-        env.define_prim(U16Type, &UNIVERSE);
-        env.define_prim(U32Type, &UNIVERSE);
-        env.define_prim(U64Type, &UNIVERSE);
-        env.define_prim(S8Type, &UNIVERSE);
-        env.define_prim(S16Type, &UNIVERSE);
-        env.define_prim(S32Type, &UNIVERSE);
-        env.define_prim(S64Type, &UNIVERSE);
-        env.define_prim(F32Type, &UNIVERSE);
-        env.define_prim(F64Type, &UNIVERSE);
-        env.define_prim_fun(OptionType, [&UNIVERSE], &UNIVERSE);
-        env.define_prim_fun(ArrayType, [&UNIVERSE], &UNIVERSE);
-        env.define_prim_fun(Array8Type, [&U8_TYPE, &UNIVERSE], &UNIVERSE);
-        env.define_prim_fun(Array16Type, [&U16_TYPE, &UNIVERSE], &UNIVERSE);
-        env.define_prim_fun(Array32Type, [&U32_TYPE, &UNIVERSE], &UNIVERSE);
-        env.define_prim_fun(Array64Type, [&U64_TYPE, &UNIVERSE], &UNIVERSE);
-        env.define_prim(PosType, &UNIVERSE);
-        env.define_prim_fun(RefType, [&FORMAT_TYPE], &UNIVERSE);
-        env.define_prim(FormatType, &UNIVERSE);
+        env.define_prim(VoidType, UNIVERSE);
+        env.define_prim(BoolType, UNIVERSE);
+        env.define_prim(U8Type, UNIVERSE);
+        env.define_prim(U16Type, UNIVERSE);
+        env.define_prim(U32Type, UNIVERSE);
+        env.define_prim(U64Type, UNIVERSE);
+        env.define_prim(S8Type, UNIVERSE);
+        env.define_prim(S16Type, UNIVERSE);
+        env.define_prim(S32Type, UNIVERSE);
+        env.define_prim(S64Type, UNIVERSE);
+        env.define_prim(F32Type, UNIVERSE);
+        env.define_prim(F64Type, UNIVERSE);
+        env.define_prim_fun(OptionType, [UNIVERSE], UNIVERSE);
+        env.define_prim_fun(ArrayType, [UNIVERSE], UNIVERSE);
+        env.define_prim_fun(Array8Type, [U8_TYPE, UNIVERSE], UNIVERSE);
+        env.define_prim_fun(Array16Type, [U16_TYPE, UNIVERSE], UNIVERSE);
+        env.define_prim_fun(Array32Type, [U32_TYPE, UNIVERSE], UNIVERSE);
+        env.define_prim_fun(Array64Type, [U64_TYPE, UNIVERSE], UNIVERSE);
+        env.define_prim(PosType, UNIVERSE);
+        env.define_prim_fun(RefType, [FORMAT_TYPE], UNIVERSE);
+        env.define_prim(FormatType, UNIVERSE);
 
-        env.define_prim(FormatU8, &FORMAT_TYPE);
-        env.define_prim(FormatU16Be, &FORMAT_TYPE);
-        env.define_prim(FormatU16Le, &FORMAT_TYPE);
-        env.define_prim(FormatU32Be, &FORMAT_TYPE);
-        env.define_prim(FormatU32Le, &FORMAT_TYPE);
-        env.define_prim(FormatU64Be, &FORMAT_TYPE);
-        env.define_prim(FormatU64Le, &FORMAT_TYPE);
-        env.define_prim(FormatS8, &FORMAT_TYPE);
-        env.define_prim(FormatS16Be, &FORMAT_TYPE);
-        env.define_prim(FormatS16Le, &FORMAT_TYPE);
-        env.define_prim(FormatS32Be, &FORMAT_TYPE);
-        env.define_prim(FormatS32Le, &FORMAT_TYPE);
-        env.define_prim(FormatS64Be, &FORMAT_TYPE);
-        env.define_prim(FormatS64Le, &FORMAT_TYPE);
-        env.define_prim(FormatF32Be, &FORMAT_TYPE);
-        env.define_prim(FormatF32Le, &FORMAT_TYPE);
-        env.define_prim(FormatF64Be, &FORMAT_TYPE);
-        env.define_prim(FormatF64Le, &FORMAT_TYPE);
-        env.define_prim_fun(FormatRepeatLen8, [&U8_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatRepeatLen16, [&U16_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatRepeatLen32, [&U32_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatRepeatLen64, [&U64_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatRepeatUntilEnd, [&FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatLimit8, [&U8_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatLimit16, [&U16_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatLimit32, [&U32_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatLimit64, [&U64_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
-        env.define_prim_fun(FormatLink, [&POS_TYPE, &FORMAT_TYPE], &FORMAT_TYPE);
+        env.define_prim(FormatU8, FORMAT_TYPE);
+        env.define_prim(FormatU16Be, FORMAT_TYPE);
+        env.define_prim(FormatU16Le, FORMAT_TYPE);
+        env.define_prim(FormatU32Be, FORMAT_TYPE);
+        env.define_prim(FormatU32Le, FORMAT_TYPE);
+        env.define_prim(FormatU64Be, FORMAT_TYPE);
+        env.define_prim(FormatU64Le, FORMAT_TYPE);
+        env.define_prim(FormatS8, FORMAT_TYPE);
+        env.define_prim(FormatS16Be, FORMAT_TYPE);
+        env.define_prim(FormatS16Le, FORMAT_TYPE);
+        env.define_prim(FormatS32Be, FORMAT_TYPE);
+        env.define_prim(FormatS32Le, FORMAT_TYPE);
+        env.define_prim(FormatS64Be, FORMAT_TYPE);
+        env.define_prim(FormatS64Le, FORMAT_TYPE);
+        env.define_prim(FormatF32Be, FORMAT_TYPE);
+        env.define_prim(FormatF32Le, FORMAT_TYPE);
+        env.define_prim(FormatF64Be, FORMAT_TYPE);
+        env.define_prim(FormatF64Le, FORMAT_TYPE);
+        env.define_prim_fun(FormatRepeatLen8, [U8_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatRepeatLen16, [U16_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatRepeatLen32, [U32_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatRepeatLen64, [U64_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatRepeatUntilEnd, [FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatLimit8, [U8_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatLimit16, [U16_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatLimit32, [U32_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatLimit64, [U64_TYPE, FORMAT_TYPE], FORMAT_TYPE);
+        env.define_prim_fun(FormatLink, [POS_TYPE, FORMAT_TYPE], FORMAT_TYPE);
         env.define_prim(
             FormatDeref,
-            &core::Term::FunType(
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
-                env.name("f"),
-                &FORMAT_TYPE,
-                &Term::FunType(
-                    Span::Empty,
-                    Plicity::Explicit,
-                    None,
-                    &Term::FunApp(
+                env.name("A"),
+                &(
+                    FORMAT_TYPE,
+                    Term::FunType(
                         Span::Empty,
                         Plicity::Explicit,
-                        &Term::Prim(Span::Empty, RefType),
-                        &VAR0,
+                        None,
+                        &(
+                            Term::FunApp(
+                                Span::Empty,
+                                Plicity::Explicit,
+                                &(Term::Prim(Span::Empty, RefType), VAR0),
+                            ),
+                            FORMAT_TYPE,
+                        ),
                     ),
-                    &FORMAT_TYPE,
                 ),
             ),
         );
-        env.define_prim(FormatStreamPos, &FORMAT_TYPE);
+        env.define_prim(FormatStreamPos, FORMAT_TYPE);
         env.define_prim(
             FormatSucceed,
-            &core::Term::FunType(
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
                 env.name("A"),
-                &UNIVERSE,
-                &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR0, &FORMAT_TYPE),
-            ),
-        );
-        env.define_prim(FormatFail, &FORMAT_TYPE);
-        env.define_prim(
-            FormatUnwrap,
-            // fun (@A : Type) -> Option A   -> Format
-            // fun (@A : Type) -> Option A@0 -> Format
-            &core::Term::FunType(
-                Span::Empty,
-                Plicity::Implicit,
-                env.name("A"),
-                &UNIVERSE,
-                &Term::FunType(
-                    Span::Empty,
-                    Plicity::Explicit,
-                    None,
-                    &Term::FunApp(
-                        Span::Empty,
-                        Plicity::Explicit,
-                        &Term::Prim(Span::Empty, OptionType),
-                        &VAR0,
-                    ),
-                    &FORMAT_TYPE,
+                &(
+                    UNIVERSE,
+                    Term::FunType(Span::Empty, Plicity::Explicit, None, &(VAR0, FORMAT_TYPE)),
                 ),
             ),
         );
-        env.define_prim_fun(FormatRepr, [&FORMAT_TYPE], &UNIVERSE);
+        env.define_prim(FormatFail, FORMAT_TYPE);
+        env.define_prim(
+            FormatUnwrap,
+            // fun (A : Type) -> Option A   -> Format
+            // fun (A : Type) -> Option A@0 -> Format
+            core::Term::FunType(
+                Span::Empty,
+                Plicity::Implicit,
+                env.name("A"),
+                &(
+                    UNIVERSE,
+                    Term::FunType(
+                        Span::Empty,
+                        Plicity::Explicit,
+                        None,
+                        &(
+                            Term::FunApp(
+                                Span::Empty,
+                                Plicity::Explicit,
+                                &(Term::Prim(Span::Empty, OptionType), VAR0),
+                            ),
+                            FORMAT_TYPE,
+                        ),
+                    ),
+                ),
+            ),
+        );
+        env.define_prim_fun(FormatRepr, [FORMAT_TYPE], UNIVERSE);
 
         // fun (@A : Type) -> Void -> A
         env.define_prim(
             Absurd,
-            &core::Term::FunType(
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
                 env.name("A"),
-                &UNIVERSE,
-                &core::Term::FunType(Span::Empty, Plicity::Explicit, None, &VOID_TYPE, &VAR1),
+                &(
+                    UNIVERSE,
+                    core::Term::FunType(Span::Empty, Plicity::Explicit, None, &(VOID_TYPE, VAR1)),
+                ),
             ),
         );
 
-        env.define_prim_fun(BoolEq, [&BOOL_TYPE, &BOOL_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(BoolNeq, [&BOOL_TYPE, &BOOL_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(BoolNot, [&BOOL_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(BoolAnd, [&BOOL_TYPE, &BOOL_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(BoolOr, [&BOOL_TYPE, &BOOL_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(BoolXor, [&BOOL_TYPE, &BOOL_TYPE], &BOOL_TYPE);
+        env.define_prim_fun(BoolEq, [BOOL_TYPE, BOOL_TYPE], BOOL_TYPE);
+        env.define_prim_fun(BoolNeq, [BOOL_TYPE, BOOL_TYPE], BOOL_TYPE);
+        env.define_prim_fun(BoolNot, [BOOL_TYPE], BOOL_TYPE);
+        env.define_prim_fun(BoolAnd, [BOOL_TYPE, BOOL_TYPE], BOOL_TYPE);
+        env.define_prim_fun(BoolOr, [BOOL_TYPE, BOOL_TYPE], BOOL_TYPE);
+        env.define_prim_fun(BoolXor, [BOOL_TYPE, BOOL_TYPE], BOOL_TYPE);
 
-        env.define_prim_fun(U8Eq, [&U8_TYPE, &U8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U8Neq, [&U8_TYPE, &U8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U8Lt, [&U8_TYPE, &U8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U8Gt, [&U8_TYPE, &U8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U8Lte, [&U8_TYPE, &U8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U8Gte, [&U8_TYPE, &U8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U8Add, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Sub, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Mul, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Div, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Not, [&U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Shl, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Shr, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8And, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Or, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
-        env.define_prim_fun(U8Xor, [&U8_TYPE, &U8_TYPE], &U8_TYPE);
+        env.define_prim_fun(U8Eq, [U8_TYPE, U8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U8Neq, [U8_TYPE, U8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U8Lt, [U8_TYPE, U8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U8Gt, [U8_TYPE, U8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U8Lte, [U8_TYPE, U8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U8Gte, [U8_TYPE, U8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U8Add, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Sub, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Mul, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Div, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Not, [U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Shl, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Shr, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8And, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Or, [U8_TYPE, U8_TYPE], U8_TYPE);
+        env.define_prim_fun(U8Xor, [U8_TYPE, U8_TYPE], U8_TYPE);
 
-        env.define_prim_fun(U16Eq, [&U16_TYPE, &U16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U16Neq, [&U16_TYPE, &U16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U16Lt, [&U16_TYPE, &U16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U16Gt, [&U16_TYPE, &U16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U16Lte, [&U16_TYPE, &U16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U16Gte, [&U16_TYPE, &U16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U16Add, [&U16_TYPE, &U16_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Sub, [&U16_TYPE, &U16_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Mul, [&U16_TYPE, &U16_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Div, [&U16_TYPE, &U16_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Not, [&U16_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Shl, [&U16_TYPE, &U8_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Shr, [&U16_TYPE, &U8_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16And, [&U16_TYPE, &U16_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Or, [&U16_TYPE, &U16_TYPE], &U16_TYPE);
-        env.define_prim_fun(U16Xor, [&U16_TYPE, &U16_TYPE], &U16_TYPE);
+        env.define_prim_fun(U16Eq, [U16_TYPE, U16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U16Neq, [U16_TYPE, U16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U16Lt, [U16_TYPE, U16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U16Gt, [U16_TYPE, U16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U16Lte, [U16_TYPE, U16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U16Gte, [U16_TYPE, U16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U16Add, [U16_TYPE, U16_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Sub, [U16_TYPE, U16_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Mul, [U16_TYPE, U16_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Div, [U16_TYPE, U16_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Not, [U16_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Shl, [U16_TYPE, U8_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Shr, [U16_TYPE, U8_TYPE], U16_TYPE);
+        env.define_prim_fun(U16And, [U16_TYPE, U16_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Or, [U16_TYPE, U16_TYPE], U16_TYPE);
+        env.define_prim_fun(U16Xor, [U16_TYPE, U16_TYPE], U16_TYPE);
 
-        env.define_prim_fun(U32Eq, [&U32_TYPE, &U32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U32Neq, [&U32_TYPE, &U32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U32Lt, [&U32_TYPE, &U32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U32Gt, [&U32_TYPE, &U32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U32Lte, [&U32_TYPE, &U32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U32Gte, [&U32_TYPE, &U32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U32Add, [&U32_TYPE, &U32_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Sub, [&U32_TYPE, &U32_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Mul, [&U32_TYPE, &U32_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Div, [&U32_TYPE, &U32_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Not, [&U32_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Shl, [&U32_TYPE, &U8_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Shr, [&U32_TYPE, &U8_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32And, [&U32_TYPE, &U32_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Or, [&U32_TYPE, &U32_TYPE], &U32_TYPE);
-        env.define_prim_fun(U32Xor, [&U32_TYPE, &U32_TYPE], &U32_TYPE);
+        env.define_prim_fun(U32Eq, [U32_TYPE, U32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U32Neq, [U32_TYPE, U32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U32Lt, [U32_TYPE, U32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U32Gt, [U32_TYPE, U32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U32Lte, [U32_TYPE, U32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U32Gte, [U32_TYPE, U32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U32Add, [U32_TYPE, U32_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Sub, [U32_TYPE, U32_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Mul, [U32_TYPE, U32_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Div, [U32_TYPE, U32_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Not, [U32_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Shl, [U32_TYPE, U8_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Shr, [U32_TYPE, U8_TYPE], U32_TYPE);
+        env.define_prim_fun(U32And, [U32_TYPE, U32_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Or, [U32_TYPE, U32_TYPE], U32_TYPE);
+        env.define_prim_fun(U32Xor, [U32_TYPE, U32_TYPE], U32_TYPE);
 
-        env.define_prim_fun(U64Eq, [&U64_TYPE, &U64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U64Neq, [&U64_TYPE, &U64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U64Lt, [&U64_TYPE, &U64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U64Gt, [&U64_TYPE, &U64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U64Lte, [&U64_TYPE, &U64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U64Gte, [&U64_TYPE, &U64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(U64Add, [&U64_TYPE, &U64_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Sub, [&U64_TYPE, &U64_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Mul, [&U64_TYPE, &U64_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Div, [&U64_TYPE, &U64_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Not, [&U64_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Shl, [&U64_TYPE, &U8_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Shr, [&U64_TYPE, &U8_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64And, [&U64_TYPE, &U64_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Or, [&U64_TYPE, &U64_TYPE], &U64_TYPE);
-        env.define_prim_fun(U64Xor, [&U64_TYPE, &U64_TYPE], &U64_TYPE);
+        env.define_prim_fun(U64Eq, [U64_TYPE, U64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U64Neq, [U64_TYPE, U64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U64Lt, [U64_TYPE, U64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U64Gt, [U64_TYPE, U64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U64Lte, [U64_TYPE, U64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U64Gte, [U64_TYPE, U64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(U64Add, [U64_TYPE, U64_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Sub, [U64_TYPE, U64_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Mul, [U64_TYPE, U64_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Div, [U64_TYPE, U64_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Not, [U64_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Shl, [U64_TYPE, U8_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Shr, [U64_TYPE, U8_TYPE], U64_TYPE);
+        env.define_prim_fun(U64And, [U64_TYPE, U64_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Or, [U64_TYPE, U64_TYPE], U64_TYPE);
+        env.define_prim_fun(U64Xor, [U64_TYPE, U64_TYPE], U64_TYPE);
 
-        env.define_prim_fun(S8Eq, [&S8_TYPE, &S8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S8Neq, [&S8_TYPE, &S8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S8Lt, [&S8_TYPE, &S8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S8Gt, [&S8_TYPE, &S8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S8Lte, [&S8_TYPE, &S8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S8Gte, [&S8_TYPE, &S8_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S8Neg, [&S8_TYPE], &S8_TYPE);
-        env.define_prim_fun(S8Add, [&S8_TYPE, &S8_TYPE], &S8_TYPE);
-        env.define_prim_fun(S8Sub, [&S8_TYPE, &S8_TYPE], &S8_TYPE);
-        env.define_prim_fun(S8Mul, [&S8_TYPE, &S8_TYPE], &S8_TYPE);
-        env.define_prim_fun(S8Div, [&S8_TYPE, &S8_TYPE], &S8_TYPE);
-        env.define_prim_fun(S8Abs, [&S8_TYPE], &S8_TYPE);
-        env.define_prim_fun(S8UAbs, [&S8_TYPE], &U8_TYPE);
+        env.define_prim_fun(S8Eq, [S8_TYPE, S8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S8Neq, [S8_TYPE, S8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S8Lt, [S8_TYPE, S8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S8Gt, [S8_TYPE, S8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S8Lte, [S8_TYPE, S8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S8Gte, [S8_TYPE, S8_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S8Neg, [S8_TYPE], S8_TYPE);
+        env.define_prim_fun(S8Add, [S8_TYPE, S8_TYPE], S8_TYPE);
+        env.define_prim_fun(S8Sub, [S8_TYPE, S8_TYPE], S8_TYPE);
+        env.define_prim_fun(S8Mul, [S8_TYPE, S8_TYPE], S8_TYPE);
+        env.define_prim_fun(S8Div, [S8_TYPE, S8_TYPE], S8_TYPE);
+        env.define_prim_fun(S8Abs, [S8_TYPE], S8_TYPE);
+        env.define_prim_fun(S8UAbs, [S8_TYPE], U8_TYPE);
 
-        env.define_prim_fun(S16Eq, [&S16_TYPE, &S16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S16Neq, [&S16_TYPE, &S16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S16Lt, [&S16_TYPE, &S16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S16Gt, [&S16_TYPE, &S16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S16Lte, [&S16_TYPE, &S16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S16Gte, [&S16_TYPE, &S16_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S16Neg, [&S16_TYPE], &S16_TYPE);
-        env.define_prim_fun(S16Add, [&S16_TYPE, &S16_TYPE], &S16_TYPE);
-        env.define_prim_fun(S16Sub, [&S16_TYPE, &S16_TYPE], &S16_TYPE);
-        env.define_prim_fun(S16Mul, [&S16_TYPE, &S16_TYPE], &S16_TYPE);
-        env.define_prim_fun(S16Div, [&S16_TYPE, &S16_TYPE], &S16_TYPE);
-        env.define_prim_fun(S16Abs, [&S16_TYPE], &S16_TYPE);
-        env.define_prim_fun(S16UAbs, [&S16_TYPE], &U16_TYPE);
+        env.define_prim_fun(S16Eq, [S16_TYPE, S16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S16Neq, [S16_TYPE, S16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S16Lt, [S16_TYPE, S16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S16Gt, [S16_TYPE, S16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S16Lte, [S16_TYPE, S16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S16Gte, [S16_TYPE, S16_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S16Neg, [S16_TYPE], S16_TYPE);
+        env.define_prim_fun(S16Add, [S16_TYPE, S16_TYPE], S16_TYPE);
+        env.define_prim_fun(S16Sub, [S16_TYPE, S16_TYPE], S16_TYPE);
+        env.define_prim_fun(S16Mul, [S16_TYPE, S16_TYPE], S16_TYPE);
+        env.define_prim_fun(S16Div, [S16_TYPE, S16_TYPE], S16_TYPE);
+        env.define_prim_fun(S16Abs, [S16_TYPE], S16_TYPE);
+        env.define_prim_fun(S16UAbs, [S16_TYPE], U16_TYPE);
 
-        env.define_prim_fun(S32Eq, [&S32_TYPE, &S32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S32Neq, [&S32_TYPE, &S32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S32Lt, [&S32_TYPE, &S32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S32Gt, [&S32_TYPE, &S32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S32Lte, [&S32_TYPE, &S32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S32Gte, [&S32_TYPE, &S32_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S32Neg, [&S32_TYPE], &S32_TYPE);
-        env.define_prim_fun(S32Add, [&S32_TYPE, &S32_TYPE], &S32_TYPE);
-        env.define_prim_fun(S32Sub, [&S32_TYPE, &S32_TYPE], &S32_TYPE);
-        env.define_prim_fun(S32Mul, [&S32_TYPE, &S32_TYPE], &S32_TYPE);
-        env.define_prim_fun(S32Div, [&S32_TYPE, &S32_TYPE], &S32_TYPE);
-        env.define_prim_fun(S32Abs, [&S32_TYPE], &S32_TYPE);
-        env.define_prim_fun(S32UAbs, [&S32_TYPE], &U32_TYPE);
+        env.define_prim_fun(S32Eq, [S32_TYPE, S32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S32Neq, [S32_TYPE, S32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S32Lt, [S32_TYPE, S32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S32Gt, [S32_TYPE, S32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S32Lte, [S32_TYPE, S32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S32Gte, [S32_TYPE, S32_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S32Neg, [S32_TYPE], S32_TYPE);
+        env.define_prim_fun(S32Add, [S32_TYPE, S32_TYPE], S32_TYPE);
+        env.define_prim_fun(S32Sub, [S32_TYPE, S32_TYPE], S32_TYPE);
+        env.define_prim_fun(S32Mul, [S32_TYPE, S32_TYPE], S32_TYPE);
+        env.define_prim_fun(S32Div, [S32_TYPE, S32_TYPE], S32_TYPE);
+        env.define_prim_fun(S32Abs, [S32_TYPE], S32_TYPE);
+        env.define_prim_fun(S32UAbs, [S32_TYPE], U32_TYPE);
 
-        env.define_prim_fun(S64Eq, [&S64_TYPE, &S64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S64Neq, [&S64_TYPE, &S64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S64Lt, [&S64_TYPE, &S64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S64Gt, [&S64_TYPE, &S64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S64Lte, [&S64_TYPE, &S64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S64Gte, [&S64_TYPE, &S64_TYPE], &BOOL_TYPE);
-        env.define_prim_fun(S64Neg, [&S64_TYPE], &S64_TYPE);
-        env.define_prim_fun(S64Add, [&S64_TYPE, &S64_TYPE], &S64_TYPE);
-        env.define_prim_fun(S64Sub, [&S64_TYPE, &S64_TYPE], &S64_TYPE);
-        env.define_prim_fun(S64Mul, [&S64_TYPE, &S64_TYPE], &S64_TYPE);
-        env.define_prim_fun(S64Div, [&S64_TYPE, &S64_TYPE], &S64_TYPE);
-        env.define_prim_fun(S64Abs, [&S64_TYPE], &S64_TYPE);
-        env.define_prim_fun(S64UAbs, [&S64_TYPE], &U64_TYPE);
+        env.define_prim_fun(S64Eq, [S64_TYPE, S64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S64Neq, [S64_TYPE, S64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S64Lt, [S64_TYPE, S64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S64Gt, [S64_TYPE, S64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S64Lte, [S64_TYPE, S64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S64Gte, [S64_TYPE, S64_TYPE], BOOL_TYPE);
+        env.define_prim_fun(S64Neg, [S64_TYPE], S64_TYPE);
+        env.define_prim_fun(S64Add, [S64_TYPE, S64_TYPE], S64_TYPE);
+        env.define_prim_fun(S64Sub, [S64_TYPE, S64_TYPE], S64_TYPE);
+        env.define_prim_fun(S64Mul, [S64_TYPE, S64_TYPE], S64_TYPE);
+        env.define_prim_fun(S64Div, [S64_TYPE, S64_TYPE], S64_TYPE);
+        env.define_prim_fun(S64Abs, [S64_TYPE], S64_TYPE);
+        env.define_prim_fun(S64UAbs, [S64_TYPE], U64_TYPE);
 
         env.define_prim(
             OptionSome,
-            // fun (@A : Type) -> A   -> Option A
-            // fun (@A : Type) -> A@0 -> Option A@1
-            &core::Term::FunType(
+            // fun (A : Type) -> A   -> Option A
+            // fun (A : Type) -> A@0 -> Option A@1
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
                 env.name("A"),
-                &UNIVERSE,
-                &Term::FunType(
-                    Span::Empty,
-                    Plicity::Explicit,
-                    None,
-                    &VAR0,
-                    &Term::FunApp(
+                &(
+                    UNIVERSE,
+                    Term::FunType(
                         Span::Empty,
                         Plicity::Explicit,
-                        &Term::Prim(Span::Empty, OptionType),
-                        &VAR1,
+                        None,
+                        &(
+                            VAR0,
+                            Term::FunApp(
+                                Span::Empty,
+                                Plicity::Explicit,
+                                &(Term::Prim(Span::Empty, OptionType), VAR1),
+                            ),
+                        ),
                     ),
                 ),
             ),
         );
         env.define_prim(
             OptionNone,
-            // fun (@A : Type) -> Option A
-            // fun (@A : Type) -> Option A@0
-            &core::Term::FunType(
+            // fun (A : Type) -> Option A
+            // fun (A : Type) -> Option A@0
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
                 env.name("A"),
-                &UNIVERSE,
-                &Term::FunApp(
-                    Span::Empty,
-                    Plicity::Explicit,
-                    &Term::Prim(Span::Empty, OptionType),
-                    &VAR0,
+                &(
+                    UNIVERSE,
+                    Term::FunApp(
+                        Span::Empty,
+                        Plicity::Explicit,
+                        &(Term::Prim(Span::Empty, OptionType), VAR0),
+                    ),
                 ),
             ),
         );
         env.define_prim(
             OptionFold,
-            // fun (@A : Type) (@B : Type) -> B   -> (A   -> B  ) -> Option A   -> B
-            // fun (@A : Type) (@B : Type) -> B@0 -> (A@2 -> B@2) -> Option A@3 -> B@3
-            scope.to_scope(core::Term::FunType(
+            // fun (A : Type) (B : Type) -> B   -> (A   -> B  ) -> Option A   -> B
+            // fun (A : Type) (B : Type) -> B@0 -> (A@2 -> B@2) -> Option A@3 -> B@3
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
                 env.name("A"),
-                &UNIVERSE,
-                scope.to_scope(core::Term::FunType(
-                    Span::Empty,
-                    Plicity::Implicit,
-                    env.name("B"),
-                    &UNIVERSE,
-                    scope.to_scope(core::Term::FunType(
+                scope.to_scope((
+                    UNIVERSE,
+                    core::Term::FunType(
                         Span::Empty,
-                        Plicity::Explicit,
-                        None,
-                        &VAR0, // B@0
-                        scope.to_scope(core::Term::FunType(
-                            Span::Empty,
-                            Plicity::Explicit,
-                            None,
-                            // A@2 -> B@2
-                            &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR2, &VAR2),
-                            scope.to_scope(core::Term::FunType(
+                        Plicity::Implicit,
+                        env.name("B"),
+                        &(
+                            UNIVERSE,
+                            core::Term::FunType(
                                 Span::Empty,
                                 Plicity::Explicit,
                                 None,
-                                // Option A@3
-                                &Term::FunApp(
-                                    Span::Empty,
-                                    Plicity::Explicit,
-                                    &Term::Prim(Span::Empty, OptionType),
-                                    &VAR3,
+                                &(
+                                    VAR0, // B@0
+                                    core::Term::FunType(
+                                        Span::Empty,
+                                        Plicity::Explicit,
+                                        None,
+                                        &(
+                                            Term::FunType(
+                                                Span::Empty,
+                                                Plicity::Explicit,
+                                                None,
+                                                &(VAR2, VAR2),
+                                            ), // A@2 -> B@2
+                                            core::Term::FunType(
+                                                Span::Empty,
+                                                Plicity::Explicit,
+                                                None,
+                                                &(
+                                                    Term::FunApp(
+                                                        Span::Empty,
+                                                        Plicity::Explicit,
+                                                        &(
+                                                            Term::Prim(Span::Empty, OptionType),
+                                                            VAR3,
+                                                        ),
+                                                    ), // Option A@3
+                                                    VAR3, // B@3
+                                                ),
+                                            ),
+                                        ),
+                                    ),
                                 ),
-                                &VAR3, // B@3
-                            )),
-                        )),
-                    )),
+                            ),
+                        ),
+                    ),
                 )),
-            )),
+            ),
         );
 
-        // fun (@len : UN) (@A : Type) -> (A   -> Bool) -> ArrayN len   A   -> Option A
-        // fun (@len : UN) (@A : Type) -> (A@0 -> Bool) -> ArrayN len@2 A@1 -> Option
-        // A@2
-        let find_type = |index_type, array_type| {
-            scope.to_scope(core::Term::FunType(
+        // fun (len : UN) (A : Type) -> (A   -> Bool) -> ArrayN len   A   -> Option A
+        // fun (len : UN) (A : Type) -> (A@0 -> Bool) -> ArrayN len@2 A@1 -> Option A@2
+        let find_type = |index_type: Term<'arena>, array_type: Term<'arena>| {
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
                 env.name("len"),
-                index_type,
-                scope.to_scope(core::Term::FunType(
-                    Span::Empty,
-                    Plicity::Implicit,
-                    env.name("A"),
-                    &UNIVERSE,
-                    scope.to_scope(core::Term::FunType(
+                scope.to_scope((
+                    index_type,
+                    core::Term::FunType(
                         Span::Empty,
-                        Plicity::Explicit,
-                        None,
-                        // (A@0 -> Bool)
-                        &Term::FunType(Span::Empty, Plicity::Explicit, None, &VAR0, &BOOL_TYPE),
-                        scope.to_scope(core::Term::FunType(
-                            Span::Empty,
-                            Plicity::Explicit,
-                            None,
-                            // ArrayN len@2 A@1
-                            scope.to_scope(Term::FunApp(
+                        Plicity::Implicit,
+                        env.name("A"),
+                        scope.to_scope((
+                            UNIVERSE,
+                            core::Term::FunType(
                                 Span::Empty,
                                 Plicity::Explicit,
-                                scope.to_scope(Term::FunApp(
-                                    Span::Empty,
-                                    Plicity::Explicit,
-                                    array_type,
-                                    &VAR2,
+                                None,
+                                scope.to_scope((
+                                    Term::FunType(
+                                        Span::Empty,
+                                        Plicity::Explicit,
+                                        None,
+                                        &(VAR0, BOOL_TYPE),
+                                    ), // (A@0 -> Bool)
+                                    core::Term::FunType(
+                                        Span::Empty,
+                                        Plicity::Explicit,
+                                        None,
+                                        // ArrayN len@2 A@1
+                                        scope.to_scope((
+                                            Term::FunApp(
+                                                Span::Empty,
+                                                Plicity::Explicit,
+                                                scope.to_scope((
+                                                    Term::FunApp(
+                                                        Span::Empty,
+                                                        Plicity::Explicit,
+                                                        scope.to_scope((array_type, VAR2)),
+                                                    ),
+                                                    VAR1,
+                                                )),
+                                            ),
+                                            Term::FunApp(
+                                                Span::Empty,
+                                                Plicity::Explicit,
+                                                &(Term::Prim(Span::Empty, OptionType), VAR2),
+                                            ), // Option A@2
+                                        )),
+                                    ),
                                 )),
-                                &VAR1,
-                            )),
-                            // Option A@2
-                            &Term::FunApp(
-                                Span::Empty,
-                                Plicity::Explicit,
-                                &Term::Prim(Span::Empty, OptionType),
-                                &VAR2,
                             ),
                         )),
-                    )),
+                    ),
                 )),
-            ))
+            )
         };
-        let array8_find_type = find_type(&U8_TYPE, &ARRAY8_TYPE);
-        let array16_find_type = find_type(&U16_TYPE, &ARRAY16_TYPE);
-        let array32_find_type = find_type(&U32_TYPE, &ARRAY32_TYPE);
-        let array64_find_type = find_type(&U64_TYPE, &ARRAY64_TYPE);
+        let array8_find_type = find_type(U8_TYPE, ARRAY8_TYPE);
+        let array16_find_type = find_type(U16_TYPE, ARRAY16_TYPE);
+        let array32_find_type = find_type(U32_TYPE, ARRAY32_TYPE);
+        let array64_find_type = find_type(U64_TYPE, ARRAY64_TYPE);
         env.define_prim(Array8Find, array8_find_type);
         env.define_prim(Array16Find, array16_find_type);
         env.define_prim(Array32Find, array32_find_type);
         env.define_prim(Array64Find, array64_find_type);
 
-        // fun (@len : UN) (@A : Type) (index : UN) -> ArrayN len   A   -> A
-        // fun (@len : UN) (@A : Type) (index : UN) -> ArrayN len@2 A@1 -> A@2
-        let array_index_type = |index_type, array_type| {
-            scope.to_scope(core::Term::FunType(
+        // fun (len : UN) -> (A : Type) -> (index : UN) -> ArrayN len   A   -> A
+        // fun (len : UN) -> (A : Type) -> (index : UN) -> ArrayN len@2 A@1 -> A@2
+        let array_index_type = |index_type: Term<'arena>, array_type: Term<'arena>| {
+            core::Term::FunType(
                 Span::Empty,
                 Plicity::Implicit,
                 env.name("len"),
-                index_type,
-                scope.to_scope(core::Term::FunType(
-                    Span::Empty,
-                    Plicity::Implicit,
-                    env.name("A"),
-                    &UNIVERSE,
-                    scope.to_scope(core::Term::FunType(
+                scope.to_scope((
+                    index_type.clone(),
+                    core::Term::FunType(
                         Span::Empty,
-                        Plicity::Explicit,
-                        env.name("index"),
-                        index_type,
-                        scope.to_scope(core::Term::FunType(
-                            Span::Empty,
-                            Plicity::Explicit,
-                            None,
-                            // ArrayN len@2 A@1
-                            scope.to_scope(Term::FunApp(
+                        Plicity::Implicit,
+                        env.name("A"),
+                        scope.to_scope((
+                            UNIVERSE,
+                            core::Term::FunType(
                                 Span::Empty,
                                 Plicity::Explicit,
-                                scope.to_scope(Term::FunApp(
-                                    Span::Empty,
-                                    Plicity::Explicit,
-                                    array_type,
-                                    &VAR2,
+                                env.name("index"),
+                                scope.to_scope((
+                                    index_type,
+                                    core::Term::FunType(
+                                        Span::Empty,
+                                        Plicity::Explicit,
+                                        None,
+                                        // ArrayN len@2 A@1
+                                        scope.to_scope((
+                                            Term::FunApp(
+                                                Span::Empty,
+                                                Plicity::Explicit,
+                                                scope.to_scope((
+                                                    Term::FunApp(
+                                                        Span::Empty,
+                                                        Plicity::Explicit,
+                                                        scope.to_scope((array_type, VAR2)),
+                                                    ),
+                                                    VAR1,
+                                                )),
+                                            ),
+                                            VAR2, // A@2
+                                        )),
+                                    ),
                                 )),
-                                &VAR1,
-                            )),
-                            &VAR2, // A@2
+                            ),
                         )),
-                    )),
+                    ),
                 )),
-            ))
+            )
         };
-        let array8_index_type = array_index_type(&U8_TYPE, &ARRAY8_TYPE);
-        let array16_index_type = array_index_type(&U16_TYPE, &ARRAY16_TYPE);
-        let array32_index_type = array_index_type(&U32_TYPE, &ARRAY32_TYPE);
-        let array64_index_type = array_index_type(&U64_TYPE, &ARRAY64_TYPE);
+        let array8_index_type = array_index_type(U8_TYPE, ARRAY8_TYPE);
+        let array16_index_type = array_index_type(U16_TYPE, ARRAY16_TYPE);
+        let array32_index_type = array_index_type(U32_TYPE, ARRAY32_TYPE);
+        let array64_index_type = array_index_type(U64_TYPE, ARRAY64_TYPE);
         env.define_prim(Array8Index, array8_index_type);
         env.define_prim(Array16Index, array16_index_type);
         env.define_prim(Array32Index, array32_index_type);
         env.define_prim(Array64Index, array64_index_type);
 
-        env.define_prim_fun(PosAddU8, [&POS_TYPE, &U8_TYPE], &POS_TYPE);
-        env.define_prim_fun(PosAddU16, [&POS_TYPE, &U16_TYPE], &POS_TYPE);
-        env.define_prim_fun(PosAddU32, [&POS_TYPE, &U32_TYPE], &POS_TYPE);
-        env.define_prim_fun(PosAddU64, [&POS_TYPE, &U64_TYPE], &POS_TYPE);
+        env.define_prim_fun(PosAddU8, [POS_TYPE, U8_TYPE], POS_TYPE);
+        env.define_prim_fun(PosAddU16, [POS_TYPE, U16_TYPE], POS_TYPE);
+        env.define_prim_fun(PosAddU32, [POS_TYPE, U32_TYPE], POS_TYPE);
+        env.define_prim_fun(PosAddU64, [POS_TYPE, U64_TYPE], POS_TYPE);
 
         env.build()
     }
@@ -535,31 +583,33 @@ impl<'interner, 'arena> EnvBuilder<'interner, 'arena> {
         Some(self.interner.borrow_mut().get_or_intern_static(name))
     }
 
-    fn define_prim(&mut self, prim: Prim, r#type: &core::Term<'arena>) {
+    fn define_prim(&mut self, prim: Prim, r#type: core::Term<'arena>) {
         let name = self.interner.borrow_mut().get_or_intern_static(prim.name());
         let r#type = ElimEnv::new(&self.item_exprs, &self.meta_exprs)
             .eval_env(&mut self.local_exprs)
-            .eval(r#type);
+            .eval(&r#type);
         self.entries.insert(name, (prim, r#type));
     }
 
     fn define_prim_fun<const ARITY: usize>(
         &mut self,
         prim: Prim,
-        param_types: [&'arena core::Term<'arena>; ARITY],
-        body_type: &'arena core::Term<'arena>,
+        param_types: [core::Term<'arena>; ARITY],
+        body_type: core::Term<'arena>,
     ) {
         self.define_prim(
             prim,
-            (param_types.iter().rev()).fold(body_type, |r#type, param_type| {
-                self.scope.to_scope(core::Term::FunType(
-                    Span::Empty,
-                    Plicity::Explicit,
-                    None,
-                    param_type,
-                    r#type,
-                ))
-            }),
+            (IntoIterator::into_iter(param_types).rev()).fold(
+                body_type,
+                |r#type: core::Term, param_type: core::Term| {
+                    core::Term::FunType(
+                        Span::Empty,
+                        Plicity::Explicit,
+                        None,
+                        self.scope.to_scope((param_type, r#type)),
+                    )
+                },
+            ),
         );
     }
 

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -249,7 +249,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         let term = context.check(&term);
         let r#type = context.check(&r#type);
 
-        self.emit_term(&surface::Term::Ann((), &term, &r#type));
+        self.emit_term(&surface::Term::Ann((), &(term, r#type)));
 
         Status::Ok
     }
@@ -277,7 +277,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         let term = context.check(&term);
         let r#type = context.check(&r#type);
 
-        self.emit_term(&surface::Term::Ann((), &term, &r#type));
+        self.emit_term(&surface::Term::Ann((), &(term, r#type)));
 
         Status::Ok
     }

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -181,6 +181,7 @@ impl<Range: Clone> Pattern<Range> {
 
 /// Surface terms.
 #[derive(Debug, Clone)]
+#[allow(clippy::type_complexity)]
 pub enum Term<'arena, Range> {
     /// Parenthesized term
     Paren(Range, &'arena Term<'arena, Range>),
@@ -191,25 +192,25 @@ pub enum Term<'arena, Range> {
     /// Placeholder expressions.
     Placeholder(Range),
     /// Annotated expressions.
-    Ann(
-        Range,
-        &'arena Term<'arena, Range>,
-        &'arena Term<'arena, Range>,
-    ),
+    Ann(Range, &'arena (Term<'arena, Range>, Term<'arena, Range>)),
     /// Let expressions.
     Let(
         Range,
-        Pattern<Range>,
-        Option<&'arena Term<'arena, Range>>,
-        &'arena Term<'arena, Range>,
-        &'arena Term<'arena, Range>,
+        &'arena (
+            Pattern<Range>,
+            Option<Term<'arena, Range>>,
+            Term<'arena, Range>,
+            Term<'arena, Range>,
+        ),
     ),
     /// If expressions
     If(
         Range,
-        &'arena Term<'arena, Range>,
-        &'arena Term<'arena, Range>,
-        &'arena Term<'arena, Range>,
+        &'arena (
+            Term<'arena, Range>,
+            Term<'arena, Range>,
+            Term<'arena, Range>,
+        ),
     ),
     /// Match expressions
     Match(
@@ -223,8 +224,7 @@ pub enum Term<'arena, Range> {
     Arrow(
         Range,
         Plicity,
-        &'arena Term<'arena, Range>,
-        &'arena Term<'arena, Range>,
+        &'arena (Term<'arena, Range>, Term<'arena, Range>),
     ),
     /// Dependent function types.
     FunType(
@@ -277,15 +277,13 @@ pub enum Term<'arena, Range> {
     FormatCond(
         Range,
         (Range, StringId),
-        &'arena Term<'arena, Range>,
-        &'arena Term<'arena, Range>,
+        &'arena (Term<'arena, Range>, Term<'arena, Range>),
     ),
     /// Binary operator expressions.
     BinOp(
         Range,
-        &'arena Term<'arena, Range>,
         BinOp<Range>,
-        &'arena Term<'arena, Range>,
+        &'arena (Term<'arena, Range>, Term<'arena, Range>),
     ),
     /// Reported error sentinel.
     ReportedError(Range),
@@ -295,32 +293,32 @@ impl<'arena, Range: Clone> Term<'arena, Range> {
     /// Get the source range of the term.
     pub fn range(&self) -> Range {
         match self {
-            Term::Paren(range, _)
-            | Term::Name(range, _)
-            | Term::Hole(range, _)
+            Term::Paren(range, ..)
+            | Term::Name(range, ..)
+            | Term::Hole(range, ..)
             | Term::Placeholder(range)
-            | Term::Ann(range, _, _)
-            | Term::Let(range, _, _, _, _)
-            | Term::If(range, _, _, _)
-            | Term::Match(range, _, _)
+            | Term::Ann(range, ..)
+            | Term::Let(range, ..)
+            | Term::If(range, ..)
+            | Term::Match(range, ..)
             | Term::Universe(range)
             | Term::Arrow(range, ..)
-            | Term::FunType(range, _, _)
-            | Term::FunLiteral(range, _, _)
-            | Term::App(range, _, _)
-            | Term::RecordType(range, _)
-            | Term::RecordLiteral(range, _)
-            | Term::Tuple(range, _)
-            | Term::Proj(range, _, _)
-            | Term::ArrayLiteral(range, _)
-            | Term::StringLiteral(range, _)
-            | Term::NumberLiteral(range, _)
-            | Term::BooleanLiteral(range, _)
-            | Term::FormatRecord(range, _)
-            | Term::FormatCond(range, _, _, _)
-            | Term::FormatOverlap(range, _)
-            | Term::BinOp(range, _, _, _)
-            | Term::ReportedError(range) => range.clone(),
+            | Term::FunType(range, ..)
+            | Term::FunLiteral(range, ..)
+            | Term::App(range, ..)
+            | Term::RecordType(range, ..)
+            | Term::RecordLiteral(range, ..)
+            | Term::Tuple(range, ..)
+            | Term::Proj(range, ..)
+            | Term::ArrayLiteral(range, ..)
+            | Term::StringLiteral(range, ..)
+            | Term::NumberLiteral(range, ..)
+            | Term::BooleanLiteral(range, ..)
+            | Term::FormatRecord(range, ..)
+            | Term::FormatCond(range, ..)
+            | Term::FormatOverlap(range, ..)
+            | Term::BinOp(range, ..)
+            | Term::ReportedError(range, ..) => range.clone(),
         }
     }
 }
@@ -530,8 +528,8 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn term_size() {
         assert_eq!(std::mem::size_of::<Term<()>>(), 32);
-        assert_eq!(std::mem::size_of::<Term<ByteRange>>(), 56);
-        assert_eq!(std::mem::size_of::<Term<FileRange>>(), 64);
+        assert_eq!(std::mem::size_of::<Term<ByteRange>>(), 40);
+        assert_eq!(std::mem::size_of::<Term<FileRange>>(), 40);
     }
 
     #[test]

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -378,8 +378,9 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 core::Const::Pos(number) => self.check_number_literal(number),
                 core::Const::Ref(number) => self.check_number_literal(number),
             },
-            core::Term::ConstMatch(_span, head_expr, branches, default_branch) => {
-                if let Some((then_expr, else_expr)) = match_if_then_else(branches, *default_branch)
+            core::Term::ConstMatch(_span, (head_expr, default_branch), branches) => {
+                if let Some((then_expr, else_expr)) =
+                    match_if_then_else(branches, default_branch.as_ref())
                 {
                     let cond_expr = self.check_prec(Prec::Fun, head_expr);
                     let then_expr = self.check_prec(Prec::Let, then_expr);
@@ -764,8 +765,10 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                     self.synth_number_literal(prec, number, core::Prim::RefType)
                 }
             },
-            core::Term::ConstMatch(_span, head_expr, branches, default_expr) => {
-                if let Some((then_expr, else_expr)) = match_if_then_else(branches, *default_expr) {
+            core::Term::ConstMatch(_span, (head_expr, default_expr), branches) => {
+                if let Some((then_expr, else_expr)) =
+                    match_if_then_else(branches, default_expr.as_ref())
+                {
                     let cond_expr = self.check_prec(Prec::Fun, head_expr);
                     let then_expr = self.synth_prec(Prec::Let, then_expr);
                     let else_expr = self.synth_prec(Prec::Let, else_expr);

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1013,9 +1013,9 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
         match (surface_term, expected_type.as_ref()) {
             (Term::Paren(_, term), _) => self.check(term, &expected_type),
-            (Term::Let(_, def_pattern, def_type, def_expr, body_expr), _) => {
+            (Term::Let(_, (def_pattern, def_type, def_expr, body_expr)), _) => {
                 let (def_pattern, def_type, def_type_value) =
-                    self.synth_ann_pattern(def_pattern, *def_type);
+                    self.synth_ann_pattern(def_pattern, def_type.as_ref());
                 let def_expr = self.check(def_expr, &def_type_value);
                 let def_expr_value = self.eval_env().eval(&def_expr);
 
@@ -1031,7 +1031,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                     self.scope.to_scope(body_expr),
                 )
             }
-            (Term::If(_, cond_expr, then_expr, else_expr), _) => {
+            (Term::If(_, (cond_expr, then_expr, else_expr)), _) => {
                 let cond_expr = self.check(cond_expr, &self.bool_type.clone());
                 let then_expr = self.check(then_expr, &expected_type);
                 let else_expr = self.check(else_expr, &expected_type);
@@ -1407,7 +1407,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
                 (expr, r#type)
             }
-            Term::Ann(_, expr, r#type) => {
+            Term::Ann(_, (expr, r#type)) => {
                 let r#type = self.check(r#type, &self.universe.clone());
                 let type_value = self.eval_env().eval(&r#type);
                 let expr = self.check(expr, &type_value);
@@ -1420,9 +1420,9 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
                 (ann_expr, type_value)
             }
-            Term::Let(_, def_pattern, def_type, def_expr, body_expr) => {
+            Term::Let(_, (def_pattern, def_type, def_expr, body_expr)) => {
                 let (def_pattern, def_type, def_type_value) =
-                    self.synth_ann_pattern(def_pattern, *def_type);
+                    self.synth_ann_pattern(def_pattern, def_type.as_ref());
                 let def_expr = self.check(def_expr, &def_type_value);
                 let def_expr_value = self.eval_env().eval(&def_expr);
 
@@ -1440,7 +1440,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
                 (let_expr, body_type)
             }
-            Term::If(_, cond_expr, then_expr, else_expr) => {
+            Term::If(_, (cond_expr, then_expr, else_expr)) => {
                 let cond_expr = self.check(cond_expr, &self.bool_type.clone());
                 let (then_expr, r#type) = self.synth(then_expr);
                 let else_expr = self.check(else_expr, &r#type);
@@ -1470,7 +1470,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 core::Term::Universe(file_range.into()),
                 self.universe.clone(),
             ),
-            Term::Arrow(_, plicity, param_type, body_type) => {
+            Term::Arrow(_, plicity, (param_type, body_type)) => {
                 let universe = self.universe.clone();
                 let param_type = self.check(param_type, &universe);
                 let param_type_value = self.eval_env().eval(&param_type);
@@ -1740,7 +1740,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 let format_record = core::Term::FormatRecord(file_range.into(), labels, formats);
                 (format_record, self.format_type.clone())
             }
-            Term::FormatCond(_, (_, name), format, pred) => {
+            Term::FormatCond(_, (_, name), (format, pred)) => {
                 let format_type = self.format_type.clone();
                 let format = self.check(format, &format_type);
                 let format_value = self.eval_env().eval(&format);
@@ -1766,7 +1766,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
 
                 (overlap_format, self.format_type.clone())
             }
-            Term::BinOp(range, lhs, op, rhs) => self.synth_bin_op(*range, lhs, *op, rhs),
+            Term::BinOp(range, op, (lhs, rhs)) => self.synth_bin_op(*range, lhs, *op, rhs),
             Term::ReportedError(range) => self.synth_reported_error(*range),
         }
     }

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -177,11 +177,11 @@ fn term_deps(
                 deps.push(*name);
             }
         }
-        Term::Ann(_, expr, r#type) => {
+        Term::Ann(_, (expr, r#type)) => {
             term_deps(expr, item_names, local_names, deps);
             term_deps(r#type, item_names, local_names, deps);
         }
-        Term::Let(_, pattern, r#type, def_expr, body_expr) => {
+        Term::Let(_, (pattern, r#type, def_expr, body_expr)) => {
             push_pattern(pattern, local_names);
             if let Some(r#type) = r#type {
                 term_deps(r#type, item_names, local_names, deps);
@@ -190,7 +190,7 @@ fn term_deps(
             term_deps(body_expr, item_names, local_names, deps);
             pop_pattern(pattern, local_names);
         }
-        Term::If(_, cond_expr, then_expr, else_expr) => {
+        Term::If(_, (cond_expr, then_expr, else_expr)) => {
             term_deps(cond_expr, item_names, local_names, deps);
             term_deps(then_expr, item_names, local_names, deps);
             term_deps(else_expr, item_names, local_names, deps);
@@ -204,7 +204,7 @@ fn term_deps(
             }
             local_names.truncate(initial_locals_names_len);
         }
-        Term::Arrow(.., param_type, body_type) => {
+        Term::Arrow(.., (param_type, body_type)) => {
             term_deps(param_type, item_names, local_names, deps);
             term_deps(body_type, item_names, local_names, deps);
         }
@@ -259,13 +259,13 @@ fn term_deps(
         Term::FormatOverlap(_, format_fields) => {
             field_deps(format_fields, item_names, local_names, deps);
         }
-        Term::FormatCond(_, (_, name), format, cond) => {
+        Term::FormatCond(_, (_, name), (format, cond)) => {
             local_names.push(*name);
             term_deps(format, item_names, local_names, deps);
             term_deps(cond, item_names, local_names, deps);
             local_names.pop();
         }
-        Term::BinOp(_, lhs, _, rhs) => {
+        Term::BinOp(_, _, (lhs, rhs)) => {
             term_deps(lhs, item_names, local_names, deps);
             term_deps(rhs, item_names, local_names, deps);
         }

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -561,8 +561,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                         Elim::FunApp(plicity, arg_expr) => Term::FunApp(
                             span,
                             *plicity,
-                            self.scope.to_scope(head_expr),
-                            self.scope.to_scope(self.rename(meta_var, arg_expr)?),
+                            (self.scope).to_scope((head_expr, self.rename(meta_var, arg_expr)?)),
                         ),
                         Elim::RecordProj(label) => {
                             Term::RecordProj(span, self.scope.to_scope(head_expr), *label)
@@ -594,7 +593,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                                 self.scope.to_scope(head_expr),
                                 pattern_branches.into(),
                                 default_branch
-                                    .map(|(name, expr)| (name, self.scope.to_scope(expr) as &_)),
+                                    .map(|(name, expr)| self.scope.to_scope((name, (expr))) as &_),
                             )
                         }
                     })
@@ -611,8 +610,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                     span,
                     *plicity,
                     *param_name,
-                    self.scope.to_scope(param_type),
-                    self.scope.to_scope(body_type),
+                    self.scope.to_scope((param_type, body_type)),
                 ))
             }
             Value::FunLit(plicity, param_name, body_expr) => {
@@ -660,8 +658,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
                 Ok(Term::FormatCond(
                     span,
                     *label,
-                    self.scope.to_scope(format),
-                    self.scope.to_scope(cond),
+                    self.scope.to_scope((format, cond)),
                 ))
             }
             Value::FormatOverlap(labels, formats) => {

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -590,10 +590,8 @@ impl<'arena, 'env> Context<'arena, 'env> {
 
                             Term::ConstMatch(
                                 span,
-                                self.scope.to_scope(head_expr),
+                                self.scope.to_scope((head_expr, default_branch)),
                                 pattern_branches.into(),
-                                default_branch
-                                    .map(|(name, expr)| self.scope.to_scope((name, (expr))) as &_),
                             )
                         }
                     })

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -103,27 +103,17 @@ Pattern: Pattern<ByteRange> = {
 pub Term: Term<'arena, ByteRange> = {
     LetTerm,
     <start: @L> <expr: LetTerm> ":" <r#type: LetTerm> <end: @R> => {
-        Term::Ann(
-            ByteRange::new(start, end),
-            scope.to_scope(expr),
-            scope.to_scope(r#type),
-        )
+        Term::Ann(ByteRange::new(start, end), scope.to_scope((expr, r#type)))
     },
 };
 
 LetTerm: Term<'arena, ByteRange> = {
     FunTerm,
     <start: @L> "let" <def_pattern: Pattern> <def_type: (":" <LetTerm>)?> "=" <def_expr: Term> ";" <body_expr: LetTerm> <end: @R> => {
-        Term::Let(
-            ByteRange::new(start, end),
-            def_pattern,
-            def_type.map(|def_type| scope.to_scope(def_type) as &_),
-            scope.to_scope(def_expr),
-            scope.to_scope(body_expr),
-        )
+        Term::Let(ByteRange::new(start, end), scope.to_scope((def_pattern, def_type, def_expr, body_expr)))
     },
     <start: @L> "if" <cond_expr: FunTerm> "then" <then_expr: LetTerm> "else" <else_expr: LetTerm> <end: @R> => {
-        Term::If(ByteRange::new(start, end), scope.to_scope(cond_expr), scope.to_scope(then_expr), scope.to_scope(else_expr))
+        Term::If(ByteRange::new(start, end), scope.to_scope((cond_expr, then_expr, else_expr)))
     },
 };
 
@@ -133,8 +123,7 @@ FunTerm: Term<'arena, ByteRange> = {
         Term::Arrow(
             ByteRange::new(start, end),
             plicity,
-            scope.to_scope(param_type),
-            scope.to_scope(body_type),
+            scope.to_scope((param_type, body_type)),
         )
     },
     <start: @L> "fun" <params: Param+> "->"  <output_type: FunTerm> <end: @R> => {
@@ -227,7 +216,7 @@ AtomicTerm: Term<'arena, ByteRange> = {
         Term::FormatRecord(ByteRange::new(start, end), fields)
     },
     <start: @L> "{" <name: RangedName> "<-" <format:Term> "|" <cond:Term> "}" <end: @R> => {
-        Term::FormatCond(ByteRange::new(start, end), name, scope.to_scope(format), scope.to_scope(cond))
+        Term::FormatCond(ByteRange::new(start, end), name, scope.to_scope((format, cond)))
     },
     <start: @L> "overlap" "{" <fields: Seq1<FormatField, ",">> "}" <end: @R> => {
         Term::FormatOverlap(ByteRange::new(start, end), fields)
@@ -262,9 +251,8 @@ BinExpr<Lhs, Op, Rhs>: Term<'arena, ByteRange> = {
     <start: @L> <lhs: Lhs> <op: Op> <rhs: Rhs> <end: @R> => {
         Term::BinOp(
             ByteRange::new(start, end),
-            scope.to_scope(lhs),
             op,
-            scope.to_scope(rhs),
+            scope.to_scope((lhs, rhs)),
         )
     },
 };


### PR DESCRIPTION
By replacing tuples of references with references to tuples (eg `(&Term, &Term)` becomes `&(Term, Term)` we can further reduce the size of AST types. I think this should also reduce allocation overhead by batching smaller allocations together into larger ones.

# Size changes:
- `surface::Term<ByteRange>`: 48 bytes to 40 bytes
- `surface::Term<FileRange>`: 56 bytes to 40 bytes
- `core::Term`: 56 bytes to 48 bytes