### PR TITLE
Use `Self` in place of explicit type names where possible

### DIFF
--- a/fathom/src/core.rs
+++ b/fathom/src/core.rs
@@ -49,8 +49,8 @@ pub enum Plicity {
 impl fmt::Display for Plicity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Plicity::Explicit => write!(f, "explicit"),
-            Plicity::Implicit => write!(f, "implicit"),
+            Self::Explicit => write!(f, "explicit"),
+            Self::Implicit => write!(f, "implicit"),
         }
     }
 }
@@ -602,19 +602,19 @@ pub enum Const {
 impl PartialEq for Const {
     fn eq(&self, other: &Self) -> bool {
         match (*self, *other) {
-            (Const::Bool(a), Const::Bool(b)) => a == b,
-            (Const::U8(a, _), Const::U8(b, _)) => a == b,
-            (Const::U16(a, _), Const::U16(b, _)) => a == b,
-            (Const::U32(a, _), Const::U32(b, _)) => a == b,
-            (Const::U64(a, _), Const::U64(b, _)) => a == b,
-            (Const::S8(a), Const::S8(b)) => a == b,
-            (Const::S16(a), Const::S16(b)) => a == b,
-            (Const::S32(a), Const::S32(b)) => a == b,
-            (Const::S64(a), Const::S64(b)) => a == b,
-            (Const::F32(a), Const::F32(b)) => a.total_cmp(&b).is_eq(),
-            (Const::F64(a), Const::F64(b)) => a.total_cmp(&b).is_eq(),
-            (Const::Pos(a), Const::Pos(b)) => a == b,
-            (Const::Ref(a), Const::Ref(b)) => a == b,
+            (Self::Bool(a), Self::Bool(b)) => a == b,
+            (Self::U8(a, _), Self::U8(b, _)) => a == b,
+            (Self::U16(a, _), Self::U16(b, _)) => a == b,
+            (Self::U32(a, _), Self::U32(b, _)) => a == b,
+            (Self::U64(a, _), Self::U64(b, _)) => a == b,
+            (Self::S8(a), Self::S8(b)) => a == b,
+            (Self::S16(a), Self::S16(b)) => a == b,
+            (Self::S32(a), Self::S32(b)) => a == b,
+            (Self::S64(a), Self::S64(b)) => a == b,
+            (Self::F32(a), Self::F32(b)) => a.total_cmp(&b).is_eq(),
+            (Self::F64(a), Self::F64(b)) => a.total_cmp(&b).is_eq(),
+            (Self::Pos(a), Self::Pos(b)) => a == b,
+            (Self::Ref(a), Self::Ref(b)) => a == b,
             _ => false,
         }
     }
@@ -631,19 +631,19 @@ impl PartialOrd for Const {
 impl Ord for Const {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (*self, *other) {
-            (Const::Bool(a), Const::Bool(b)) => a.cmp(&b),
-            (Const::U8(a, _), Const::U8(b, _)) => a.cmp(&b),
-            (Const::U16(a, _), Const::U16(b, _)) => a.cmp(&b),
-            (Const::U32(a, _), Const::U32(b, _)) => a.cmp(&b),
-            (Const::U64(a, _), Const::U64(b, _)) => a.cmp(&b),
-            (Const::S8(a), Const::S8(b)) => a.cmp(&b),
-            (Const::S16(a), Const::S16(b)) => a.cmp(&b),
-            (Const::S32(a), Const::S32(b)) => a.cmp(&b),
-            (Const::S64(a), Const::S64(b)) => a.cmp(&b),
-            (Const::F32(a), Const::F32(b)) => a.total_cmp(&b),
-            (Const::F64(a), Const::F64(b)) => a.total_cmp(&b),
-            (Const::Pos(a), Const::Pos(b)) => a.cmp(&b),
-            (Const::Ref(a), Const::Ref(b)) => a.cmp(&b),
+            (Self::Bool(a), Self::Bool(b)) => a.cmp(&b),
+            (Self::U8(a, _), Self::U8(b, _)) => a.cmp(&b),
+            (Self::U16(a, _), Self::U16(b, _)) => a.cmp(&b),
+            (Self::U32(a, _), Self::U32(b, _)) => a.cmp(&b),
+            (Self::U64(a, _), Self::U64(b, _)) => a.cmp(&b),
+            (Self::S8(a), Self::S8(b)) => a.cmp(&b),
+            (Self::S16(a), Self::S16(b)) => a.cmp(&b),
+            (Self::S32(a), Self::S32(b)) => a.cmp(&b),
+            (Self::S64(a), Self::S64(b)) => a.cmp(&b),
+            (Self::F32(a), Self::F32(b)) => a.total_cmp(&b),
+            (Self::F64(a), Self::F64(b)) => a.total_cmp(&b),
+            (Self::Pos(a), Self::Pos(b)) => a.cmp(&b),
+            (Self::Ref(a), Self::Ref(b)) => a.cmp(&b),
             _ => {
                 fn discriminant(r#const: &Const) -> usize {
                     match r#const {
@@ -699,10 +699,10 @@ pub trait UIntStyled<const N: usize>:
 impl UIntStyle {
     pub fn format<T: UIntStyled<N>, const N: usize>(&self, number: T) -> String {
         match self {
-            UIntStyle::Binary => format!("0b{number:b}"),
-            UIntStyle::Decimal => number.to_string(),
-            UIntStyle::Hexadecimal => format!("0x{number:x}"),
-            UIntStyle::Ascii => {
+            Self::Binary => format!("0b{number:b}"),
+            Self::Decimal => number.to_string(),
+            Self::Hexadecimal => format!("0x{number:x}"),
+            Self::Ascii => {
                 let bytes = number.to_be_bytes();
                 if bytes.iter().all(|c| c.is_ascii() && !c.is_ascii_control()) {
                     let s = std::str::from_utf8(&bytes).unwrap(); // unwrap safe due to above check
@@ -714,7 +714,7 @@ impl UIntStyle {
         }
     }
 
-    pub fn merge(left: UIntStyle, right: UIntStyle) -> UIntStyle {
+    pub fn merge(left: Self, right: Self) -> Self {
         use UIntStyle::*;
 
         match (left, right) {

--- a/fathom/src/core/binary.rs
+++ b/fathom/src/core/binary.rs
@@ -239,14 +239,14 @@ impl BufferError {
 impl fmt::Display for BufferError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BufferError::SetOffsetBeforeStartOfBuffer { .. } => {
+            Self::SetOffsetBeforeStartOfBuffer { .. } => {
                 f.write_str("attempt to set buffer offset before the start of the buffer")
             }
-            BufferError::SetOffsetAfterEndOfBuffer { .. } => {
+            Self::SetOffsetAfterEndOfBuffer { .. } => {
                 f.write_str("attempt to set buffer offset after the end of the buffer")
             }
-            BufferError::UnexpectedEndOfBuffer => f.write_str("unexpected end of buffer"),
-            BufferError::PositionOverflow => f.write_str("position overflow"),
+            Self::UnexpectedEndOfBuffer => f.write_str("unexpected end of buffer"),
+            Self::PositionOverflow => f.write_str("position overflow"),
         }
     }
 }

--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -227,14 +227,14 @@ pub enum Error {
 impl Error {
     pub fn description(&self) -> &str {
         match &self {
-            Error::UnboundItemVar => "unbound item variable",
-            Error::UnboundLocalVar => "unbound local variable",
-            Error::UnboundMetaVar => "unbound metavariable",
-            Error::InvalidFunctionApp => "invalid function application",
-            Error::InvalidRecordProj => "invalid record projection",
-            Error::InvalidConstMatch => "invalid constant match",
-            Error::InvalidFormatRepr => "invalid format repr",
-            Error::MissingConstDefault => "missing default expression",
+            Self::UnboundItemVar => "unbound item variable",
+            Self::UnboundLocalVar => "unbound local variable",
+            Self::UnboundMetaVar => "unbound metavariable",
+            Self::InvalidFunctionApp => "invalid function application",
+            Self::InvalidRecordProj => "invalid record projection",
+            Self::InvalidConstMatch => "invalid constant match",
+            Self::InvalidFormatRepr => "invalid format repr",
+            Self::MissingConstDefault => "missing default expression",
         }
     }
 }

--- a/fathom/src/driver.rs
+++ b/fathom/src/driver.rs
@@ -22,8 +22,8 @@ pub enum Status {
 impl Status {
     pub fn exit_code(self) -> i32 {
         match self {
-            Status::Ok => 0,
-            Status::Error => 1,
+            Self::Ok => 0,
+            Self::Error => 1,
         }
     }
 }

--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -46,13 +46,13 @@ pub struct Index(RawVar);
 
 impl Index {
     /// The last variable to be bound in the environment.
-    pub const fn last() -> Index {
-        Index(0)
+    pub const fn last() -> Self {
+        Self(0)
     }
 
     /// Returns the previously bound variable, relative to this one.
-    pub const fn prev(self) -> Index {
-        Index(self.0 + 1) // FIXME: check overflow?
+    pub const fn prev(self) -> Self {
+        Self(self.0 + 1) // FIXME: check overflow?
     }
 }
 
@@ -93,13 +93,13 @@ pub struct Level(RawVar);
 
 impl Level {
     /// The first variable to be bound in the environment.
-    pub const fn first() -> Level {
-        Level(0)
+    pub const fn first() -> Self {
+        Self(0)
     }
 
     /// Returns the next bound variable, relative to this one.
-    pub const fn next(self) -> Level {
-        Level(self.0 + 1) // FIXME: check overflow?
+    pub const fn next(self) -> Self {
+        Self(self.0 + 1) // FIXME: check overflow?
     }
 }
 
@@ -128,13 +128,13 @@ pub struct EnvLen(RawVar);
 
 impl EnvLen {
     /// Construct a new, empty environment.
-    pub fn new() -> EnvLen {
-        EnvLen(0)
+    pub fn new() -> Self {
+        Self(0)
     }
 
     /// Reset the environment to the empty environment.
     pub fn clear(&mut self) {
-        *self = EnvLen::new();
+        *self = Self::new();
     }
 
     /// Convert an index to a level in the current environment.
@@ -163,7 +163,7 @@ impl EnvLen {
     }
 
     /// Truncate the environment to the given length.
-    pub fn truncate(&mut self, len: EnvLen) {
+    pub fn truncate(&mut self, len: Self) {
         *self = len;
     }
 }
@@ -176,8 +176,8 @@ pub struct UniqueEnv<Entry> {
 
 impl<Entry> UniqueEnv<Entry> {
     /// Construct a new, empty environment.
-    pub fn new() -> UniqueEnv<Entry> {
-        UniqueEnv {
+    pub fn new() -> Self {
+        Self {
             entries: Vec::new(),
         }
     }
@@ -313,8 +313,8 @@ pub struct SharedEnv<Entry> {
 
 impl<Entry> SharedEnv<Entry> {
     /// Construct a new, empty environment.
-    pub fn new() -> SharedEnv<Entry> {
-        SharedEnv {
+    pub fn new() -> Self {
+        Self {
             entries: rpds::Vector::new_sync(),
         }
     }

--- a/fathom/src/files.rs
+++ b/fathom/src/files.rs
@@ -43,7 +43,7 @@ impl From<FileId> for u32 {
 
 impl From<FileId> for usize {
     fn from(value: FileId) -> Self {
-        value.0.get() as usize
+        value.0.get() as Self
     }
 }
 
@@ -57,8 +57,8 @@ where
     Source: AsRef<str>,
 {
     /// Create a new files database.
-    pub fn new() -> Files<Name, Source> {
-        Files { files: Vec::new() }
+    pub fn new() -> Self {
+        Self { files: Vec::new() }
     }
 
     /// Add a file to the database, returning the handle that can be used to

--- a/fathom/src/lib.rs
+++ b/fathom/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../../README.md")]
+#![warn(clippy::use_self)]
 #![allow(clippy::bool_assert_comparison)]
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::new_without_default)]

--- a/fathom/src/source.rs
+++ b/fathom/src/source.rs
@@ -37,8 +37,8 @@ impl DerefMut for StringInterner {
 
 impl StringInterner {
     /// Construct an empty string interner.
-    pub fn new() -> StringInterner {
-        StringInterner {
+    pub fn new() -> Self {
+        Self {
             alphabetic_names: Vec::new(),
             tuple_labels: Vec::new(),
             strings: string_interner::StringInterner::new(),
@@ -153,11 +153,11 @@ pub struct Spanned<T> {
 
 impl<T> Spanned<T> {
     pub fn new(span: Span, inner: T) -> Self {
-        Spanned { span, inner }
+        Self { span, inner }
     }
 
     pub fn empty(inner: T) -> Self {
-        Spanned {
+        Self {
             span: Span::Empty,
             inner,
         }
@@ -169,12 +169,12 @@ impl<T> Spanned<T> {
 
     /// Merge the supplied span with the span of `other` and return `other`
     /// wrapped in that span.
-    pub fn merge(span: Span, other: Spanned<T>) -> Spanned<T> {
-        let Spanned {
+    pub fn merge(span: Span, other: Self) -> Self {
+        let Self {
             span: other_span,
             inner,
         } = other;
-        Spanned {
+        Self {
             span: span.merge(&other_span),
             inner,
         }
@@ -202,29 +202,29 @@ pub enum Span {
 }
 
 impl Span {
-    pub fn merge(&self, other: &Span) -> Span {
+    pub fn merge(&self, other: &Self) -> Self {
         match (self, other) {
-            (Span::Range(a), Span::Range(b)) => a.merge(b).map(Span::Range).unwrap_or(Span::Empty),
-            (_, _) => Span::Empty,
+            (Self::Range(a), Self::Range(b)) => a.merge(b).map(Span::Range).unwrap_or(Self::Empty),
+            (_, _) => Self::Empty,
         }
     }
 }
 
 impl From<FileRange> for Span {
     fn from(range: FileRange) -> Self {
-        Span::Range(range)
+        Self::Range(range)
     }
 }
 
 impl From<&FileRange> for Span {
     fn from(range: &FileRange) -> Self {
-        Span::Range(*range)
+        Self::Range(*range)
     }
 }
 
 impl From<Option<FileRange>> for Span {
-    fn from(range: Option<FileRange>) -> Span {
-        range.map_or(Span::Empty, Span::Range)
+    fn from(range: Option<FileRange>) -> Self {
+        range.map_or(Self::Empty, Span::Range)
     }
 }
 
@@ -249,8 +249,8 @@ impl fmt::Debug for FileRange {
 }
 
 impl FileRange {
-    pub const fn new(file_id: FileId, byte_range: ByteRange) -> FileRange {
-        FileRange {
+    pub const fn new(file_id: FileId, byte_range: ByteRange) -> Self {
+        Self {
             file_id,
             byte_range,
         }
@@ -272,9 +272,9 @@ impl FileRange {
         self.byte_range.end
     }
 
-    pub fn merge(&self, other: &FileRange) -> Option<FileRange> {
+    pub fn merge(&self, other: &Self) -> Option<Self> {
         if self.file_id == other.file_id {
-            Some(FileRange::new(
+            Some(Self::new(
                 self.file_id,
                 ByteRange::merge(self.byte_range, other.byte_range),
             ))

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -12,7 +12,7 @@ use crate::files::FileId;
 use crate::source::{BytePos, ByteRange, FileRange, ProgramSource, StringId, StringInterner};
 
 lalrpop_mod!(
-    #[allow(clippy::all)]
+    #[allow(clippy::all, clippy::use_self)]
     grammar,
     "/surface/grammar.rs"
 );
@@ -117,46 +117,46 @@ impl<Range> BinOp<Range> {
         Range: Clone,
     {
         match self {
-            BinOp::Add(range)
-            | BinOp::Sub(range)
-            | BinOp::Mul(range)
-            | BinOp::Div(range)
-            | BinOp::Eq(range)
-            | BinOp::Neq(range)
-            | BinOp::Lt(range)
-            | BinOp::Lte(range)
-            | BinOp::Gt(range)
-            | BinOp::Gte(range) => range.clone(),
+            Self::Add(range)
+            | Self::Sub(range)
+            | Self::Mul(range)
+            | Self::Div(range)
+            | Self::Eq(range)
+            | Self::Neq(range)
+            | Self::Lt(range)
+            | Self::Lte(range)
+            | Self::Gt(range)
+            | Self::Gte(range) => range.clone(),
         }
     }
 
     fn as_str(&self) -> &'static str {
         match self {
-            BinOp::Add(_) => "+",
-            BinOp::Sub(_) => "-",
-            BinOp::Mul(_) => "*",
-            BinOp::Div(_) => "/",
-            BinOp::Eq(_) => "==",
-            BinOp::Neq(_) => "!=",
-            BinOp::Lt(_) => "<",
-            BinOp::Lte(_) => "<=",
-            BinOp::Gt(_) => ">",
-            BinOp::Gte(_) => ">=",
+            Self::Add(_) => "+",
+            Self::Sub(_) => "-",
+            Self::Mul(_) => "*",
+            Self::Div(_) => "/",
+            Self::Eq(_) => "==",
+            Self::Neq(_) => "!=",
+            Self::Lt(_) => "<",
+            Self::Lte(_) => "<=",
+            Self::Gt(_) => ">",
+            Self::Gte(_) => ">=",
         }
     }
 
     fn map_range<T>(self, f: impl Fn(Range) -> T) -> BinOp<T> {
         match self {
-            BinOp::Add(range) => BinOp::Add(f(range)),
-            BinOp::Sub(range) => BinOp::Sub(f(range)),
-            BinOp::Mul(range) => BinOp::Mul(f(range)),
-            BinOp::Div(range) => BinOp::Div(f(range)),
-            BinOp::Eq(range) => BinOp::Eq(f(range)),
-            BinOp::Neq(range) => BinOp::Neq(f(range)),
-            BinOp::Lt(range) => BinOp::Lt(f(range)),
-            BinOp::Lte(range) => BinOp::Lte(f(range)),
-            BinOp::Gt(range) => BinOp::Gt(f(range)),
-            BinOp::Gte(range) => BinOp::Gte(f(range)),
+            Self::Add(range) => BinOp::Add(f(range)),
+            Self::Sub(range) => BinOp::Sub(f(range)),
+            Self::Mul(range) => BinOp::Mul(f(range)),
+            Self::Div(range) => BinOp::Div(f(range)),
+            Self::Eq(range) => BinOp::Eq(f(range)),
+            Self::Neq(range) => BinOp::Neq(f(range)),
+            Self::Lt(range) => BinOp::Lt(f(range)),
+            Self::Lte(range) => BinOp::Lte(f(range)),
+            Self::Gt(range) => BinOp::Gt(f(range)),
+            Self::Gte(range) => BinOp::Gte(f(range)),
         }
     }
 }
@@ -170,11 +170,11 @@ impl<Range> fmt::Display for BinOp<Range> {
 impl<Range: Clone> Pattern<Range> {
     pub fn range(&self) -> Range {
         match self {
-            Pattern::Name(range, _)
-            | Pattern::Placeholder(range)
-            | Pattern::StringLiteral(range, _)
-            | Pattern::NumberLiteral(range, _)
-            | Pattern::BooleanLiteral(range, _) => range.clone(),
+            Self::Name(range, _)
+            | Self::Placeholder(range)
+            | Self::StringLiteral(range, _)
+            | Self::NumberLiteral(range, _)
+            | Self::BooleanLiteral(range, _) => range.clone(),
         }
     }
 }
@@ -428,21 +428,21 @@ pub enum ParseMessage {
 impl ParseMessage {
     pub fn range(&self) -> ByteRange {
         match self {
-            ParseMessage::Lexer(error) => error.range(),
-            ParseMessage::InvalidToken { range }
-            | ParseMessage::UnrecognizedEof { range, .. }
-            | ParseMessage::UnrecognizedToken { range, .. }
-            | ParseMessage::ExtraToken { range, .. } => *range,
+            Self::Lexer(error) => error.range(),
+            Self::InvalidToken { range }
+            | Self::UnrecognizedEof { range, .. }
+            | Self::UnrecognizedToken { range, .. }
+            | Self::ExtraToken { range, .. } => *range,
         }
     }
 
-    fn from_lalrpop(error: LalrpopParseError<'_>) -> ParseMessage {
+    fn from_lalrpop(error: LalrpopParseError<'_>) -> Self {
         match error {
-            LalrpopParseError::InvalidToken { location } => ParseMessage::InvalidToken {
+            LalrpopParseError::InvalidToken { location } => Self::InvalidToken {
                 range: ByteRange::new(location, location),
             },
             LalrpopParseError::UnrecognizedEOF { location, expected } => {
-                ParseMessage::UnrecognizedEof {
+                Self::UnrecognizedEof {
                     range: ByteRange::new(location, location),
                     expected, // TODO: convert to descriptions?
                 }
@@ -450,41 +450,41 @@ impl ParseMessage {
             LalrpopParseError::UnrecognizedToken {
                 token: (start, token, end),
                 expected,
-            } => ParseMessage::UnrecognizedToken {
+            } => Self::UnrecognizedToken {
                 range: ByteRange::new(start, end),
                 token: token.description(),
                 expected,
             },
             LalrpopParseError::ExtraToken {
                 token: (start, token, end),
-            } => ParseMessage::ExtraToken {
+            } => Self::ExtraToken {
                 range: ByteRange::new(start, end),
                 token: token.description(),
             },
-            LalrpopParseError::User { error } => ParseMessage::Lexer(error),
+            LalrpopParseError::User { error } => Self::Lexer(error),
         }
     }
 
-    fn from_lalrpop_recovery(error: LalrpopErrorRecovery<'_>) -> ParseMessage {
+    fn from_lalrpop_recovery(error: LalrpopErrorRecovery<'_>) -> Self {
         // TODO: make use of use `error.dropped_tokens` in error reporting?
-        ParseMessage::from_lalrpop(error.error)
+        Self::from_lalrpop(error.error)
     }
 
     pub fn to_diagnostic(&self, file_id: FileId) -> Diagnostic<FileId> {
         let primary_label = |range: &ByteRange| Label::primary(file_id, *range);
 
         match self {
-            ParseMessage::Lexer(error) => error.to_diagnostic(file_id),
-            ParseMessage::InvalidToken { range } => Diagnostic::error()
+            Self::Lexer(error) => error.to_diagnostic(file_id),
+            Self::InvalidToken { range } => Diagnostic::error()
                 .with_message("invalid token")
                 .with_labels(vec![primary_label(range)]),
-            ParseMessage::UnrecognizedEof { range, expected } => Diagnostic::error()
+            Self::UnrecognizedEof { range, expected } => Diagnostic::error()
                 .with_message("unexpected end of file")
                 .with_labels(vec![
                     primary_label(range).with_message("unexpected end of file")
                 ])
                 .with_notes(format_expected(expected).map_or(Vec::new(), |message| vec![message])),
-            ParseMessage::UnrecognizedToken {
+            Self::UnrecognizedToken {
                 range,
                 token,
                 expected,
@@ -492,7 +492,7 @@ impl ParseMessage {
                 .with_message(format!("unexpected token {token}"))
                 .with_labels(vec![primary_label(range).with_message("unexpected token")])
                 .with_notes(format_expected(expected).map_or(Vec::new(), |message| vec![message])),
-            ParseMessage::ExtraToken { range, token } => Diagnostic::error()
+            Self::ExtraToken { range, token } => Diagnostic::error()
                 .with_message(format!("extra token {token}"))
                 .with_labels(vec![primary_label(range).with_message("extra token")]),
         }

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -959,12 +959,12 @@ impl<Range> BinOp<Range> {
     /// (lhs, op, rhs)
     fn precedence_impl(&self) -> (Prec, Prec, Prec) {
         match self {
-            BinOp::Eq(_) | BinOp::Neq(_) => (Prec::Cmp, Prec::Eq, Prec::Eq),
-            BinOp::Lt(_) | BinOp::Lte(_) | BinOp::Gt(_) | BinOp::Gte(_) => {
+            Self::Eq(_) | Self::Neq(_) => (Prec::Cmp, Prec::Eq, Prec::Eq),
+            Self::Lt(_) | Self::Lte(_) | Self::Gt(_) | Self::Gte(_) => {
                 (Prec::Add, Prec::Cmp, Prec::Cmp)
             }
-            BinOp::Add(_) | BinOp::Sub(_) => (Prec::Mul, Prec::Add, Prec::Add),
-            BinOp::Mul(_) | BinOp::Div(_) => (Prec::App, Prec::Mul, Prec::Mul),
+            Self::Add(_) | Self::Sub(_) => (Prec::Mul, Prec::Add, Prec::Add),
+            Self::Mul(_) | Self::Div(_) => (Prec::App, Prec::Mul, Prec::Mul),
         }
     }
 }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -198,15 +198,15 @@ pub enum MetaSource {
 impl MetaSource {
     pub fn range(&self) -> FileRange {
         match self {
-            MetaSource::ImplicitArg(range, _)
-            | MetaSource::HoleType(range, _)
-            | MetaSource::HoleExpr(range, _)
-            | MetaSource::PlaceholderType(range)
-            | MetaSource::PlaceholderExpr(range)
-            | MetaSource::PlaceholderPatternType(range)
-            | MetaSource::NamedPatternType(range, _)
-            | MetaSource::MatchExprType(range)
-            | MetaSource::ReportedErrorType(range) => *range,
+            Self::ImplicitArg(range, _)
+            | Self::HoleType(range, _)
+            | Self::HoleExpr(range, _)
+            | Self::PlaceholderType(range)
+            | Self::PlaceholderExpr(range)
+            | Self::PlaceholderPatternType(range)
+            | Self::NamedPatternType(range, _)
+            | Self::MatchExprType(range)
+            | Self::ReportedErrorType(range) => *range,
         }
     }
 }

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -146,7 +146,7 @@ impl Message {
         let secondary_label = |range: &FileRange| Label::secondary(range.file_id(), *range);
 
         match self {
-            Message::UnboundName {
+            Self::UnboundName {
                 range,
                 name,
                 suggestion,
@@ -166,13 +166,13 @@ impl Message {
                 }
                 diagnostic
             }
-            Message::RefutablePattern { pattern_range } => Diagnostic::error()
+            Self::RefutablePattern { pattern_range } => Diagnostic::error()
                 .with_message("refutable patterns found in binding")
                 .with_labels(vec![
                     primary_label(pattern_range).with_message("refutable pattern")
                 ])
                 .with_notes(vec!["expected an irrefutable pattern".to_owned()]),
-            Message::NonExhaustiveMatchExpr {
+            Self::NonExhaustiveMatchExpr {
                 match_expr_range,
                 scrutinee_expr_range,
             } => Diagnostic::error()
@@ -181,16 +181,16 @@ impl Message {
                     primary_label(scrutinee_expr_range).with_message("patterns not covered"),
                     secondary_label(match_expr_range).with_message("in match expression"),
                 ]),
-            Message::UnreachablePattern { range } => Diagnostic::warning()
+            Self::UnreachablePattern { range } => Diagnostic::warning()
                 .with_message("unreachable pattern")
                 .with_labels(vec![primary_label(range)]),
-            Message::UnexpectedParameter { param_range } => Diagnostic::error()
+            Self::UnexpectedParameter { param_range } => Diagnostic::error()
                 .with_message("too many parameters in function literal")
                 .with_labels(vec![
                     primary_label(param_range).with_message("unexpected parameter")
                 ])
                 .with_notes(vec!["this parameter can be removed".to_owned()]),
-            Message::UnexpectedArgument {
+            Self::UnexpectedArgument {
                 head_range,
                 head_type,
                 arg_range,
@@ -201,7 +201,7 @@ impl Message {
                     secondary_label(head_range)
                         .with_message(format!("expression of type {head_type}")),
                 ]),
-            Message::PlicityArgumentMismatch {
+            Self::PlicityArgumentMismatch {
                 head_range,
                 head_plicity,
                 head_type,
@@ -216,7 +216,7 @@ impl Message {
                     secondary_label(head_range)
                         .with_message(format!("{head_plicity} function of type {head_type}")),
                 ]),
-            Message::UnknownField {
+            Self::UnknownField {
                 head_range,
                 head_type,
                 label_range,
@@ -241,7 +241,7 @@ impl Message {
                 }
                 diagnostic
             }
-            Message::MismatchedFieldLabels {
+            Self::MismatchedFieldLabels {
                 range,
                 expr_labels,
                 type_labels,
@@ -307,7 +307,7 @@ impl Message {
                         format!("   found fields {found_labels}"),
                     ])
             }
-            Message::DuplicateFieldLabels { range, labels } => {
+            Self::DuplicateFieldLabels { range, labels } => {
                 let interner = interner.borrow();
                 let diagnostic_labels = (labels.iter())
                     .map(|(range, _)| primary_label(range).with_message("duplicate field"))
@@ -326,7 +326,7 @@ impl Message {
                             .format_with(", ", |label, f| f(&format_args!("`{label}`")))
                     )])
             }
-            Message::ArrayLiteralNotSupported {
+            Self::ArrayLiteralNotSupported {
                 range,
                 expected_type,
             } => Diagnostic::error()
@@ -335,7 +335,7 @@ impl Message {
                     primary_label(range).with_message(format!("expected `{expected_type}`"))
                 ])
                 .with_notes(vec![format!("expected `{expected_type}`")]),
-            Message::MismatchedArrayLength {
+            Self::MismatchedArrayLength {
                 range,
                 found_len,
                 expected_len,
@@ -348,12 +348,12 @@ impl Message {
                     format!("expected length {expected_len}"),
                     format!("   found length {found_len}"),
                 ]),
-            Message::AmbiguousArrayLiteral { range } => Diagnostic::error()
+            Self::AmbiguousArrayLiteral { range } => Diagnostic::error()
                 .with_message("ambiguous array literal")
                 .with_labels(vec![
                     primary_label(range).with_message("type annotations needed")
                 ]),
-            Message::MismatchedStringLiteralByteLength {
+            Self::MismatchedStringLiteralByteLength {
                 range,
                 expected_len,
                 found_len,
@@ -366,12 +366,12 @@ impl Message {
                     format!("expected byte length {expected_len}"),
                     format!("   found byte length {found_len}"),
                 ]),
-            Message::NonAsciiStringLiteral { invalid_range } => Diagnostic::error()
+            Self::NonAsciiStringLiteral { invalid_range } => Diagnostic::error()
                 .with_message("non-ASCII character found in string literal")
                 .with_labels(vec![
                     primary_label(invalid_range).with_message("non-ASCII character")
                 ]),
-            Message::StringLiteralNotSupported {
+            Self::StringLiteralNotSupported {
                 range,
                 expected_type,
             } => Diagnostic::error()
@@ -380,15 +380,15 @@ impl Message {
                     primary_label(range).with_message(format!("expected `{expected_type}`"))
                 ])
                 .with_notes(vec![format!("expected `{expected_type}`")]),
-            Message::AmbiguousStringLiteral { range } => Diagnostic::error()
+            Self::AmbiguousStringLiteral { range } => Diagnostic::error()
                 .with_message("ambiguous string literal")
                 .with_labels(vec![
                     primary_label(range).with_message("type annotations needed")
                 ]),
-            Message::InvalidNumericLiteral { range, message } => Diagnostic::error()
+            Self::InvalidNumericLiteral { range, message } => Diagnostic::error()
                 .with_message("failed to parse numeric literal")
                 .with_labels(vec![(primary_label(range)).with_message(message)]),
-            Message::NumericLiteralNotSupported {
+            Self::NumericLiteralNotSupported {
                 range,
                 expected_type,
             } => Diagnostic::error()
@@ -397,15 +397,15 @@ impl Message {
                     primary_label(range).with_message(format!("expected `{expected_type}`"))
                 ])
                 .with_notes(vec![format!("expected `{expected_type}`")]),
-            Message::AmbiguousNumericLiteral { range } => Diagnostic::error()
+            Self::AmbiguousNumericLiteral { range } => Diagnostic::error()
                 .with_message("ambiguous numeric literal")
                 .with_labels(vec![
                     primary_label(range).with_message("type annotations needed")
                 ]),
-            Message::BooleanLiteralNotSupported { range } => Diagnostic::error()
+            Self::BooleanLiteralNotSupported { range } => Diagnostic::error()
                 .with_message("boolean literal not supported for expected type")
                 .with_labels(vec![primary_label(range)]),
-            Message::BinOpMismatchedTypes {
+            Self::BinOpMismatchedTypes {
                 range: _,
                 lhs_range,
                 rhs_range,
@@ -420,7 +420,7 @@ impl Message {
                     secondary_label(&op.range())
                         .with_message(format!("no implementation for `{lhs} {op} {rhs}`")),
                 ]),
-            Message::FailedToUnify {
+            Self::FailedToUnify {
                 range,
                 found,
                 expected,
@@ -465,7 +465,7 @@ impl Message {
                     },
                 }
             }
-            Message::HoleSolution { range, name, expr } => {
+            Self::HoleSolution { range, name, expr } => {
                 let interner = interner.borrow();
                 let name = interner.resolve(*name).unwrap();
 
@@ -476,7 +476,7 @@ impl Message {
                         "hole `?{name}` can be replaced with `{expr}`",
                     )])
             }
-            Message::UnsolvedMetaVar { source } => {
+            Self::UnsolvedMetaVar { source } => {
                 let (range, source_name) = match source {
                     MetaSource::ImplicitArg(range, _) => (range, "implicit argument"),
                     MetaSource::HoleExpr(range, _) => (range, "hole expression"),
@@ -499,7 +499,7 @@ impl Message {
                         primary_label(range).with_message(format!("unsolved {source_name}"))
                     ])
             }
-            Message::CycleDetected { names } => {
+            Self::CycleDetected { names } => {
                 let interner = interner.borrow();
                 let names: Vec<_> = names
                     .iter()
@@ -510,7 +510,7 @@ impl Message {
                     .with_message("cycle detected")
                     .with_notes(vec![cycle])
             }
-            Message::MissingSpan { range } => Diagnostic::bug()
+            Self::MissingSpan { range } => Diagnostic::bug()
                 .with_message("produced core term without span")
                 .with_labels(vec![primary_label(range)])
                 .with_notes(vec![format!(

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -50,14 +50,14 @@ pub enum Error {
 }
 
 impl From<SpineError> for Error {
-    fn from(error: SpineError) -> Error {
-        Error::Spine(error)
+    fn from(error: SpineError) -> Self {
+        Self::Spine(error)
     }
 }
 
 impl From<RenameError> for Error {
-    fn from(error: RenameError) -> Error {
-        Error::Rename(error)
+    fn from(error: RenameError) -> Self {
+        Self::Rename(error)
     }
 }
 
@@ -731,8 +731,8 @@ pub struct PartialRenaming {
 
 impl PartialRenaming {
     /// Create a new, empty renaming.
-    pub fn new() -> PartialRenaming {
-        PartialRenaming {
+    pub fn new() -> Self {
+        Self {
             source: UniqueEnv::new(),
             target: EnvLen::new(),
         }

--- a/fathom/src/surface/lexer.rs
+++ b/fathom/src/surface/lexer.rs
@@ -181,17 +181,17 @@ pub enum Error {
 impl Error {
     pub fn range(&self) -> ByteRange {
         match self {
-            Error::UnexpectedCharacter { range } => *range,
-            Error::UnclosedBlockComment { first_open, .. } => *first_open,
+            Self::UnexpectedCharacter { range } => *range,
+            Self::UnclosedBlockComment { first_open, .. } => *first_open,
         }
     }
 
     pub fn to_diagnostic(&self, file_id: FileId) -> Diagnostic<FileId> {
         match self {
-            Error::UnexpectedCharacter { range } => Diagnostic::error()
+            Self::UnexpectedCharacter { range } => Diagnostic::error()
                 .with_message("unexpected character")
                 .with_labels(vec![Label::primary(file_id, *range)]),
-            Error::UnclosedBlockComment {
+            Self::UnclosedBlockComment {
                 depth,
                 first_open,
                 last_close,


### PR DESCRIPTION
Use `Self` in place of explicit type names where possible. 
Also adds `#![warn(clippy::use_self)]` to enforce the new style. 

Dual to https://github.com/yeslogic/fathom/pull/479