### PR TITLE
Introduce a smart constructor around `String` for input sources

### DIFF
--- a/fathom/src/main.rs
+++ b/fathom/src/main.rs
@@ -123,6 +123,14 @@ fn load_file_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> fathom::
     })
 }
 
+fn load_source_or_exit(
+    driver: &mut fathom::Driver,
+    name: String,
+    source: String,
+) -> fathom::files::FileId {
+    unwrap_or_exit(driver.load_source(name, source.as_bytes()))
+}
+
 fn read_bytes_or_exit(driver: &mut fathom::Driver, file: PathOrStdin) -> Vec<u8> {
     unwrap_or_exit(match file {
         PathOrStdin::StdIn => driver.read_bytes("<stdin>".to_owned(), std::io::stdin()),
@@ -192,7 +200,7 @@ fn main() -> ! {
             driver.set_emit_width(get_pretty_width());
 
             let module_file_id = module_file.map(|input| load_file_or_exit(&mut driver, input));
-            let format_file_id = driver.load_source_string("<FORMAT>".to_owned(), format);
+            let format_file_id = load_source_or_exit(&mut driver, "<FORMAT>".to_owned(), format);
 
             let data = read_bytes_or_exit(&mut driver, binary_file);
             let status = driver.read_and_emit_format(module_file_id, format_file_id, &data);

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -326,6 +326,58 @@ impl From<ByteRange> for Range<usize> {
     }
 }
 
+/// A smart constructor around `String`, which guarantees its length is <=
+/// `u32::MAX`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgramSource(String);
+
+pub const MAX_SOURCE_LEN: usize = u32::MAX as usize;
+
+impl fmt::Display for ProgramSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for ProgramSource {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ProgramSource {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<ProgramSource> for String {
+    fn from(source: ProgramSource) -> Self {
+        source.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceTooBig {
+    pub actual_len: usize,
+}
+
+impl TryFrom<String> for ProgramSource {
+    type Error = SourceTooBig;
+
+    fn try_from(string: String) -> Result<Self, Self::Error> {
+        if string.len() <= MAX_SOURCE_LEN {
+            Ok(Self(string))
+        } else {
+            Err(SourceTooBig {
+                actual_len: string.len(),
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -9,7 +9,7 @@ use scoped_arena::Scope;
 
 use crate::core::Plicity;
 use crate::files::FileId;
-use crate::source::{BytePos, ByteRange, FileRange, StringId, StringInterner};
+use crate::source::{BytePos, ByteRange, FileRange, ProgramSource, StringId, StringInterner};
 
 lalrpop_mod!(
     #[allow(clippy::all)]
@@ -34,7 +34,7 @@ impl<'arena> Module<'arena, ByteRange> {
     pub fn parse<'source>(
         interner: &RefCell<StringInterner>,
         scope: &'arena Scope<'arena>,
-        source: &'source str,
+        source: &ProgramSource,
     ) -> (Module<'arena, ByteRange>, Vec<ParseMessage>) {
         let mut messages = Vec::new();
 
@@ -328,7 +328,7 @@ impl<'arena> Term<'arena, FileRange> {
     pub fn parse<'source>(
         interner: &RefCell<StringInterner>,
         scope: &'arena Scope<'arena>,
-        source: &'source str,
+        source: &ProgramSource,
     ) -> (Term<'arena, ByteRange>, Vec<ParseMessage>) {
         let mut messages = Vec::new();
 

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -31,7 +31,7 @@ pub struct Module<'arena, Range> {
 impl<'arena> Module<'arena, ByteRange> {
     /// Parse a term from the `source` string, interning strings to the
     /// supplied `interner` and allocating nodes to the `arena`.
-    pub fn parse<'source>(
+    pub fn parse(
         interner: &RefCell<StringInterner>,
         scope: &'arena Scope<'arena>,
         source: &ProgramSource,
@@ -325,7 +325,7 @@ impl<'arena, Range: Clone> Term<'arena, Range> {
 impl<'arena> Term<'arena, FileRange> {
     /// Parse a term from the `source` string, interning strings to the
     /// supplied `interner` and allocating nodes to the `arena`.
-    pub fn parse<'source>(
+    pub fn parse(
         interner: &RefCell<StringInterner>,
         scope: &'arena Scope<'arena>,
         source: &ProgramSource,

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -2,7 +2,7 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use logos::{Filter, Logos};
 
 use crate::files::FileId;
-use crate::source::{BytePos, ByteRange};
+use crate::source::{BytePos, ByteRange, ProgramSource};
 
 pub const KEYWORDS: &[&str] = &[
     "def", "else", "false", "fun", "if", "let", "match", "overlap", "then", "true", "Type", "where",
@@ -206,12 +206,9 @@ impl Error {
     }
 }
 
-pub fn tokens(source: &str) -> impl Iterator<Item = Result<Spanned<Token<'_>, BytePos>, Error>> {
-    assert!(
-        source.len() <= u32::MAX as usize,
-        "`source` must be less than 4GiB in length"
-    );
-
+pub fn tokens(
+    source: &ProgramSource,
+) -> impl Iterator<Item = Result<Spanned<Token<'_>, BytePos>, Error>> {
     Token::lexer(source).spanned().map(move |(token, range)| {
         let start = range.start as BytePos;
         let end = range.end as BytePos;


### PR DESCRIPTION
Adds `ProgramSource`, a wrapper around `String` which guarantees the length is `<= u32::MAX`. Allows us to remove the `assert` from `tokens`. 