### PR TITLE
Bump to rust v1.67

### DIFF
--- a/fathom/Cargo.toml
+++ b/fathom/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["YesLogic Pty. Ltd. <info@yeslogic.com>"]
 repository = "https://github.com/yeslogic/fathom"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 publish = false
 
 description = "A language for declaratively specifying binary data formats"

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -530,8 +530,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn term_size() {
         assert_eq!(std::mem::size_of::<Term<()>>(), 32);
-        assert_eq!(std::mem::size_of::<Term<ByteRange>>(), 56);
-        assert_eq!(std::mem::size_of::<Term<FileRange>>(), 64);
+        assert_eq!(std::mem::size_of::<Term<ByteRange>>(), 48);
     }
 
     #[test]
@@ -539,6 +538,5 @@ mod tests {
     fn pattern_size() {
         assert_eq!(std::mem::size_of::<Pattern<()>>(), 8);
         assert_eq!(std::mem::size_of::<Pattern<ByteRange>>(), 16);
-        assert_eq!(std::mem::size_of::<Pattern<FileRange>>(), 20);
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673301451,
-        "narHash": "sha256-0IvOqAXZ+dHjOV7dQl4iEcCUmzqg8VvGg+UZ68ONDIg=",
+        "lastModified": 1674778051,
+        "narHash": "sha256-iJ4/HZok9JVSDdl8bYQx2a6Btxna+C/E5Otp0mTXWH0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "35f1f865c03671a4f75a6996000f03ac3dc3e472",
+        "rev": "e62676e855cc300d6a2a76f72c28eaa532aff277",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673317790,
-        "narHash": "sha256-GWjj/bqTXPsKgwWGFZUyHRShxFvufShYnuyyeP99wmk=",
+        "lastModified": 1674786480,
+        "narHash": "sha256-n25V3Ug/dJewbJaxj1gL0cUMBdOonrVkIQCHd9yHHvw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9724998ea2caf23214674bf0c2cdf6ec0b1719af",
+        "rev": "296dd673b46aaebe1c8355f1848ceb7c905dda35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Rust version `1.67` includes [an improvement to packing of structs and enums](https://releases.rs/docs/1.67.0/). This saves us 8 bytes on the size of `surface::Term<ByteRange>`.

Took the liberty of removing the tests for the size of `surface::Term<FileRange>` and `surface::Pattern<FileRange>` since we don't use them anymore. 