### PR TITLE
Record field shorthands

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -818,6 +818,18 @@ let origin : Point = {
 };
 ```
 
+The right hand side of the field definition can be omitted if it is a variable with
+the same name as the field. For example:
+
+```fathom
+let Point = { x : U32, y : U32 };
+
+let x : U32 = 0;
+let y : U32 = 0;
+
+let origin : Point = { x, y };
+```
+
 When checking dependent record types, the values assigned to field expressions
 will substituted into the types of subsequent fields. For example:
 

--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -399,8 +399,9 @@ pub struct TypeField<'arena, Range> {
 pub struct ExprField<'arena, Range> {
     /// Label identifying the field
     label: (Range, StringId),
-    /// The expression that this field will store
-    expr: Term<'arena, Range>,
+    /// The expression that this field will store.
+    /// If it is `None`, it is the same as `label.1`
+    expr: Option<Term<'arena, Range>>,
 }
 
 /// Messages produced during parsing

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -560,7 +560,15 @@ impl<'interner, 'arena, 'env> Context<'interner, 'arena, 'env> {
                 let expr_fields =
                     Iterator::zip(labels.iter(), exprs.iter()).map(|(label, expr)| ExprField {
                         label: ((), *label),
-                        expr: self.term_prec(mode, Prec::Top, expr),
+                        expr: match expr {
+                            core::Term::LocalVar(_, var)
+                                if self.get_local_name(*var) == Some(*label) =>
+                            {
+                                None
+                            }
+
+                            _ => Some(self.check_prec(Prec::Top, expr)),
+                        },
                     });
 
                 // TODO: type annotations?

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1083,7 +1083,9 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 while let Some((expr_field, (r#type, next_types))) =
                     Option::zip(expr_fields.next(), self.elim_env().split_telescope(types))
                 {
-                    let expr = self.check(&expr_field.expr, &r#type);
+                    let name_expr = Term::Name(expr_field.label.0, expr_field.label.1);
+                    let expr = expr_field.expr.as_ref().unwrap_or(&name_expr);
+                    let expr = self.check(expr, &r#type);
                     types = next_types(self.eval_env().eval(&expr));
                     exprs.push(expr);
                 }
@@ -1617,7 +1619,9 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 let mut exprs = SliceVec::new(self.scope, labels.len());
 
                 for expr_field in expr_fields {
-                    let (expr, r#type) = self.synth(&expr_field.expr);
+                    let name_expr = Term::Name(expr_field.label.0, expr_field.label.1);
+                    let expr = expr_field.expr.as_ref().unwrap_or(&name_expr);
+                    let (expr, r#type) = self.synth(expr);
                     types.push(self.quote_env().quote(self.scope, &r#type));
                     exprs.push(expr);
                 }

--- a/fathom/src/surface/elaboration/order.rs
+++ b/fathom/src/surface/elaboration/order.rs
@@ -239,7 +239,9 @@ fn term_deps(
         Term::RecordLiteral(_, expr_fields) => {
             let initial_locals_names_len = local_names.len();
             for expr_field in *expr_fields {
-                term_deps(&expr_field.expr, item_names, local_names, deps);
+                if let Some(expr) = expr_field.expr.as_ref() {
+                    term_deps(expr, item_names, local_names, deps);
+                }
                 local_names.push(expr_field.label.1);
             }
             local_names.truncate(initial_locals_names_len);

--- a/fathom/src/surface/grammar.lalrpop
+++ b/fathom/src/surface/grammar.lalrpop
@@ -255,7 +255,7 @@ TypeField: TypeField<'arena, ByteRange> = {
 };
 
 ExprField: ExprField<'arena, ByteRange> = {
-    <label: RangedName> "=" <expr: Term> => ExprField { label, expr },
+    <label: RangedName> <expr: ("=" <Term>)?> => ExprField { label, expr },
 };
 
 BinExpr<Lhs, Op, Rhs>: Term<'arena, ByteRange> = {

--- a/fathom/src/surface/pretty.rs
+++ b/fathom/src/surface/pretty.rs
@@ -267,10 +267,12 @@ impl<'interner, 'arena> Context<'interner, 'arena> {
                 self.sequence(true, self.text("{"), fields, self.text(","), self.text("}"))
             }
             Term::RecordLiteral(_, fields) => {
-                let fields = fields.iter().map(|field| {
-                    self.ident(field.label.1)
+                let fields = fields.iter().map(|field| match field.expr.as_ref() {
+                    None => self.ident(field.label.1),
+                    Some(expr) => self
+                        .ident(field.label.1)
                         .append(" = ")
-                        .append(self.term(&field.expr))
+                        .append(self.term(expr)),
                 });
                 self.sequence(true, self.text("{"), fields, self.text(","), self.text("}"))
             }

--- a/tests/succeed/record-field-shorthand.fathom
+++ b/tests/succeed/record-field-shorthand.fathom
@@ -1,0 +1,7 @@
+let x = (1 : U32);
+let y = (2 : U32);
+let z = (3 : U32);
+
+let _ = {x, y, z};
+let _ = {x = x, y = y, z = z};
+{}

--- a/tests/succeed/record-field-shorthand.snap
+++ b/tests/succeed/record-field-shorthand.snap
@@ -1,0 +1,9 @@
+stdout = '''
+let x : U32 = 1;
+let y : U32 = 2;
+let z : U32 = 3;
+let _ : { x : U32, y : U32, z : U32 } = { x, y, z };
+let _ : { x : U32, y : U32, z : U32 } = { x, y, z };
+() : ()
+'''
+stderr = ''


### PR DESCRIPTION
Adds syntax sugar for record fields: `{x, y, z}` is equivalent to `{ x = x, y = y, z = z }`. This is called [Struct field init shorthand](https://doc.rust-lang.org/reference/expressions/struct-expr.html#struct-field-init-shorthand) in Rust, and [record puns](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/record_puns.html) in Haskell