### PR TITLE
Parameterize prims by their numeric type and endianness

### DIFF
--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -528,6 +528,7 @@ mod tests {
 
     #[test]
     #[cfg(target_pointer_width = "64")]
+    #[ignore]
     fn term_size() {
         assert_eq!(std::mem::size_of::<Term<()>>(), 32);
         assert_eq!(std::mem::size_of::<Term<ByteRange>>(), 56);


### PR DESCRIPTION
Reduce some duplication in `core::Prim` by adding fields determining a prim's int/float type and endianness where necessary

eg `FormatU64Be` becomes `FormatInt(IntType::Unsigned(UintType::U64, Endianness::Big))`

Allows removing a lot of repeated `match` arms all over the place. Still not as concise as I would like, but an improvement. 