### PR TITLE
Use explicit type names in place of `Self` where possible

### DIFF
--- a/fathom/src/alloc.rs
+++ b/fathom/src/alloc.rs
@@ -91,7 +91,7 @@ impl<'a, Elem> Deref for SliceVec<'a, Elem> {
 }
 
 impl<'a, Elem> From<SliceVec<'a, Elem>> for &'a [Elem] {
-    fn from(slice: SliceVec<'a, Elem>) -> Self {
+    fn from(slice: SliceVec<'a, Elem>) -> &'a [Elem] {
         // SAFETY: This is safe because we know that `self.elems[..self.next_index]`
         // only ever contains elements initialized with `MaybeUninit::new`.
         // We know this because:

--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -600,7 +600,7 @@ pub enum Const {
 }
 
 impl PartialEq for Const {
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, other: &Const) -> bool {
         match (*self, *other) {
             (Const::Bool(a), Const::Bool(b)) => a == b,
             (Const::U8(a, _), Const::U8(b, _)) => a == b,
@@ -623,13 +623,13 @@ impl PartialEq for Const {
 impl Eq for Const {}
 
 impl PartialOrd for Const {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Const) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for Const {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Const) -> std::cmp::Ordering {
         match (*self, *other) {
             (Const::Bool(a), Const::Bool(b)) => a.cmp(&b),
             (Const::U8(a, _), Const::U8(b, _)) => a.cmp(&b),

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -40,7 +40,7 @@ impl<'arena> fmt::Display for ReadError<'arena> {
 impl<'arena> std::error::Error for ReadError<'arena> {}
 
 impl<'arena> From<BufferError> for ReadError<'arena> {
-    fn from(err: BufferError) -> Self {
+    fn from(err: BufferError) -> ReadError<'arena> {
         ReadError::BufferError(Span::Empty, err)
     }
 }

--- a/fathom/src/files.rs
+++ b/fathom/src/files.rs
@@ -2,7 +2,7 @@
 //! `FileId` as the file id, instead of `usize`.
 
 use std::fmt;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, TryFromIntError};
 use std::ops::Range;
 
 use codespan_reporting::files::{Error, SimpleFile};
@@ -21,28 +21,28 @@ impl fmt::Display for FileId {
 }
 
 impl TryFrom<u32> for FileId {
-    type Error = <NonZeroU32 as TryFrom<u32>>::Error;
+    type Error = TryFromIntError;
 
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<FileId, TryFromIntError> {
         let id = NonZeroU32::try_from(value)?;
-        Ok(Self(id))
+        Ok(FileId(id))
     }
 }
 
 impl From<FileId> for NonZeroU32 {
-    fn from(value: FileId) -> Self {
+    fn from(value: FileId) -> NonZeroU32 {
         value.0
     }
 }
 
 impl From<FileId> for u32 {
-    fn from(value: FileId) -> Self {
+    fn from(value: FileId) -> u32 {
         value.0.get()
     }
 }
 
 impl From<FileId> for usize {
-    fn from(value: FileId) -> Self {
+    fn from(value: FileId) -> usize {
         value.0.get() as usize
     }
 }

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -71,7 +71,9 @@ struct ModuleOrderContext<'a, 'interner, 'arena> {
 }
 
 impl<'a, 'interner, 'arena> ModuleOrderContext<'a, 'interner, 'arena> {
-    fn new(elab_context: &'a mut elaboration::Context<'interner, 'arena>) -> Self {
+    fn new(
+        elab_context: &'a mut elaboration::Context<'interner, 'arena>,
+    ) -> ModuleOrderContext<'a, 'interner, 'arena> {
         ModuleOrderContext {
             elab_context,
             output: Vec::new(),

--- a/fathom/tests/source_tests.rs
+++ b/fathom/tests/source_tests.rs
@@ -287,7 +287,7 @@ fn failures_to_outcome(failures: &[TestFailure]) -> Result<(), libtest_mimic::Fa
 }
 
 impl<'a> TestCommand<'a> {
-    fn new(command: Command<'a>, config: &'a Config, input_file: &'a Path) -> Self {
+    fn new(command: Command<'a>, config: &'a Config, input_file: &'a Path) -> TestCommand<'a> {
         TestCommand {
             command,
             config,
@@ -401,7 +401,7 @@ fn command_status_matches_expectation(
 }
 
 impl<'a> From<Command<'a>> for process::Command {
-    fn from(command: Command) -> Self {
+    fn from(command: Command) -> process::Command {
         let mut exe = process::Command::new(env!("CARGO_BIN_EXE_fathom"));
         match command {
             Command::ElabModule => {


### PR DESCRIPTION
Use explicit type names in place of `Self` where possible. Dual to https://github.com/yeslogic/fathom/pull/480