### PR TITLE
Make parenthesized terms explicit in the surface AST

### DIFF
--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -182,6 +182,8 @@ impl<Range: Clone> Pattern<Range> {
 /// Surface terms.
 #[derive(Debug, Clone)]
 pub enum Term<'arena, Range> {
+    /// Parenthesized term
+    Paren(Range, &'arena Term<'arena, Range>),
     /// Named patterns.
     Name(Range, StringId),
     /// Hole expressions.
@@ -293,7 +295,8 @@ impl<'arena, Range: Clone> Term<'arena, Range> {
     /// Get the source range of the term.
     pub fn range(&self) -> Range {
         match self {
-            Term::Name(range, _)
+            Term::Paren(range, _)
+            | Term::Name(range, _)
             | Term::Hole(range, _)
             | Term::Placeholder(range)
             | Term::Ann(range, _, _)

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1012,6 +1012,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         let expected_type = self.elim_env().force(expected_type);
 
         match (surface_term, expected_type.as_ref()) {
+            (Term::Paren(_, term), _) => self.check(term, &expected_type),
             (Term::Let(_, def_pattern, def_type, def_expr, body_expr), _) => {
                 let (def_pattern, def_type, def_type_value) =
                     self.synth_ann_pattern(def_pattern, *def_type);
@@ -1357,6 +1358,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
     ) -> (core::Term<'arena>, ArcValue<'arena>) {
         let file_range = self.file_range(surface_term.range());
         match surface_term {
+            Term::Paren(_, term) => self.synth(term),
             Term::Name(range, name) => {
                 if let Some((term, r#type)) = self.get_local_name(*name) {
                     return (

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -167,6 +167,7 @@ fn term_deps(
     deps: &mut Vec<StringId>,
 ) {
     match term {
+        Term::Paren(_, term) => term_deps(term, item_names, local_names, deps),
         Term::Name(_, name) => {
             if local_names.iter().rev().any(|local| name == local) {
                 // local binding, do nothing

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -202,7 +202,7 @@ ProjTerm: Term<'arena, ByteRange> = {
 };
 
 AtomicTerm: Term<'arena, ByteRange> = {
-    <start: @L> "(" <term: Term> ")" <end: @R> => term,
+    <start: @L> "(" <term: Term> ")" <end: @R> => Term::Paren(ByteRange::new(start, end), scope.to_scope(term)),
     <start: @L> <terms: Tuple<Term>> <end: @R> => Term::Tuple(ByteRange::new(start, end), terms),
 
     <start: @L> <name: Name> <end: @R> => Term::Name(ByteRange::new(start, end), name),

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -173,6 +173,7 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
         // FIXME: indentation and grouping
 
         match term {
+            Term::Paren(_, term) => self.paren(true, self.term(term)),
             Term::Name(_, name) => self.ident(*name),
             Term::Hole(_, name) => self.concat([self.text("?"), self.ident(*name)]),
             Term::Placeholder(_) => self.text("_"),

--- a/tests/fail/elaboration/non-exhaustive-patterns/match-check.snap
+++ b/tests/fail/elaboration/non-exhaustive-patterns/match-check.snap
@@ -7,12 +7,12 @@ error: cannot find `x` in scope
   │        ^ unbound name
 
 error: non-exhaustive patterns in match expression
-  ┌─ tests/fail/elaboration/non-exhaustive-patterns/match-check.fathom:3:8
+  ┌─ tests/fail/elaboration/non-exhaustive-patterns/match-check.fathom:3:7
   │
 3 │ match (x : U8) {} : U32
-  │ -------^^^^^^----
-  │ │      │
-  │ │      patterns not covered
+  │ ------^^^^^^^^---
+  │ │     │
+  │ │     patterns not covered
   │ in match expression
 
 '''

--- a/tests/fail/elaboration/non-exhaustive-patterns/match-synth.snap
+++ b/tests/fail/elaboration/non-exhaustive-patterns/match-synth.snap
@@ -7,12 +7,12 @@ error: cannot find `x` in scope
   │        ^ unbound name
 
 error: non-exhaustive patterns in match expression
-  ┌─ tests/fail/elaboration/non-exhaustive-patterns/match-synth.fathom:3:8
+  ┌─ tests/fail/elaboration/non-exhaustive-patterns/match-synth.fathom:3:7
   │
 3 │ match (x : U8) {}
-  │ -------^^^^^^----
-  │ │      │
-  │ │      patterns not covered
+  │ ------^^^^^^^^---
+  │ │     │
+  │ │     patterns not covered
   │ in match expression
 
 error: failed to infer match expression type


### PR DESCRIPTION
This would allow us to pretty print the user's input exactly in the future (eg if we want a `fathom fmt` command). Would also allow us to move the precedence logic from `surface::pretty` to `core::distillation`