### PR TITLE
Scope each metavar to the definition where it was generated

### DIFF
--- a/fathom/src/core/semantics.rs
+++ b/fathom/src/core/semantics.rs
@@ -953,19 +953,14 @@ impl<'arena, 'env> EvalEnv<'arena, 'env> {
                 // The metavariable has a solution, so unfold it.
                 Some(value) => TermOrValue::Value(value.clone()),
                 // No solution was found for the metavariable.
-                // NOTE: We might want to replace this with `ReportedError`.
-                None => TermOrValue::Term(Term::MetaVar(*span, *var)),
+                None => TermOrValue::Term(Term::Prim(*span, Prim::ReportedError)),
             },
             Term::InsertedMeta(span, var, infos) => {
                 match self.elim_env.get_meta_expr(*var) {
                     // The metavariable has a solution, so unfold it.
                     Some(value) => TermOrValue::Value(self.apply_local_infos(value.clone(), infos)),
                     // No solution was found for the metavariable.
-                    // NOTE: We might want to replace this with `ReportedError`.
-                    None => {
-                        let infos = scope.to_scope_from_iter(infos.iter().copied());
-                        TermOrValue::Term(Term::InsertedMeta(*span, *var, infos))
-                    }
+                    None => TermOrValue::Term(Term::Prim(*span, Prim::ReportedError)),
                 }
             }
 

--- a/fathom/src/env.rs
+++ b/fathom/src/env.rs
@@ -319,6 +319,11 @@ impl<Entry> SharedEnv<Entry> {
         }
     }
 
+    /// Clear the renaming. This is useful for reusing environment allocations.
+    pub fn clear(&mut self) {
+        self.truncate(EnvLen(0));
+    }
+
     /// The length of the environment.
     pub fn len(&self) -> EnvLen {
         // SAFETY:

--- a/fathom/src/surface/elaboration/unification.rs
+++ b/fathom/src/surface/elaboration/unification.rs
@@ -804,4 +804,9 @@ impl PartialRenaming {
         self.source.truncate(len.0);
         self.target.truncate(len.1);
     }
+
+    pub fn clear(&mut self) {
+        self.source.clear();
+        self.target.clear();
+    }
 }

--- a/tests/fail/elaboration/local-metavars.fathom
+++ b/tests/fail/elaboration/local-metavars.fathom
@@ -1,0 +1,11 @@
+//~ exit-code = 1
+//~ mode = "module"
+
+// metavars in `f` are updated by type annotation because whole expression is contained in one def
+def h =
+    let f = fun x => x;
+    f : U32 -> U32;
+
+// metavars in `f` are not updated by type annotated in `g` becaues they are in different defs
+def f = fun x => x;
+def g : U32 -> U32 = f;

--- a/tests/fail/elaboration/local-metavars.snap
+++ b/tests/fail/elaboration/local-metavars.snap
@@ -1,0 +1,9 @@
+stdout = ''
+stderr = '''
+error: failed to infer named pattern type
+   ┌─ tests/fail/elaboration/local-metavars.fathom:10:13
+   │
+10 │ def f = fun x => x;
+   │             ^ unsolved named pattern type
+
+'''


### PR DESCRIPTION
Currently, metavars are treated as global to the whole module. This PR changes `elab_module` so that each toplevel definition has its own set of metavars, and metavar solutions do not take into account how the definition is used in other definitions. This should make it possible to elaborate definitions that do not refer to each other in parallel (but I will leave that for a later PR).

This is similar to, but not quite as strict as, local type inference, which requires each toplevel definition to be fully annotated with its type. This would allow even more parallelism, since we could elaborate all definitions in parallel, even if they form a long chain of dependencies