### PR TITLE
Use `SymbolU32` instead of `SymbolU16`

### DIFF
--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut, Range};
 use crate::files::FileId;
 
 // Interned strings.
-pub type StringId = string_interner::symbol::SymbolU16;
+pub type StringId = string_interner::symbol::SymbolU32;
 
 /// String interner.
 pub struct StringInterner {

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -527,15 +527,15 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn term_size() {
         assert_eq!(std::mem::size_of::<Term<()>>(), 32);
-        assert_eq!(std::mem::size_of::<Term<ByteRange>>(), 48);
-        assert_eq!(std::mem::size_of::<Term<FileRange>>(), 56);
+        assert_eq!(std::mem::size_of::<Term<ByteRange>>(), 56);
+        assert_eq!(std::mem::size_of::<Term<FileRange>>(), 64);
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn pattern_size() {
-        assert_eq!(std::mem::size_of::<Pattern<()>>(), 4);
-        assert_eq!(std::mem::size_of::<Pattern<ByteRange>>(), 12);
-        assert_eq!(std::mem::size_of::<Pattern<FileRange>>(), 16);
+        assert_eq!(std::mem::size_of::<Pattern<()>>(), 8);
+        assert_eq!(std::mem::size_of::<Pattern<ByteRange>>(), 16);
+        assert_eq!(std::mem::size_of::<Pattern<FileRange>>(), 20);
     }
 }


### PR DESCRIPTION
`get_or_intern` panics when trying to intern more than 2^16 strings. 2^32 strings should be enough for anyone (said only slightly ironically)