### PR TITLE
Make it easier to distill/pretty print values

### DIFF
--- a/fathom/src/surface.rs
+++ b/fathom/src/surface.rs
@@ -516,7 +516,6 @@ fn format_expected(expected: &[impl std::fmt::Display]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::source::ByteRange;
 
     #[test]
     fn no_drop() {

--- a/fathom/src/surface/distillation.rs
+++ b/fathom/src/surface/distillation.rs
@@ -41,7 +41,7 @@ pub struct Context<'arena, 'env> {
     /// Item name environment.
     item_names: &'env UniqueEnv<Symbol>,
     /// Local name environment.
-    local_names: &'env mut UniqueEnv<Option<Symbol>>,
+    local_names: UniqueEnv<Option<Symbol>>,
     /// Metavariable sources.
     meta_sources: &'env UniqueEnv<MetaSource>,
 }
@@ -51,7 +51,7 @@ impl<'arena, 'env> Context<'arena, 'env> {
     pub fn new(
         scope: &'arena Scope<'arena>,
         item_names: &'env UniqueEnv<Symbol>,
-        local_names: &'env mut UniqueEnv<Option<Symbol>>,
+        local_names: UniqueEnv<Option<Symbol>>,
         meta_sources: &'env UniqueEnv<MetaSource>,
     ) -> Context<'arena, 'env> {
         Context {

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -1330,20 +1330,16 @@ impl<'arena> Context<'arena> {
                     return (core::Term::Prim(file_range.into(), prim), r#type.clone());
                 }
 
-                let candidates = self
-                    .local_env
-                    .names
-                    .iter()
-                    .flatten()
-                    .copied()
-                    .chain(self.item_env.names.iter().copied());
-                let suggestion = suggest_name(*name, candidates);
-
                 self.push_message(Message::UnboundName {
                     range: file_range,
                     name: *name,
-                    suggestion,
+                    suggested_name: {
+                        let item_names = self.item_env.names.iter().copied();
+                        let local_names = self.local_env.names.iter().flatten().copied();
+                        suggest_name(*name, item_names.chain(local_names))
+                    },
                 });
+
                 self.synth_reported_error(*range)
             }
             Term::Hole(_, name) => {
@@ -1660,7 +1656,7 @@ impl<'arena> Context<'arena> {
                         head_type: self.pretty_value(&head_type),
                         label_range: self.file_range(*label_range),
                         label: *proj_label,
-                        suggestion: suggest_name(*proj_label, labels.iter().map(|(_, l)| *l)),
+                        suggested_label: suggest_name(*proj_label, labels.iter().map(|(_, l)| *l)),
                     });
                     return self.synth_reported_error(*range);
                 }

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -25,7 +25,6 @@ use std::sync::Arc;
 
 use scoped_arena::Scope;
 
-use super::ExprField;
 use crate::alloc::SliceVec;
 use crate::core::semantics::{self, ArcValue, Head, Telescope, Value};
 use crate::core::{self, prim, Const, Plicity, Prim, UIntStyle};
@@ -34,7 +33,7 @@ use crate::files::FileId;
 use crate::source::{BytePos, ByteRange, FileRange, Span, Spanned};
 use crate::surface::elaboration::reporting::Message;
 use crate::surface::{
-    distillation, pretty, BinOp, FormatField, Item, Module, Param, Pattern, Term,
+    distillation, pretty, BinOp, ExprField, FormatField, Item, Module, Param, Pattern, Term,
 };
 use crate::symbol::Symbol;
 

--- a/fathom/src/surface/elaboration.rs
+++ b/fathom/src/surface/elaboration.rs
@@ -375,19 +375,7 @@ impl<'arena> Context<'arena> {
                 (None, source) => on_message(Message::UnsolvedMetaVar { source }),
                 // Yield messages of solved named holes
                 (Some(expr), MetaSource::HoleExpr(range, name)) => {
-                    let term = self.quote_env().quote(self.scope, expr);
-                    let surface_term = distillation::Context::new(
-                        self.scope,
-                        &self.item_env.names,
-                        &mut self.local_env.names,
-                        &self.meta_env.sources,
-                    )
-                    .check(&term);
-
-                    let pretty_context = pretty::Context::new(self.scope);
-                    let doc = pretty_context.term(&surface_term).into_doc();
-                    let expr = doc.pretty(usize::MAX).to_string();
-
+                    let expr = self.pretty_value(expr);
                     on_message(Message::HoleSolution { range, name, expr });
                 }
                 // Ignore solutions of anything else
@@ -420,24 +408,22 @@ impl<'arena> Context<'arena> {
     }
 
     pub fn distillation_context<'out_arena>(
-        &mut self,
+        &self,
         scope: &'out_arena Scope<'out_arena>,
     ) -> distillation::Context<'out_arena, '_> {
         distillation::Context::new(
             scope,
             &self.item_env.names,
-            &mut self.local_env.names,
+            self.local_env.names.clone(),
             &self.meta_env.sources,
         )
     }
 
-    fn pretty_print_value(&mut self, value: &ArcValue<'_>) -> String {
-        let scope = self.scope;
+    fn pretty_value(&self, value: &ArcValue<'_>) -> String {
+        let term = self.quote_env().unfolding_metas().quote(self.scope, value);
+        let surface_term = self.distillation_context(self.scope).check(&term);
 
-        let term = self.quote_env().unfolding_metas().quote(scope, value);
-        let surface_term = self.distillation_context(scope).check(&term);
-
-        pretty::Context::new(scope)
+        pretty::Context::new(self.scope)
             .term(&surface_term)
             .pretty(usize::MAX)
             .to_string()
@@ -625,12 +611,10 @@ impl<'arena> Context<'arena> {
                         }
                     };
 
-                    let from = self.pretty_print_value(&from);
-                    let to = self.pretty_print_value(&to);
                     self.push_message(Message::FailedToUnify {
                         range,
-                        found: from,
-                        expected: to,
+                        found: self.pretty_value(&from),
+                        expected: self.pretty_value(&to),
                         error,
                     });
                     core::Term::Prim(span, Prim::ReportedError)
@@ -757,10 +741,9 @@ impl<'arena> Context<'arena> {
                     // Some((Prim::Array64Type, [len, _])) => todo!(),
                     Some((Prim::ReportedError, _)) => None,
                     _ => {
-                        let expected_type = self.pretty_print_value(expected_type);
                         self.push_message(Message::StringLiteralNotSupported {
                             range: file_range,
-                            expected_type,
+                            expected_type: self.pretty_value(expected_type),
                         });
                         None
                     }
@@ -785,10 +768,9 @@ impl<'arena> Context<'arena> {
                     Some((Prim::F64Type, [])) => self.parse_number(*range, *lit, Const::F64),
                     Some((Prim::ReportedError, _)) => None,
                     _ => {
-                        let expected_type = self.pretty_print_value(expected_type);
                         self.push_message(Message::NumericLiteralNotSupported {
                             range: file_range,
-                            expected_type,
+                            expected_type: self.pretty_value(expected_type),
                         });
                         None
                     }
@@ -875,12 +857,10 @@ impl<'arena> Context<'arena> {
                 match self.unification_context().unify(&r#type, expected_type) {
                     Ok(()) => self.check_pattern(pattern, &r#type),
                     Err(error) => {
-                        let lhs = self.pretty_print_value(&r#type);
-                        let rhs = self.pretty_print_value(expected_type);
                         self.push_message(Message::FailedToUnify {
                             range: file_range,
-                            found: lhs,
-                            expected: rhs,
+                            found: self.pretty_value(&r#type),
+                            expected: self.pretty_value(expected_type),
                             error,
                         });
                         CheckedPattern::ReportedError(file_range)
@@ -1178,10 +1158,9 @@ impl<'arena> Context<'arena> {
                         return core::Term::Prim(file_range.into(), Prim::ReportedError)
                     }
                     _ => {
-                        let expected_type = self.pretty_print_value(&expected_type);
                         self.push_message(Message::ArrayLiteralNotSupported {
                             range: file_range,
-                            expected_type,
+                            expected_type: self.pretty_value(&expected_type),
                         });
                         return core::Term::Prim(file_range.into(), Prim::ReportedError);
                     }
@@ -1213,11 +1192,10 @@ impl<'arena> Context<'arena> {
                             self.check(elem_expr, elem_type);
                         }
 
-                        let expected_len = self.pretty_print_value(len_value.unwrap());
                         self.push_message(Message::MismatchedArrayLength {
                             range: file_range,
                             found_len: elem_exprs.len(),
-                            expected_len,
+                            expected_len: self.pretty_value(len_value.unwrap()),
                         });
 
                         core::Term::Prim(file_range.into(), Prim::ReportedError)
@@ -1236,10 +1214,9 @@ impl<'arena> Context<'arena> {
                     // Some((Prim::Array64Type, [len, _])) => todo!(),
                     Some((Prim::ReportedError, _)) => None,
                     _ => {
-                        let expected_type = self.pretty_print_value(&expected_type);
                         self.push_message(Message::StringLiteralNotSupported {
                             range: file_range,
-                            expected_type,
+                            expected_type: self.pretty_value(&expected_type),
                         });
                         None
                     }
@@ -1264,10 +1241,9 @@ impl<'arena> Context<'arena> {
                     Some((Prim::F64Type, [])) => self.parse_number(*range, *lit, Const::F64),
                     Some((Prim::ReportedError, _)) => None,
                     _ => {
-                        let expected_type = self.pretty_print_value(&expected_type);
                         self.push_message(Message::NumericLiteralNotSupported {
                             range: file_range,
-                            expected_type,
+                            expected_type: self.pretty_value(&expected_type),
                         });
                         return core::Term::Prim(file_range.into(), Prim::ReportedError);
                     }
@@ -1521,11 +1497,10 @@ impl<'arena> Context<'arena> {
                             if arg.plicity == *plicity {
                                 (param_type, body_type)
                             } else {
-                                let head_type = self.pretty_print_value(&head_type);
                                 self.messages.push(Message::PlicityArgumentMismatch {
                                     head_range: self.file_range(head_range),
                                     head_plicity: Plicity::Explicit,
-                                    head_type,
+                                    head_type: self.pretty_value(&head_type),
                                     arg_range: self.file_range(arg.term.range()),
                                     arg_plicity: arg.plicity,
                                 });
@@ -1542,10 +1517,9 @@ impl<'arena> Context<'arena> {
                         _ => {
                             // NOTE: We could try to infer that this is a function type,
                             // but this takes more work to prevent cascading type errors
-                            let head_type = self.pretty_print_value(&head_type);
                             self.push_message(Message::UnexpectedArgument {
                                 head_range: self.file_range(head_range),
-                                head_type,
+                                head_type: self.pretty_value(&head_type),
                                 arg_range: self.file_range(arg.term.range()),
                             });
                             return self.synth_reported_error(*range);
@@ -1681,15 +1655,12 @@ impl<'arena> Context<'arena> {
                         _ => {}
                     }
 
-                    let head_type = self.pretty_print_value(&head_type);
-                    let suggestion =
-                        suggest_name(*proj_label, labels.iter().map(|(_, label)| *label));
                     self.push_message(Message::UnknownField {
                         head_range: self.file_range(head_range),
-                        head_type,
+                        head_type: self.pretty_value(&head_type),
                         label_range: self.file_range(*label_range),
                         label: *proj_label,
-                        suggestion,
+                        suggestion: suggest_name(*proj_label, labels.iter().map(|(_, l)| *l)),
                     });
                     return self.synth_reported_error(*range);
                 }
@@ -2005,15 +1976,13 @@ impl<'arena> Context<'arena> {
             (Gte(_), Some(((S64Type, []), (S64Type, [])))) => (S64Gte, BoolType),
 
             _ => {
-                let lhs_pretty = self.pretty_print_value(&lhs_type);
-                let rhs_pretty = self.pretty_print_value(&rhs_type);
                 self.push_message(Message::BinOpMismatchedTypes {
                     range: self.file_range(range),
                     lhs_range: self.file_range(lhs.range()),
                     rhs_range: self.file_range(rhs.range()),
                     op: op.map_range(|range| self.file_range(range)),
-                    lhs: lhs_pretty,
-                    rhs: rhs_pretty,
+                    lhs: self.pretty_value(&lhs_type),
+                    rhs: self.pretty_value(&rhs_type),
                 });
                 return self.synth_reported_error(range);
             }

--- a/fathom/src/surface/elaboration/reporting.rs
+++ b/fathom/src/surface/elaboration/reporting.rs
@@ -149,16 +149,12 @@ impl Message {
                 range,
                 name,
                 suggested_name,
-            } => {
-                let name = name.resolve();
-
-                Diagnostic::error()
-                    .with_message(format!("cannot find `{name}` in scope"))
-                    .with_labels(vec![primary_label(range).with_message("unbound name")])
-                    .with_notes(suggested_name.map_or(Vec::new(), |name| {
-                        vec![format!("help: did you mean `{}`?", name.resolve())]
-                    }))
-            }
+            } => Diagnostic::error()
+                .with_message(format!("cannot find `{}` in scope", name.resolve()))
+                .with_labels(vec![primary_label(range).with_message("unbound name")])
+                .with_notes(suggested_name.map_or(Vec::new(), |name| {
+                    vec![format!("help: did you mean `{}`?", name.resolve())]
+                })),
             Message::RefutablePattern { pattern_range } => Diagnostic::error()
                 .with_message("refutable patterns found in binding")
                 .with_labels(vec![
@@ -215,20 +211,16 @@ impl Message {
                 label_range,
                 label,
                 suggested_label,
-            } => {
-                let label = label.resolve();
-
-                Diagnostic::error()
-                    .with_message(format!("cannot find `{label}` in expression"))
-                    .with_labels(vec![
-                        primary_label(label_range).with_message("unknown label"),
-                        secondary_label(head_range)
-                            .with_message(format!("expression of type {head_type}")),
-                    ])
-                    .with_notes(suggested_label.map_or(Vec::new(), |label| {
-                        vec![format!("help: did you mean `{}`?", label.resolve())]
-                    }))
-            }
+            } => Diagnostic::error()
+                .with_message(format!("cannot find `{}` in expression", label.resolve()))
+                .with_labels(vec![
+                    primary_label(label_range).with_message("unknown label"),
+                    secondary_label(head_range)
+                        .with_message(format!("expression of type {head_type}")),
+                ])
+                .with_notes(suggested_label.map_or(Vec::new(), |label| {
+                    vec![format!("help: did you mean `{}`?", label.resolve())]
+                })),
             Message::MismatchedFieldLabels {
                 range,
                 expr_labels,
@@ -242,24 +234,18 @@ impl Message {
                         'type_labels: loop {
                             match type_labels.next() {
                                 None => {
-                                    let expr_label = expr_label.resolve();
-                                    diagnostic_labels.push(
-                                        primary_label(range).with_message(format!(
-                                            "unexpected field `{expr_label}`"
-                                        )),
-                                    );
+                                    diagnostic_labels.push(primary_label(range).with_message(
+                                        format!("unexpected field `{}`", expr_label.resolve()),
+                                    ));
                                     continue 'expr_labels;
                                 }
                                 Some(type_label) if expr_label == type_label => {
                                     continue 'expr_labels;
                                 }
                                 Some(type_label) => {
-                                    let type_label = type_label.resolve();
-                                    diagnostic_labels.push(
-                                        primary_label(range).with_message(format!(
-                                            "expected field `{type_label}`",
-                                        )),
-                                    );
+                                    diagnostic_labels.push(primary_label(range).with_message(
+                                        format!("expected field `{}`", type_label.resolve()),
+                                    ));
                                     continue 'type_labels;
                                 }
                             }
@@ -485,8 +471,7 @@ impl Message {
                     ])
             }
             Message::CycleDetected { names } => {
-                let names: Vec<_> = names.iter().map(|id| id.resolve()).collect();
-                let cycle = names.join(" → ");
+                let cycle = names.iter().map(|name| name.resolve()).join(" → ");
                 Diagnostic::error()
                     .with_message("cycle detected")
                     .with_notes(vec![cycle])


### PR DESCRIPTION
In an attempt to address #488, this reduces some of the gymnasics we’ve needed to do whenever we want to pretty print something. We achieve this by cloning the name environment as opposed to taking it by mutable reference when constructing a distillation environment.

This means we can no longer reuse the existing allocation when temporarily pushing local names, but I think the savings we got from this was probably minor, and the increase in clarity is worth it.