### PR TITLE
Update `scoped-arena` from `0.3.0` to `0.4.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-arena"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5677c9035371ff3e7bd919efb70e9b3b152f1cadb7ea54215cd8575a924d4abd"
+checksum = "645d0fd2f2d53abbe078b38ece982935064936e916bb2d696cf059e9d50f1d66"
 
 [[package]]
 name = "scopeguard"

--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -28,7 +28,7 @@ levenshtein = "1.0.5"
 logos = "0.12"
 pretty = "0.11.2"
 rpds = "0.12.0"
-scoped-arena = "0.3"
+scoped-arena = "0.4.1"
 string-interner = "0.14.0"
 termsize = "0.1.6"
 

--- a/fathom/src/alloc.rs
+++ b/fathom/src/alloc.rs
@@ -34,11 +34,9 @@ impl<'a, Elem> SliceVec<'a, Elem> {
         //       drop glue of `Elem` with `scoped_arena::Scope`.
         assert!(!std::mem::needs_drop::<Elem>());
 
-        let elems = std::iter::repeat_with(MaybeUninit::uninit).take(max_len);
-
         SliceVec {
             next_index: 0,
-            elems: scope.to_scope_from_iter(elems),
+            elems: scope.to_scope_many_with(max_len, MaybeUninit::uninit),
         }
     }
 


### PR DESCRIPTION
Update `scoped-arena` from `0.3.0` to `0.4.1`. This allows us to use the new `to_scope_many_with` method when creating a `SliceVec`