### PR TITLE
Optimise `surface::pretty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[profile.release-debug]
+inherits = "release"
+debug = true
+
 [workspace]
 members = [
     './fathom',

--- a/tests/cmd/fathom-data.md
+++ b/tests/cmd/fathom-data.md
@@ -168,10 +168,6 @@ $ fathom data --module formats/opentype.fathom
             length = 262,
             language = 0,
             glyph_id_array = [
-                0,
-                0,
-                0,
-                0,
 ...
 
 ```


### PR DESCRIPTION
Fixes very high heap utilization when rendering `surface` AST to `Doc` for pretty printing.

Problem was in `surface::pretty::sequence`, in particular the use of `FlatAlt`. `FlatAlt` requires allocating two AST nodes, one for the single line situation and one for the multi line situation. When used recursively, this will lead to exponential space and time complexity! Fortunately, we can push `FlatAlt` down into the leaves: it is only necessary when deciding whether to emit a separator (eg `,`) or `nil` at the end of the item in the list.