### PR TITLE
Replace all spellings of `-ise` with `-ize`

### DIFF
--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -1,5 +1,5 @@
-//! The semantics of the core language, implemented using [normalisation by
-//! evaluation](https://en.wikipedia.org/wiki/Normalisation_by_evaluation).
+//! The semantics of the core language, implemented using [normalization by
+//! evaluation](https://en.wikipedia.org/wiki/Normalization_by_evaluation).
 
 use std::panic::panic_any;
 use std::sync::Arc;
@@ -268,10 +268,10 @@ impl<'arena, 'env> EvalEnv<'arena, 'env> {
         value.unwrap_or_else(|| panic_any(Error::UnboundLocalVar))
     }
 
-    /// Fully normalise a term by first [evaluating][EvalEnv::eval] it into
+    /// Fully normalize a term by first [evaluating][EvalEnv::eval] it into
     /// a [value][Value], then [quoting it back][QuoteEnv::quote] into a
     /// [term][Term].
-    pub fn normalise<'out_arena>(
+    pub fn normalize<'out_arena>(
         &mut self,
         scope: &'out_arena Scope<'out_arena>,
         term: &Term<'arena>,

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -254,7 +254,7 @@ impl<'surface, 'core> Driver<'surface, 'core> {
         Status::Ok
     }
 
-    pub fn normalise_and_emit_term(&mut self, file_id: FileId) -> Status {
+    pub fn normalize_and_emit_term(&mut self, file_id: FileId) -> Status {
         let mut context =
             elaboration::Context::new(file_id, &self.interner, &self.core_scope, ItemEnv::new());
 
@@ -269,8 +269,8 @@ impl<'surface, 'core> Driver<'surface, 'core> {
             return Status::Error;
         }
 
-        let term = context.eval_env().normalise(&self.core_scope, &term);
-        let r#type = context.eval_env().normalise(&self.core_scope, &r#type);
+        let term = context.eval_env().normalize(&self.core_scope, &term);
+        let r#type = context.eval_env().normalize(&self.core_scope, &r#type);
 
         self.surface_scope.reset(); // Reuse the surface scope for distillation
         let mut context = context.distillation_context(&self.surface_scope);

--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -87,7 +87,7 @@ pub fn indices() -> impl Iterator<Item = Index> {
 /// Levels are used in [values][crate::core::semantics::Value] because they
 /// are not tied to a specific binding depth, unlike [indices][Index].
 /// Because of this, we're able to sidestep the need for expensive variable
-/// shifting during [normalisation][crate::core::semantics::EvalEnv::normalise].
+/// shifting during [normalization][crate::core::semantics::EvalEnv::normalize].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Level(RawVar);
 

--- a/fathom/src/main.rs
+++ b/fathom/src/main.rs
@@ -33,9 +33,9 @@ enum Cli {
         #[clap(long = "pretty-core", conflicts_with("TERM_FILE"))]
         pretty_core: bool,
     },
-    /// Normalise a Fathom term, printing its normal form and type
+    /// Normalize a Fathom term, printing its normal form and type
     Norm {
-        /// Path to a term to normalise
+        /// Path to a term to normalize
         #[clap(long = "term", name = "TERM_FILE", display_order = 0)]
         term_file: PathOrStdin,
         /// Continue even if errors were encountered
@@ -184,7 +184,7 @@ fn main() -> ! {
             driver.set_emit_width(get_pretty_width());
 
             let file_id = load_file_or_exit(&mut driver, term_file);
-            let status = driver.normalise_and_emit_term(file_id);
+            let status = driver.normalize_and_emit_term(file_id);
 
             std::process::exit(status.exit_code());
         }

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -810,7 +810,7 @@ fn match_if_then_else<'arena>(
 ) -> Option<(&'arena core::Term<'arena>, &'arena core::Term<'arena>)> {
     match (branches, default_branch) {
         ([(Const::Bool(false), else_expr), (Const::Bool(true), then_expr)], None)
-        // TODO: Normalise boolean branches when elaborating patterns
+        // TODO: Normalize boolean branches when elaborating patterns
         | ([(Const::Bool(true), then_expr)], Some((_, else_expr)))
         | ([(Const::Bool(false), else_expr)], Some((_, then_expr))) => Some((then_expr, else_expr)),
         _ => None,

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1804,7 +1804,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                             self.scope.to_scope(body_expr),
                         )
                     }
-                    // If an implicit function is expected, try to generalise the
+                    // If an implicit function is expected, try to generalize the
                     // function literal by wrapping it in an implicit function
                     Value::FunType(Plicity::Implicit, param_name, param_type, next_body_type)
                         if param.plicity == Plicity::Explicit =>

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -490,7 +490,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
         Ok(())
     }
 
-    /// Re-initialise the [`Context::renaming`] by mapping the local variables
+    /// Re-initialize the [`Context::renaming`] by mapping the local variables
     /// in the spine to the local variables in the solution. This can fail if
     /// the spine does not contain distinct local variables.
     fn init_renaming(&mut self, spine: &[Elim<'arena>]) -> Result<(), SpineError> {
@@ -738,7 +738,7 @@ impl PartialRenaming {
         }
     }
 
-    /// Re-initialise the renaming to the requested `source_len`, reusing the
+    /// Re-initialize the renaming to the requested `source_len`, reusing the
     /// previous allocation.
     fn init(&mut self, source_len: EnvLen) {
         self.source.clear();

--- a/fathom/tests/source_tests.rs
+++ b/fathom/tests/source_tests.rs
@@ -52,15 +52,15 @@ struct Config {
     example_data_invalid: Vec<String>,
     #[serde(skip)]
     update_snapshots: bool,
-    #[serde(default = "DEFAULT_TEST_NORMALISATION")]
-    test_normalisation: bool,
+    #[serde(default = "DEFAULT_TEST_NORMALIZATION")]
+    test_normalization: bool,
 }
 
 const DEFAULT_ALLOW_ERRORS: fn() -> bool = || false;
 const DEFAULT_IGNORE: fn() -> bool = || false;
 const DEFAULT_EXIT_CODE: fn() -> i32 = || 0;
 const DEFAULT_EXAMPLE_DATA: fn() -> Vec<String> = Vec::new;
-const DEFAULT_TEST_NORMALISATION: fn() -> bool = || false;
+const DEFAULT_TEST_NORMALIZATION: fn() -> bool = || false;
 
 struct TestFailure {
     name: &'static str,
@@ -99,7 +99,7 @@ struct TestCommand<'a> {
 enum Command<'a> {
     ElabModule,
     ElabTerm,
-    Normalise,
+    Normalize,
     ParseData(&'a Path, ExpectedOutcome),
 }
 
@@ -112,7 +112,7 @@ enum ExpectedOutcome {
 impl<'a> Command<'a> {
     fn snap_name(&self) -> &'static str {
         match self {
-            Command::Normalise => "norm",
+            Command::Normalize => "norm",
             Command::ElabModule | Command::ElabTerm | Command::ParseData(_, _) => "",
         }
     }
@@ -120,7 +120,7 @@ impl<'a> Command<'a> {
     pub(crate) fn expected_outcome(&self) -> ExpectedOutcome {
         match self {
             Command::ParseData(_, outcome) => *outcome,
-            Command::ElabModule | Command::ElabTerm | Command::Normalise => {
+            Command::ElabModule | Command::ElabTerm | Command::Normalize => {
                 ExpectedOutcome::Success
             }
         }
@@ -205,8 +205,8 @@ fn run_test(
         }
     }
 
-    if config.test_normalisation {
-        let test_command = TestCommand::new(Command::Normalise, &config, &input_file);
+    if config.test_normalization {
+        let test_command = TestCommand::new(Command::Normalize, &config, &input_file);
         match test_command.run() {
             Ok(mut test_failures) => failures.append(&mut test_failures),
             Err(error) => {
@@ -410,7 +410,7 @@ impl<'a> From<Command<'a>> for process::Command {
             Command::ElabTerm => {
                 exe.args(["elab", "--term"]);
             }
-            Command::Normalise => {
+            Command::Normalize => {
                 exe.args(["norm", "--term"]);
             }
             Command::ParseData(format, _) => {
@@ -487,9 +487,9 @@ impl Snapshot {
     }
 
     fn update(&mut self) -> Result<(), io::Error> {
-        let serialised = toml::to_string_pretty(&self.actual)
+        let serialized = toml::to_string_pretty(&self.actual)
             .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-        fs::write(&self.path, serialised)?;
+        fs::write(&self.path, serialized)?;
         self.expected = Some(self.actual.clone());
         Ok(())
     }

--- a/tests/cmd/fathom-norm.md
+++ b/tests/cmd/fathom-norm.md
@@ -6,12 +6,12 @@ Short help can be printed with `-h`
 
 ```console
 $ fathom norm -h
-Normalise a Fathom term, printing its normal form and type
+Normalize a Fathom term, printing its normal form and type
 
 Usage: fathom norm [OPTIONS] --term <TERM_FILE>
 
 Options:
-      --term <TERM_FILE>  Path to a term to normalise
+      --term <TERM_FILE>  Path to a term to normalize
       --allow-errors      Continue even if errors were encountered
   -h, --help              Print help information
 
@@ -21,12 +21,12 @@ Long help can be printed with `--help`
 
 ```console
 $ fathom norm --help
-Normalise a Fathom term, printing its normal form and type
+Normalize a Fathom term, printing its normal form and type
 
 Usage: fathom norm [OPTIONS] --term <TERM_FILE>
 
 Options:
-      --term <TERM_FILE>  Path to a term to normalise
+      --term <TERM_FILE>  Path to a term to normalize
       --allow-errors      Continue even if errors were encountered
   -h, --help              Print help information
 
@@ -76,7 +76,7 @@ error: couldn't read `does/not/exist.fathom`: No such file or directory (os erro
 
 ### Type errors
 
-The term must be well-typed before normalisation
+The term must be well-typed before normalization
 
 ```console
 $ fathom norm --term tests/fail/elaboration/duplicate-field-labels/record-literal.fathom

--- a/tests/cmd/fathom.md
+++ b/tests/cmd/fathom.md
@@ -12,7 +12,7 @@ Usage: fathom <COMMAND>
 
 Commands:
   elab  Elaborate a Fathom module or term, printing the result to stdout
-  norm  Normalise a Fathom term, printing its normal form and type
+  norm  Normalize a Fathom term, printing its normal form and type
   data  Manipulate binary data based on a Fathom format
   help  Print this message or the help of the given subcommand(s)
 
@@ -32,7 +32,7 @@ Usage: fathom <COMMAND>
 
 Commands:
   elab  Elaborate a Fathom module or term, printing the result to stdout
-  norm  Normalise a Fathom term, printing its normal form and type
+  norm  Normalize a Fathom term, printing its normal form and type
   data  Manipulate binary data based on a Fathom format
   help  Print this message or the help of the given subcommand(s)
 
@@ -55,7 +55,7 @@ Usage: fathom <COMMAND>
 
 Commands:
   elab  Elaborate a Fathom module or term, printing the result to stdout
-  norm  Normalise a Fathom term, printing its normal form and type
+  norm  Normalize a Fathom term, printing its normal form and type
   data  Manipulate binary data based on a Fathom format
   help  Print this message or the help of the given subcommand(s)
 

--- a/tests/succeed/implicit-args/specialize.fathom
+++ b/tests/succeed/implicit-args/specialize.fathom
@@ -2,17 +2,17 @@ let id = fun (@A : Type) (a : A) => a;
 let always = fun (@A : Type) (@B : Type) (a : A) (b : B) => a;
 let apply = fun (@A : Type) (@B : Type) (f : A -> B) (x : A) => f x;
 
-// No specialisation
+// No specialization
 let _ = id;
 let _ = always;
 let _ = apply;
 
-// Full specialisation
+// Full specialization
 let _ : Bool -> Bool = id;
 let _ : Bool -> U32 -> Bool = always;
 let _ : (Bool -> U32) -> Bool -> U32 = apply;
 
-// Specialisation of higher order functions
+// Specialization of higher order functions
 let _ = apply (always false) (0 : U32);
 
 {}

--- a/tests/succeed/numeric-literal/style-conflict.fathom
+++ b/tests/succeed/numeric-literal/style-conflict.fathom
@@ -1,3 +1,3 @@
-//~ test-normalisation = true
+//~ test-normalization = true
 
 u32_add "nope" 0xcafe

--- a/tests/succeed/numeric-literal/style-preserve-binary.fathom
+++ b/tests/succeed/numeric-literal/style-preserve-binary.fathom
@@ -1,3 +1,3 @@
-//~ test-normalisation = true
+//~ test-normalization = true
 
 u8_shl 0b00000001 4

--- a/tests/succeed/numeric-literal/style-propagate-binary.fathom
+++ b/tests/succeed/numeric-literal/style-propagate-binary.fathom
@@ -1,3 +1,3 @@
-//~ test-normalisation = true
+//~ test-normalization = true
 
 u8_add 0b1 2

--- a/tests/succeed/numeric-literal/style-propagate-hex.fathom
+++ b/tests/succeed/numeric-literal/style-propagate-hex.fathom
@@ -1,3 +1,3 @@
-//~ test-normalisation = true
+//~ test-normalization = true
 
 u8_add 0x2 1


### PR DESCRIPTION
We alternated between the [American `-ize` and British/Commonwealth `-ise`](https://en.wikipedia.org/wiki/American_and_British_English_spelling_differences#-ise,_-ize_(-isation,_-ization)) spelling inconsistently. I propose we standardize on the American spelling, in line with the Rust standard library documentation. [RFC 1574](https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md) states:

> All documentation for the standard library is standardized on American English, with regards to spelling, grammar, and punctuation conventions. Language changes over time, so this doesn’t mean that there is always a correct answer to every grammar question, but there is often some kind of formal consensus.